### PR TITLE
[Feature] Read index file first in hdfs mode

### DIFF
--- a/storage/src/main/java/com/tencent/rss/storage/api/ShuffleReader.java
+++ b/storage/src/main/java/com/tencent/rss/storage/api/ShuffleReader.java
@@ -26,5 +26,7 @@ public interface ShuffleReader {
 
   byte[] readData(long offset, int length);
 
+  byte[] readIndex();
+
   List<FileBasedShuffleSegment> readIndex(int limit) throws IOException, IllegalStateException;
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractHdfsClientReadHandler.java
@@ -214,14 +214,14 @@ public abstract class AbstractHdfsClientReadHandler extends AbstractFileClientRe
         path = indexSegment.getPath();
         HdfsFileReader reader = indexReaderMap.get(path);
         reader.seek(indexSegment.getOffset());
-        FileBasedShuffleSegment segment = reader.readIndex();
+        FileBasedShuffleSegment segment = reader.readIndexSegment();
         while (segment != null) {
           segments.add(segment);
           size += FileBasedShuffleSegment.SEGMENT_SIZE;
           if (size >= indexSegment.getLength()) {
             break;
           } else {
-            segment = reader.readIndex();
+            segment = reader.readIndexSegment();
           }
         }
       } catch (Exception e) {

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -18,8 +18,18 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.tencent.rss.common.ShuffleDataResult;
+import com.tencent.rss.common.ShuffleDataSegment;
+import com.tencent.rss.common.ShuffleIndexResult;
+import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +37,12 @@ import org.slf4j.LoggerFactory;
 public class HdfsClientReadHandler extends AbstractHdfsClientReadHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(HdfsClientReadHandler.class);
+
+  private final List<ShuffleDataSegment> shuffleDataSegments = Lists.newArrayList();
+  // TODO: Refactor read handler to wrapper a single index file and its indexed data file into a handler.
+  private final Iterator<Entry<String, HdfsFileReader>> readerIterator;
+  private HdfsFileReader currentIndexReader;
+  private HdfsFileReader currentDataReader;
 
   public HdfsClientReadHandler(
       String appId,
@@ -51,7 +67,92 @@ public class HdfsClientReadHandler extends AbstractHdfsClientReadHandler {
         ShuffleStorageUtils.getShuffleDataPathWithRange(appId,
             shuffleId, partitionId, partitionNumPerRange, partitionNum));
     init(fullShufflePath);
-    readAllIndexSegments();
+    readerIterator = indexReaderMap
+        .entrySet()
+        .stream()
+        .sorted(Entry.comparingByKey())
+        .collect(Collectors.toList())
+        .iterator();
   }
 
+  public ShuffleIndexResult readShuffleIndex() {
+    long start = System.currentTimeMillis();
+    try {
+      byte[] indexData = currentIndexReader.readIndex();
+      LOG.info("Read index files for shuffleId[{}], partitionId[{}] for {} ms",
+          shuffleId, partitionId, System.currentTimeMillis() - start);
+      return new ShuffleIndexResult(indexData);
+    } catch (Exception e) {
+      LOG.info("Fail to read index files for shuffleId[{}], partitionId[{}]", shuffleId, partitionId);
+    }
+
+    return new ShuffleIndexResult();
+  }
+
+  public ShuffleDataResult readShuffleData(ShuffleDataSegment shuffleDataSegment) {
+    int expectedLength = shuffleDataSegment.getLength();
+    if (expectedLength < 0) {
+      LOG.error("Invalid segment {}", shuffleDataSegment);
+      return null;
+    }
+
+    byte[] data = currentDataReader.readData(shuffleDataSegment.getOffset(), expectedLength);
+    if (data.length != expectedLength) {
+      LOG.error("Fail to read expected[{}] data, actual[{}] and segment is {}",
+          expectedLength, data.length, shuffleDataSegment);
+      return null;
+    }
+
+    return new ShuffleDataResult(data, shuffleDataSegment.getBufferSegments());
+  }
+
+  @Override
+  public ShuffleDataResult readShuffleData(int segmentIndex) {
+    if (segmentIndex >= shuffleDataSegments.size()) {
+      ShuffleIndexResult shuffleIndexResult = null;
+      while (readerIterator.hasNext()) {
+        Entry<String, HdfsFileReader> entry = readerIterator.next();
+        String key = entry.getKey();
+        currentIndexReader = entry.getValue();
+        if (currentIndexReader == null) {
+          LOG.error("Index reader of {} is invalid!", key);
+          continue;
+        }
+
+        currentDataReader = dataReaderMap.get(entry.getKey());
+        if (currentDataReader == null) {
+          LOG.error("Data reader of {} is invalid!", key);
+          continue;
+        }
+
+        shuffleIndexResult = readShuffleIndex();
+        if (!shuffleIndexResult.isEmpty()) {
+          break;
+        }
+      }
+
+      if (shuffleIndexResult == null || shuffleIndexResult.isEmpty()) {
+        return null;
+      }
+
+      List<ShuffleDataSegment> cur = RssUtils.transIndexDataToSegments(shuffleIndexResult, readBufferSize);
+      shuffleDataSegments.addAll(cur);
+    }
+
+    if (segmentIndex >= shuffleDataSegments.size()) {
+      return null;
+    }
+
+    return readShuffleData(shuffleDataSegments.get(segmentIndex));
+  }
+
+  @VisibleForTesting
+  List<ShuffleDataSegment> getShuffleDataSegments() {
+    return shuffleDataSegments;
+  }
+
+  @VisibleForTesting
+  public Iterator<Entry<String, HdfsFileReader>> getReaderIterator() {
+    return readerIterator;
+  }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleWriteHandler.java
@@ -18,6 +18,7 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
@@ -131,5 +132,10 @@ public class HdfsShuffleWriteHandler implements ShuffleWriteHandler {
     Path path = new Path(basePath, fileName);
     HdfsFileWriter writer = new HdfsFileWriter(path, hadoopConf);
     return writer;
+  }
+
+  @VisibleForTesting
+  public void setFailTimes(int failTimes) {
+    this.failTimes = failTimes;
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileReader.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,11 +53,20 @@ public class LocalFileReader implements ShuffleReader, Closeable {
     return new byte[0];
   }
 
+  public byte[] readIndex() {
+    try {
+      return IOUtils.toByteArray(dataInputStream);
+    } catch (IOException e) {
+      LOG.error("Fail to read all data from {}", path, e);
+      return new byte[0];
+    }
+  }
+
   public List<FileBasedShuffleSegment> readIndex(int limit) throws IOException, IllegalStateException {
     List<FileBasedShuffleSegment> ret = new LinkedList<>();
 
     for (int i = 0; i < limit; ++i) {
-      FileBasedShuffleSegment segment = readIndex();
+      FileBasedShuffleSegment segment = readIndexSegment();
       if (segment == null) {
         break;
       }
@@ -66,7 +76,7 @@ public class LocalFileReader implements ShuffleReader, Closeable {
     return ret;
   }
 
-  public FileBasedShuffleSegment readIndex() throws IOException, IllegalStateException {
+  public FileBasedShuffleSegment readIndexSegment() throws IOException, IllegalStateException {
     if (dataInputStream.available() <= 0) {
       return null;
     }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandler.java
@@ -177,7 +177,7 @@ public class MultiStorageHdfsClientReadHandler extends AbstractHdfsClientReadHan
         path = indexSegment.getPath();
         HdfsFileReader reader = indexReaderMap.get(path);
         reader.seek(indexSegment.getOffset());
-        FileBasedShuffleSegment segment = reader.readIndex();
+        FileBasedShuffleSegment segment = reader.readIndexSegment();
         while (segment != null) {
           segment.setOffset(segment.getOffset() + indexSegment.getLastPos());
           segments.add(segment);
@@ -185,7 +185,7 @@ public class MultiStorageHdfsClientReadHandler extends AbstractHdfsClientReadHan
           if (size >= indexSegment.getLength()) {
             break;
           } else {
-            segment = reader.readIndex();
+            segment = reader.readIndexSegment();
           }
         }
       } catch (Exception e) {

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.storage.handler.impl;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.tencent.rss.common.BufferSegment;
+import com.tencent.rss.common.ShuffleDataResult;
+import com.tencent.rss.common.ShufflePartitionedBlock;
+import com.tencent.rss.common.util.ChecksumUtils;
+import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.HdfsTestBase;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Test;
+
+public class HdfsClientReadHandlerTest extends HdfsTestBase {
+
+  private static AtomicLong ATOMIC_LONG = new AtomicLong(0);
+
+  @Test
+  public void test() {
+    try {
+      String basePath = HDFS_URI + "clientReadTest1";
+      HdfsShuffleWriteHandler writeHandler =
+          new HdfsShuffleWriteHandler(
+              "appId",
+              0,
+              1,
+              1,
+              basePath,
+              "test1",
+              conf);
+
+      Map<Long, byte[]> expectedData = Maps.newHashMap();
+
+      int readBufferSize = 13;
+      int total = 0;
+      int totalBlockNum = 0;
+      int expectTotalBlockNum = 0;
+      for (int i = 0; i < 5; i++) {
+        writeHandler.setFailTimes(i);
+        int num = new Random().nextInt(17);
+        writeTestData(writeHandler,  num, 3, 0, expectedData);
+        total += calcExpectedSegmentNum(num, 3, readBufferSize);
+        expectTotalBlockNum += num;
+      }
+
+      HdfsClientReadHandler handler = new HdfsClientReadHandler(
+          "appId",
+          0,
+          1,
+          1024 * 10214,
+          1,
+          10,
+          readBufferSize,
+          basePath,
+          conf);
+      Set<Long> actualBlockIds = Sets.newHashSet();
+
+      for (int i = 0; i < total; ++i) {
+        ShuffleDataResult shuffleDataResult = handler.readShuffleData(i);
+        totalBlockNum += shuffleDataResult.getBufferSegments().size();
+        checkData(shuffleDataResult, expectedData);
+        for (BufferSegment bufferSegment : shuffleDataResult.getBufferSegments()) {
+          actualBlockIds.add(bufferSegment.getBlockId());
+        }
+      }
+
+      assertNull(handler.readShuffleData(total));
+      assertEquals(total, handler.getShuffleDataSegments().size());
+      assertEquals(expectTotalBlockNum, totalBlockNum);
+      assertEquals(expectedData.keySet(), actualBlockIds);
+      assertFalse(handler.getReaderIterator().hasNext());
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail(e.getMessage());
+    }
+  }
+
+  private void writeTestData(
+      HdfsShuffleWriteHandler writeHandler,
+      int num, int length, long taskAttemptId,
+      Map<Long, byte[]> expectedData) throws Exception {
+    List<ShufflePartitionedBlock> blocks = Lists.newArrayList();
+    for (int i = 0; i < num; i++) {
+      byte[] buf = new byte[length];
+      new Random().nextBytes(buf);
+      long blockId = (ATOMIC_LONG.getAndIncrement()
+          << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH)) + taskAttemptId;
+      blocks.add(new ShufflePartitionedBlock(
+          length, length, ChecksumUtils.getCrc32(buf), blockId, taskAttemptId, buf));
+      expectedData.put(blockId, buf);
+    }
+    writeHandler.write(blocks);
+  }
+
+  private int calcExpectedSegmentNum(int num, int size, int bufferSize) {
+    int segmentNum = 0;
+    int cur = 0;
+    for (int i = 0; i < num; ++i) {
+      cur += size;
+      if (cur >= bufferSize) {
+        segmentNum++;
+        cur = 0;
+      }
+    }
+
+    if (cur > 0) {
+      ++segmentNum;
+    }
+
+    return segmentNum;
+  }
+
+  protected void checkData(ShuffleDataResult shuffleDataResult, Map<Long, byte[]> expectedData) {
+
+    byte[] buffer = shuffleDataResult.getData();
+    List<BufferSegment> bufferSegments = shuffleDataResult.getBufferSegments();
+
+    for (BufferSegment bs : bufferSegments) {
+      byte[] data = new byte[bs.getLength()];
+      System.arraycopy(buffer, bs.getOffset(), data, 0, bs.getLength());
+      assertEquals(bs.getCrc(), ChecksumUtils.getCrc32(data));
+      assertArrayEquals(expectedData.get(bs.getBlockId()), data);
+    }
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Add read shuffle index api in hdfs read handler
2. Read all index data from hdfs
3. Use offset and length to read data from hdfs

### Why are the changes needed?
As mentioned in #6, we want to read index first and use it to read data and
then we could realize server HA and read replica on demand.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT, integration test, TPC-DS and terasort.