### PR TITLE
[Feature] Limit upload segment num and upload time in force mode

### DIFF
--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
@@ -69,7 +69,6 @@ public class MultiStorageFaultToleranceTest extends ShuffleReadWriteBase {
     shuffleServerConf.setLong(ShuffleServerConf.SHUFFLE_EXPIRED_TIMEOUT_MS, 5000L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 60L * 1000L * 60L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
-    shuffleServerConf.setLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC, 15);
     shuffleServerConf.setBoolean(ShuffleServerConf.USE_MULTI_STORAGE, true);
     shuffleServerConf.setString("rss.storage.type", StorageType.LOCALFILE_AND_HDFS.name());
     shuffleServerConf.setString("rss.storage.basePath", basePath);

--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
@@ -85,7 +85,7 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
     shuffleServerConf.setLong(ShuffleServerConf.SHUFFLE_EXPIRED_TIMEOUT_MS, 5000L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 60L * 1000L * 60L);
     shuffleServerConf.setLong(ShuffleServerConf.SERVER_COMMIT_TIMEOUT, 20L * 1000L);
-    shuffleServerConf.setLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC, 1);
+    shuffleServerConf.setLong(ShuffleServerConf.PENDING_EVENT_TIMEOUT_SEC, 30);
     shuffleServerConf.setBoolean(ShuffleServerConf.USE_MULTI_STORAGE, true);
     createAndStartServers(shuffleServerConf, coordinatorConf);
   }

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
@@ -252,6 +252,12 @@ public class ShuffleServerConf extends RssBaseConf {
       .defaultValue(1024L * 1024L * 1024L)
       .withDescription("The max value of upload shuffle size");
 
+  public static final ConfigOption<Double> SHUFFLE_MAX_FORCE_UPLOAD_TIME_RATIO = ConfigOptions
+      .key("rss.server.shuffle.max.force.upload.time.ratio")
+      .doubleType()
+      .defaultValue(95.0)
+      .withDescription("The max upload time ratio in force mode");
+
   public static final ConfigOption<Long> SERVER_SHUFFLE_INDEX_SIZE_HINT = ConfigOptions
       .key("rss.server.index.size.hint")
       .longType()

--- a/storage/src/main/java/com/tencent/rss/storage/common/DiskItem.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/DiskItem.java
@@ -198,6 +198,18 @@ public class DiskItem {
     return diskMetaData;
   }
 
+  public long getCapacity() {
+    return capacity;
+  }
+
+  public double getHighWaterMarkOfWrite() {
+    return highWaterMarkOfWrite;
+  }
+
+  public double getLowWaterMarkOfWrite() {
+    return lowWaterMarkOfWrite;
+  }
+
   @VisibleForTesting
   void setDiskMetaData(DiskMetaData diskMetaData) {
     this.diskMetaData = diskMetaData;


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Limit upload segment num to upload thread num in force mode
- Add hard upload time restriction in force mode

### Why are the changes needed?
A huge shuffle exhaust all the disk capacity and it will trigger force upload in multistorage mode, which it is upload according to the shuffle granularity. But the huge shuffle may have lots of segments much larger than the upload thread number and make the upload time longer than the event flush expire threshold. Therefore we need to restrict both the segment number of a single shuffle and the upload time in force mode. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
UT, integration test and terasort.
