### PR TITLE
[Improvement] Avoid speculative tasks causing writing errors after shuffle is uploaded and deleted

### DIFF
--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
@@ -237,7 +237,7 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
         shuffleServerClient.sendHeartBeat(ra);
         boolean uploadFinished = true;
         for (int i = 0; i < 4; i++) {
-          DiskItem diskItem = shuffleServers.get(0).getMultiStorageManager().getDiskItem(appId, 0, 0);
+          DiskItem diskItem = shuffleServers.get(0).getMultiStorageManager().getDiskItem(appId, 0, i);
           String path = ShuffleStorageUtils.getFullShuffleDataFolder(diskItem.getBasePath(),
               ShuffleStorageUtils.getShuffleDataPath(appId, 0, i, i));
           File file = new File(path);
@@ -395,6 +395,28 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
       assertTrue(re.getMessage().contains("Can't get shuffle index"));
     }
     assertTrue(isException);
+
+    List<ShuffleBlockInfo> blocks5 = createShuffleBlockList(
+        0, 0, 1,15, 1024 * 1024, blockIdBitmap1, expectedData);
+    partitionToBlocks.clear();
+    shuffleToBlocks.clear();
+    partitionToBlocks.put(0, blocks5);
+    shuffleToBlocks.put(0, partitionToBlocks);
+    RssSendShuffleDataRequest rs5 = new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
+    DiskItem diskItem = shuffleServers.get(0).getMultiStorageManager().getDiskItem(appId, 0, 0);
+    String path = ShuffleStorageUtils.getFullShuffleDataFolder(diskItem.getBasePath(),
+        ShuffleStorageUtils.getShuffleDataPath(appId, 0, 0, 0));
+    File file = new File(path);
+    assertFalse(file.exists());
+    try {
+      shuffleServerClient.sendShuffleData(rs5);
+      shuffleServerClient.sendCommit(rc1);
+      shuffleServerClient.finishShuffle(rf1);
+      shuffleServerClient.reportShuffleResult(rrp1);
+    } catch (Exception e) {
+      fail();
+    }
+    assertFalse(file.exists());
   }
 
   @Test

--- a/server/src/main/java/com/tencent/rss/server/ShuffleFlushManager.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleFlushManager.java
@@ -157,6 +157,8 @@ public class ShuffleFlushManager {
       if (blocks == null || blocks.isEmpty()) {
         LOG.info("There is no block to be flushed: " + event);
       } else if (!event.isValid()) {
+        //  avoid printing error log
+        writeSuccess = true;
         LOG.warn("AppId {} was removed already, event {} should be dropped", event.getAppId(), event);
       } else {
         ShuffleWriteHandler handler = getHandler(event);
@@ -169,6 +171,8 @@ public class ShuffleFlushManager {
           if (!event.isValid()) {
             LOG.warn("AppId {} was removed already, event {} should be dropped, may leak one handler",
                 event.getAppId(), event);
+            //  avoid printing error log
+            writeSuccess = true;
             break;
           }
           ReadWriteLock lock = null;

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
@@ -88,17 +88,18 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
   @Override
   public synchronized void write(
       List<ShufflePartitionedBlock> shuffleBlocks) throws IOException, IllegalStateException {
-    long accessTime = System.currentTimeMillis();
-    String dataFileName = ShuffleStorageUtils.generateDataFileName(fileNamePrefix);
-    String indexFileName = ShuffleStorageUtils.generateIndexFileName(fileNamePrefix);
 
-    // if shuffle has been uploaded totally, the directory of shuffle will be deleted
-    // the event should be dropped.
+    // Ignore this write, if the shuffle directory is deleted after being uploaded in multi mode
+    // or after its app heartbeat times out.
     File baseFolder = new File(basePath);
     if (!baseFolder.exists()) {
       LOG.warn("{} don't exist, the app or shuffle may be deleted", baseFolder.getAbsolutePath());
       return;
     }
+
+    long accessTime = System.currentTimeMillis();
+    String dataFileName = ShuffleStorageUtils.generateDataFileName(fileNamePrefix);
+    String indexFileName = ShuffleStorageUtils.generateIndexFileName(fileNamePrefix);
 
     try (LocalFileWriter dataWriter = createWriter(dataFileName);
         LocalFileWriter indexWriter = createWriter(indexFileName)) {

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
@@ -92,6 +92,14 @@ public class LocalFileWriteHandler implements ShuffleWriteHandler {
     String dataFileName = ShuffleStorageUtils.generateDataFileName(fileNamePrefix);
     String indexFileName = ShuffleStorageUtils.generateIndexFileName(fileNamePrefix);
 
+    // if shuffle has been uploaded totally, the directory of shuffle will be deleted
+    // the event should be dropped.
+    File baseFolder = new File(basePath);
+    if (!baseFolder.exists()) {
+      LOG.warn("{} don't exist, the app or shuffle may be deleted", baseFolder.getAbsolutePath());
+      return;
+    }
+
     try (LocalFileWriter dataWriter = createWriter(dataFileName);
         LocalFileWriter indexWriter = createWriter(indexFileName)) {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When event write data in LocalFileWriteHanlder, if base directorys don't exist,  the method will return directly, not throw FileNotFoundException.

### Why are the changes needed?
In multiStorage mode, shuffle will be started upload after shuffle is read. When shuffle has been uploaded totally,  shuffle directory will be deleted. Speculative tasks may also write its data to shuffle server.So these data will cause FileNotFoundExceptions, these exceptions will degrade performance.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add newly UTS.
