### PR TITLE
[Improvement] fix log4j Dependabot alerts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <java.version>1.8</java.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <junit.version>4.13.1</junit.version>
-    <log4j.core.version>2.15.0</log4j.core.version>
+    <log4j.core.version>2.16.0</log4j.core.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <metrics.version>3.1.0</metrics.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Upgrade org.apache.logging.log4j:log4j-core to version 2.16.0.

## Why are the changes needed?
Fix log4j-core dependabot
>The fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations. This could allow attackers with control over Thread Context Map (MDC) input data when the logging configuration uses a non-default Pattern Layout with either a Context Lookup (for example, $${ctx:loginId}) or a Thread Context Map pattern (%X, %mdc, or %MDC) to craft malicious input data using a JNDI Lookup pattern resulting in a denial of service (DOS) attack.

## Does this PR introduce any user-facing change?
No

## How was this patch tested?
Normal ut and integration test