### PR TITLE
[Improvement] Support Firestorm with Spark 2.3 & 3.0

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
 import org.apache.spark.deploy.SparkHadoopUtil;
 import org.apache.spark.io.CompressionCodec;
+import org.apache.spark.package$;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -142,5 +143,9 @@ public class RssShuffleUtils {
 
     return conf;
 
+  }
+
+  public static String getSparkVersion() {
+    return package$.MODULE$.SPARK_VERSION();
   }
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -339,9 +339,10 @@ public class RssShuffleManager implements ShuffleManager {
   // get the actual tasks and filter the duplicate data caused by speculation task
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
+    // use toIterator() to supoort Spark 2.3 & 2.4
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
-      SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
-      .toIterator();
+        SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
+            .toIterator();
     while (mapStatusIter.hasNext()) {
       Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>> tuple2 = mapStatusIter.next();
       Option<String> topologyInfo = tuple2._1().topologyInfo();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -339,8 +339,8 @@ public class RssShuffleManager implements ShuffleManager {
   // get the actual tasks and filter the duplicate data caused by speculation task
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
-    // use toIterator() to supoort Spark 2.3 & 2.4
-    // Seq.toIterator (in 2.3) = > iterator, Iterator.toIterator (in 2.4) => iterator
+    // In 2.3, getMapSizesByExecutorId returns Seq, while it returns Iterator in 2.4,
+    // so we use toIterator() to supoort Spark 2.3 & 2.4
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
         SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
             .toIterator();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -340,7 +340,7 @@ public class RssShuffleManager implements ShuffleManager {
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     // use toIterator() to supoort Spark 2.3 & 2.4
-    // Seq.toIterator = > iterator, Iterator.toIterator => iterator
+    // Seq.toIterator (in 2.3) = > iterator, Iterator.toIterator (in 2.4) => iterator
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
         SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
             .toIterator();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -340,8 +340,8 @@ public class RssShuffleManager implements ShuffleManager {
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
-        SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition);
-
+      SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
+      .toIterator();
     while (mapStatusIter.hasNext()) {
       Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>> tuple2 = mapStatusIter.next();
       Option<String> topologyInfo = tuple2._1().topologyInfo();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -340,6 +340,7 @@ public class RssShuffleManager implements ShuffleManager {
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     // use toIterator() to supoort Spark 2.3 & 2.4
+    // Seq.toIterator = > iterator, Iterator.toIterator => iterator
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
         SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
             .toIterator();

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -415,12 +415,6 @@ public class RssShuffleManager implements ShuffleManager {
         throw new RuntimeException(ee);
       }
     }
-
-    if (mapStatusIter == null) {
-      String sparkVersion = RssShuffleUtils.getSparkVersion();
-      throw new RuntimeException("Cannot get mapStatusIter from Spark " + sparkVersion);
-    }
-
     while (mapStatusIter.hasNext()) {
       Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>> tuple2 = mapStatusIter.next();
       if (!tuple2._1().topologyInfo().isDefined()) {
@@ -428,7 +422,6 @@ public class RssShuffleManager implements ShuffleManager {
       }
       taskIdBitmap.add(Long.parseLong(tuple2._1().topologyInfo().get()));
     }
-
     return taskIdBitmap;
   }
 
@@ -454,11 +447,6 @@ public class RssShuffleManager implements ShuffleManager {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    if (mapStatusIter == null) {
-      String sparkVersion = RssShuffleUtils.getSparkVersion();
-      throw new RuntimeException("Cannot get mapStatusIter from Spark " + sparkVersion);
-    }
-
     while (mapStatusIter.hasNext()) {
       Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>> tuple2 = mapStatusIter.next();
       if (!tuple2._1().topologyInfo().isDefined()) {
@@ -466,7 +454,6 @@ public class RssShuffleManager implements ShuffleManager {
       }
       taskIdBitmap.add(Long.parseLong(tuple2._1().topologyInfo().get()));
     }
-
     return taskIdBitmap;
   }
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -387,6 +387,8 @@ public class RssShuffleManager implements ShuffleManager {
       int endMapIndex) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>> mapStatusIter = null;
+    // Since Spark 3.1 refactors the interface of getMapSizesByExecutorId,
+    // we use reflection and catch for the compatibility with 3.0 & 3.1
     try {
       // attempt to use Spark 3.1's API
       mapStatusIter = (Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>>)

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -425,6 +425,8 @@ public class RssShuffleManager implements ShuffleManager {
     return taskIdBitmap;
   }
 
+  // This API is only used by Spark3.0 and removed since 3.1,
+  // so we extract it from getExpectedTasksByExecutorId.
   private Roaring64NavigableMap getExpectedTasksByRange(
     int shuffleId,
     int startPartition,

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -351,7 +351,7 @@ public class RssShuffleManager implements ShuffleManager {
       int endPartition,
       TaskContext context,
       ShuffleReadMetricsReporter metrics) {
-    return getReader(handle, 0, Integer.MAX_VALUE, startPartition, endPartition, context, metrics);
+    return getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
   }
 
   private Roaring64NavigableMap getExpectedTasks(

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -374,7 +374,6 @@ public class RssShuffleManager implements ShuffleManager {
         readMetrics);
   }
 
-  // byRange is reserved to support Spark 3.0
   private Roaring64NavigableMap getExpectedTasks(
       int shuffleId,
       int startPartition,

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -280,6 +280,7 @@ public class RssShuffleManager implements ShuffleManager {
       int endPartition,
       TaskContext context,
       ShuffleReadMetricsReporter metrics) {
+    long start = System.currentTimeMillis();
     Roaring64NavigableMap taskIdBitmap = getExpectedTasks(
       handle.shuffleId(),
       startPartition,
@@ -287,6 +288,9 @@ public class RssShuffleManager implements ShuffleManager {
       startMapIndex,
       endMapIndex,
       false);
+    LOG.info("Get taskId cost " + (System.currentTimeMillis() - start) + " ms, and request expected blockIds from "
+      + taskIdBitmap.getLongCardinality() + " tasks for shuffleId[" + handle.shuffleId() + "], partitionId["
+      + startPartition + "]");
     return getReaderImpl(handle, startMapIndex, endMapIndex, startPartition, endPartition,
         context, metrics, taskIdBitmap);
   }
@@ -382,7 +386,6 @@ public class RssShuffleManager implements ShuffleManager {
       int endMapIndex,
       boolean byRange) {
 
-    long start = System.currentTimeMillis();
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     Iterator<Tuple2<BlockManagerId, Seq<Tuple3<BlockId, Object, Object>>>> mapStatusIter = null;
     String sparkVersion = RssShuffleUtils.getSparkVersion();
@@ -443,10 +446,6 @@ public class RssShuffleManager implements ShuffleManager {
       }
       taskIdBitmap.add(Long.parseLong(tuple2._1().topologyInfo().get()));
     }
-
-    LOG.info("Get taskId cost " + (System.currentTimeMillis() - start) + " ms, and request expected blockIds from "
-      + taskIdBitmap.getLongCardinality() + " tasks for shuffleId[" + shuffleId + "], partitionId["
-      + startPartition + "]");
 
     return taskIdBitmap;
   }

--- a/integration-test/spark3/src/test/java/com/tencent/rss/test/AQERepartitionTest.java
+++ b/integration-test/spark3/src/test/java/com/tencent/rss/test/AQERepartitionTest.java
@@ -54,7 +54,7 @@ public class AQERepartitionTest extends SparkIntegrationTestBase {
   public void updateCommonSparkConf(SparkConf sparkConf) {
     sparkConf.set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "true");
     sparkConf.set(SQLConf.COALESCE_PARTITIONS_ENABLED(), "true");
-    sparkConf.set(SQLConf.COALESCE_PARTITIONS_INITIAL_PARTITION_NUM().key(), "10");
+    sparkConf.set(SQLConf.COALESCE_PARTITIONS_INITIAL_PARTITION_NUM().key(), "6");
     sparkConf.set(SQLConf.SHUFFLE_PARTITIONS().key(), "10");
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1004,6 +1004,57 @@
     </profile>
 
     <profile>
+      <id>spark2.3</id>
+      <properties>
+        <scala.binary.version>2.11</scala.binary.version>
+        <spark.version>2.3.4</spark.version>
+        <client.type>2</client.type>
+        <jackson.version>2.9.0</jackson.version>
+      </properties>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark2</module>
+        <module>integration-test/spark-common</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark2</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
+    <profile>
       <id>spark3</id>
       <properties>
         <scala.binary.version>2.12</scala.binary.version>
@@ -1069,10 +1120,80 @@
             <type>test-jar</type>
             <scope>test</scope>
           </dependency>
-
         </dependencies>
       </dependencyManagement>
     </profile>
+
+    <profile>
+      <id>spark3.0</id>
+      <properties>
+        <scala.binary.version>2.12</scala.binary.version>
+        <spark.version>3.0.1</spark.version>
+        <client.type>3</client.type>
+        <jackson.version>2.10.0</jackson.version>
+      </properties>
+      <modules>
+        <module>client-spark/common</module>
+        <module>client-spark/spark3</module>
+        <module>integration-test/spark-common</module>
+        <module>integration-test/spark3</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark3</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <version>${spark.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-integration-spark-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
+
   </profiles>
 
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Change some interfaces in the form that Spark2.3 and Spark3.0 support.
2. Add getReaderImpl to unify the different versions of shuffle reader.

### Why are the changes needed?
 Some interfaces are different in Spark2.3 and Spark3.0.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
 UT & IT with -Pspark2.3 (or -Pspark3.0)