### PR TITLE
[Improvement] Update import style in the Spark-like way

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -291,10 +291,12 @@
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
              <!-- new add -->
-            <property name="severity" value="ignore"/>
+            <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
+            <property name="specialImportsRegExp" value="^com\.tencent\."/>
+            <property name="standardPackageRegExp" value="^java\."/>
             <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
+            <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>
         </module>
         <module name="MethodParamPad">

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -294,7 +294,7 @@
             <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="specialImportsRegExp" value="^com\.tencent\."/>
-            <property name="standardPackageRegExp" value="^(java\.)|(javax\.)"/>
+            <property name="standardPackageRegExp" value="^java\.|^javax\."/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -294,7 +294,7 @@
             <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="specialImportsRegExp" value="^com\.tencent\."/>
-            <property name="standardPackageRegExp" value="^java\."/>
+            <property name="standardPackageRegExp" value="^java\.|javax."/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -294,7 +294,7 @@
             <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="specialImportsRegExp" value="^com\.tencent\."/>
-            <property name="standardPackageRegExp" value="^java\.|javax."/>
+            <property name="standardPackageRegExp" value="^java\.|javax\."/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -294,7 +294,7 @@
             <property name="severity" value="WARNING"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="specialImportsRegExp" value="^com\.tencent\."/>
-            <property name="standardPackageRegExp" value="^java\.|javax\."/>
+            <property name="standardPackageRegExp" value="^(java\.)|(javax\.)"/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STANDARD_JAVA_PACKAGE###THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STATIC"/>
             <property name="tokens" value="IMPORT, STATIC_IMPORT, PACKAGE_DEF"/>

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
@@ -18,12 +18,14 @@
 
 package org.apache.spark.shuffle;
 
-import com.google.common.collect.Sets;
-import com.tencent.rss.common.ShuffleServerInfo;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import com.google.common.collect.Sets;
 import org.apache.spark.ShuffleDependency;
+
+import com.tencent.rss.common.ShuffleServerInfo;
 
 public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -18,12 +18,13 @@
 
 package org.apache.spark.shuffle;
 
-import com.google.common.collect.Lists;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -18,14 +18,13 @@
 
 package org.apache.spark.shuffle.reader;
 
-import com.esotericsoftware.kryo.io.Input;
-import com.google.common.annotations.VisibleForTesting;
-import com.tencent.rss.client.api.ShuffleReadClient;
-import com.tencent.rss.client.response.CompressedShuffleBlock;
-import io.netty.buffer.ByteBufInputStream;
-import io.netty.buffer.Unpooled;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+
+import com.esotericsoftware.kryo.io.Input;
+import com.google.common.annotations.VisibleForTesting;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.Unpooled;
 import org.apache.spark.executor.ShuffleReadMetrics;
 import org.apache.spark.serializer.DeserializationStream;
 import org.apache.spark.serializer.Serializer;
@@ -37,6 +36,9 @@ import scala.Product2;
 import scala.Tuple2;
 import scala.collection.AbstractIterator;
 import scala.collection.Iterator;
+
+import com.tencent.rss.client.api.ShuffleReadClient;
+import com.tencent.rss.client.response.CompressedShuffleBlock;
 
 public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C>> {
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/AddBlockEvent.java
@@ -18,8 +18,9 @@
 
 package org.apache.spark.shuffle.writer;
 
-import com.tencent.rss.common.ShuffleBlockInfo;
 import java.util.List;
+
+import com.tencent.rss.common.ShuffleBlockInfo;
 
 public class AddBlockEvent {
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -18,18 +18,14 @@
 
 package org.apache.spark.shuffle.writer;
 
-import com.clearspring.analytics.util.Lists;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
-import com.tencent.rss.client.util.ClientUtils;
-import com.tencent.rss.common.exception.RssException;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.util.ChecksumUtils;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
+
+import com.clearspring.analytics.util.Lists;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.memory.MemoryConsumer;
 import org.apache.spark.memory.TaskMemoryManager;
@@ -40,6 +36,12 @@ import org.apache.spark.shuffle.RssShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.reflect.ClassTag$;
+
+import com.tencent.rss.client.util.ClientUtils;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.exception.RssException;
+import com.tencent.rss.common.util.ChecksumUtils;
 
 public class WriteBufferManager extends MemoryConsumer {
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriterBuffer.java
@@ -18,8 +18,9 @@
 
 package org.apache.spark.shuffle.writer;
 
-import com.google.common.collect.Lists;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -18,19 +18,19 @@
 
 package org.apache.spark.shuffle;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.factory.ShuffleClientFactory;
-import com.tencent.rss.client.response.SendShuffleDataResult;
-import com.tencent.rss.common.PartitionRange;
-import com.tencent.rss.common.ShuffleAssignmentsInfo;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.util.Constants;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
@@ -52,13 +52,14 @@ import scala.Tuple2;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.factory.ShuffleClientFactory;
+import com.tencent.rss.client.response.SendShuffleDataResult;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleAssignmentsInfo;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.util.Constants;
 
 public class RssShuffleManager implements ShuffleManager {
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -18,11 +18,8 @@
 
 package org.apache.spark.shuffle.reader;
 
-import com.tencent.rss.client.api.ShuffleReadClient;
-import com.tencent.rss.client.factory.ShuffleClientFactory;
-import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
-import com.tencent.rss.common.ShuffleServerInfo;
 import java.util.List;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.InterruptibleIterator;
 import org.apache.spark.ShuffleDependency;
@@ -31,8 +28,8 @@ import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
 import org.apache.spark.shuffle.ShuffleReader;
 import org.apache.spark.util.CompletionIterator$;
-import org.apache.spark.util.collection.ExternalSorter;
 import org.apache.spark.util.TaskCompletionListener;
+import org.apache.spark.util.collection.ExternalSorter;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +39,11 @@ import scala.Product2;
 import scala.collection.Iterator;
 import scala.runtime.AbstractFunction0;
 import scala.runtime.BoxedUnit;
+
+import com.tencent.rss.client.api.ShuffleReadClient;
+import com.tencent.rss.client.factory.ShuffleClientFactory;
+import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
+import com.tencent.rss.common.ShuffleServerInfo;
 
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -18,17 +18,20 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.util.ClientUtils;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.exception.RssException;
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
@@ -47,14 +50,12 @@ import scala.Option;
 import scala.Product2;
 import scala.collection.Iterator;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.util.ClientUtils;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.exception.RssException;
+import com.tencent.rss.storage.util.StorageType;
 
 public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -18,18 +18,21 @@
 
 package org.apache.spark.shuffle;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.factory.ShuffleClientFactory;
-import com.tencent.rss.client.response.SendShuffleDataResult;
-import com.tencent.rss.common.PartitionRange;
-import com.tencent.rss.common.ShuffleAssignmentsInfo;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.util.Constants;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
@@ -52,16 +55,14 @@ import scala.Tuple3;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.factory.ShuffleClientFactory;
+import com.tencent.rss.client.response.SendShuffleDataResult;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleAssignmentsInfo;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.util.Constants;
 
 public class RssShuffleManager implements ShuffleManager {
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -18,11 +18,10 @@
 
 package org.apache.spark.shuffle.reader;
 
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.Lists;
-import com.tencent.rss.client.api.ShuffleReadClient;
-import com.tencent.rss.client.factory.ShuffleClientFactory;
-import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
-import com.tencent.rss.common.ShuffleServerInfo;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.InterruptibleIterator;
 import org.apache.spark.ShuffleDependency;
@@ -46,8 +45,10 @@ import scala.runtime.AbstractFunction0;
 import scala.runtime.AbstractFunction1;
 import scala.runtime.BoxedUnit;
 
-import java.util.List;
-import java.util.Map;
+import com.tencent.rss.client.api.ShuffleReadClient;
+import com.tencent.rss.client.factory.ShuffleClientFactory;
+import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
+import com.tencent.rss.common.ShuffleServerInfo;
 
 public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
   private static final Logger LOG = LoggerFactory.getLogger(RssShuffleReader.class);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -18,17 +18,21 @@
 
 package org.apache.spark.shuffle.writer;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.util.ClientUtils;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.exception.RssException;
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
@@ -46,15 +50,12 @@ import scala.Option;
 import scala.Product2;
 import scala.collection.Iterator;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.util.ClientUtils;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.exception.RssException;
+import com.tencent.rss.storage.util.StorageType;
 
 public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
 

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/TestUtils.java
@@ -18,11 +18,11 @@
 
 package org.apache.spark.shuffle;
 
-import org.apache.spark.SparkConf;
-import org.apache.spark.util.EventLoop;
-
 import java.util.Map;
 import java.util.Set;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.util.EventLoop;
 
 public class TestUtils {
 

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -18,15 +18,9 @@
 
 package org.apache.spark.shuffle.reader;
 
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import java.util.Map;
 
 import com.google.common.collect.Maps;
-import com.tencent.rss.storage.handler.impl.HdfsShuffleWriteHandler;
-import com.tencent.rss.storage.util.StorageType;
-import java.util.Map;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
@@ -38,6 +32,15 @@ import org.apache.spark.shuffle.RssShuffleHandle;
 import org.junit.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import scala.Option;
+
+import com.tencent.rss.storage.handler.impl.HdfsShuffleWriteHandler;
+import com.tencent.rss.storage.util.StorageType;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
 
 public class RssShuffleReaderTest extends AbstractRssReaderTest {
 

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -18,13 +18,16 @@
 
 package org.apache.spark.shuffle.writer;
 
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.Partitioner;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
@@ -47,11 +50,10 @@ import scala.Product2;
 import scala.Tuple2;
 import scala.collection.mutable.MutableList;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.storage.util.StorageType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
@@ -18,15 +18,17 @@
 
 package com.tencent.rss.client.api;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
 import com.tencent.rss.client.response.SendShuffleDataResult;
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.common.ShuffleAssignmentsInfo;
 import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 public interface ShuffleWriteClient {
 

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -18,9 +18,20 @@
 
 package com.tencent.rss.client.impl;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import org.apache.hadoop.conf.Configuration;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;
 import com.tencent.rss.common.BufferSegment;
@@ -33,16 +44,6 @@ import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.factory.ShuffleHandlerFactory;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
-import org.apache.hadoop.conf.Configuration;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class ShuffleReadClientImpl implements ShuffleReadClient {
 

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -18,11 +18,22 @@
 
 package com.tencent.rss.client.impl;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.api.ShuffleWriteClient;
@@ -47,21 +58,11 @@ import com.tencent.rss.client.response.RssReportShuffleResultResponse;
 import com.tencent.rss.client.response.RssSendCommitResponse;
 import com.tencent.rss.client.response.RssSendShuffleDataResponse;
 import com.tencent.rss.client.response.SendShuffleDataResult;
-import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.common.ShuffleAssignmentsInfo;
 import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.tencent.rss.common.exception.RssException;
 
 public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 

--- a/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
@@ -18,10 +18,12 @@
 
 package com.tencent.rss.client.request;
 
-import com.tencent.rss.common.ShuffleServerInfo;
 import java.util.List;
+
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import com.tencent.rss.common.ShuffleServerInfo;
 
 public class CreateShuffleReadClientRequest {
 

--- a/common/src/main/java/com/tencent/rss/common/ShuffleDataResult.java
+++ b/common/src/main/java/com/tencent/rss/common/ShuffleDataResult.java
@@ -18,8 +18,9 @@
 
 package com.tencent.rss.common;
 
-import com.google.common.collect.Lists;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 
 public class ShuffleDataResult {
 

--- a/common/src/main/java/com/tencent/rss/common/config/ConfigUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/config/ConfigUtils.java
@@ -18,13 +18,13 @@
 
 package com.tencent.rss.common.config;
 
-import com.google.common.collect.Lists;
-
-import com.tencent.rss.common.util.UnitConverter;
-
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.function.Function;
+
+import com.google.common.collect.Lists;
+
+import com.tencent.rss.common.util.UnitConverter;
 
 import static java.lang.reflect.Modifier.isFinal;
 import static java.lang.reflect.Modifier.isPublic;

--- a/common/src/main/java/com/tencent/rss/common/config/RssConf.java
+++ b/common/src/main/java/com/tencent/rss/common/config/RssConf.java
@@ -18,15 +18,15 @@
 
 package com.tencent.rss.common.config;
 
-import com.google.common.collect.Sets;
-
-import com.tencent.rss.common.util.UnitConverter;
-
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import com.google.common.collect.Sets;
+
+import com.tencent.rss.common.util.UnitConverter;
 
 public class RssConf {
 

--- a/common/src/main/java/com/tencent/rss/common/metrics/GRPCMetrics.java
+++ b/common/src/main/java/com/tencent/rss/common/metrics/GRPCMetrics.java
@@ -18,12 +18,12 @@
 
 package com.tencent.rss.common.metrics;
 
+import java.util.Map;
+
 import com.google.common.collect.Maps;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
-
-import java.util.Map;
 
 public abstract class GRPCMetrics {
 

--- a/common/src/main/java/com/tencent/rss/common/rpc/GrpcServer.java
+++ b/common/src/main/java/com/tencent/rss/common/rpc/GrpcServer.java
@@ -18,23 +18,23 @@
 
 package com.tencent.rss.common.rpc;
 
-import com.google.common.collect.Queues;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.tencent.rss.common.config.RssBaseConf;
-import com.tencent.rss.common.metrics.GRPCMetrics;
-import com.tencent.rss.common.util.ExitUtils;
-import io.grpc.BindableService;
-import io.grpc.Server;
-import io.grpc.ServerBuilder;
-import io.grpc.ServerInterceptors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Queues;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.grpc.BindableService;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerInterceptors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.config.RssBaseConf;
+import com.tencent.rss.common.metrics.GRPCMetrics;
+import com.tencent.rss.common.util.ExitUtils;
 
 public class GrpcServer implements ServerInterface {
 

--- a/common/src/main/java/com/tencent/rss/common/rpc/MonitoringServerCall.java
+++ b/common/src/main/java/com/tencent/rss/common/rpc/MonitoringServerCall.java
@@ -18,11 +18,12 @@
 
 package com.tencent.rss.common.rpc;
 
-import com.tencent.rss.common.metrics.GRPCMetrics;
 import io.grpc.ForwardingServerCall;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+
+import com.tencent.rss.common.metrics.GRPCMetrics;
 
 public class MonitoringServerCall<R, S> extends ForwardingServerCall.SimpleForwardingServerCall<R, S> {
 

--- a/common/src/main/java/com/tencent/rss/common/rpc/MonitoringServerInterceptor.java
+++ b/common/src/main/java/com/tencent/rss/common/rpc/MonitoringServerInterceptor.java
@@ -18,12 +18,13 @@
 
 package com.tencent.rss.common.rpc;
 
-import com.tencent.rss.common.metrics.GRPCMetrics;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+
+import com.tencent.rss.common.metrics.GRPCMetrics;
 
 public class MonitoringServerInterceptor implements ServerInterceptor {
 

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -18,14 +18,6 @@
 
 package com.tencent.rss.common.util;
 
-import com.google.common.collect.Lists;
-import com.tencent.rss.common.BufferSegment;
-import com.tencent.rss.common.ShuffleDataSegment;
-import com.tencent.rss.common.ShuffleIndexResult;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -44,6 +36,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+
+import com.google.common.collect.Lists;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.BufferSegment;
+import com.tencent.rss.common.ShuffleDataSegment;
+import com.tencent.rss.common.ShuffleIndexResult;
 
 public class RssUtils {
 

--- a/common/src/main/java/com/tencent/rss/common/util/UnitConverter.java
+++ b/common/src/main/java/com/tencent/rss/common/util/UnitConverter.java
@@ -18,13 +18,13 @@
 
 package com.tencent.rss.common.util;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableMap;
 
 // copy from org.apache.spark.network.util.JavaUtils
 public class UnitConverter {

--- a/common/src/main/java/com/tencent/rss/common/web/CommonMetricsServlet.java
+++ b/common/src/main/java/com/tencent/rss/common/web/CommonMetricsServlet.java
@@ -28,15 +28,15 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.prometheus.client.Collector;
 import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.MetricsServlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class CommonMetricsServlet extends MetricsServlet {
 

--- a/common/src/main/java/com/tencent/rss/common/web/CommonMetricsServlet.java
+++ b/common/src/main/java/com/tencent/rss/common/web/CommonMetricsServlet.java
@@ -18,11 +18,6 @@
 
 package com.tencent.rss.common.web;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.prometheus.client.Collector;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
-import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.exporter.MetricsServlet;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.Writer;
@@ -33,6 +28,12 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.exporter.MetricsServlet;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/common/src/main/java/com/tencent/rss/common/web/JettyServer.java
+++ b/common/src/main/java/com/tencent/rss/common/web/JettyServer.java
@@ -26,9 +26,9 @@ import java.nio.file.Paths;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import javax.servlet.Servlet;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import javax.servlet.Servlet;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;

--- a/common/src/main/java/com/tencent/rss/common/web/JettyServer.java
+++ b/common/src/main/java/com/tencent/rss/common/web/JettyServer.java
@@ -18,9 +18,6 @@
 
 package com.tencent.rss.common.web;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.tencent.rss.common.config.RssBaseConf;
-import com.tencent.rss.common.util.ExitUtils;
 import java.io.FileNotFoundException;
 import java.net.BindException;
 import java.nio.file.Files;
@@ -29,6 +26,8 @@ import java.nio.file.Paths;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import javax.servlet.Servlet;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.server.HttpConfiguration;
@@ -44,6 +43,9 @@ import org.eclipse.jetty.util.thread.ExecutorThreadPool;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.config.RssBaseConf;
+import com.tencent.rss.common.util.ExitUtils;
 
 public class JettyServer {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
@@ -18,14 +18,15 @@
 
 package com.tencent.rss.coordinator;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/BasicAssignmentStrategy.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/BasicAssignmentStrategy.java
@@ -18,15 +18,17 @@
 
 package com.tencent.rss.coordinator;
 
-import com.tencent.rss.common.PartitionRange;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.PartitionRange;
 
 public class BasicAssignmentStrategy implements AssignmentStrategy {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -18,13 +18,14 @@
 
 package com.tencent.rss.coordinator;
 
+import java.util.List;
+import java.util.Map;
+
 import com.tencent.rss.common.config.ConfigOption;
 import com.tencent.rss.common.config.ConfigOptions;
 import com.tencent.rss.common.config.ConfigUtils;
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.util.RssUtils;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Configuration for Coordinator Service and rss-cluster, including service port,

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorGrpcService.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorGrpcService.java
@@ -18,8 +18,20 @@
 
 package com.tencent.rss.coordinator;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.Sets;
 import com.google.protobuf.Empty;
+import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.proto.CoordinatorServerGrpc;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatRequest;
@@ -35,16 +47,7 @@ import com.tencent.rss.proto.RssProtos.ShuffleServerHeartBeatRequest;
 import com.tencent.rss.proto.RssProtos.ShuffleServerHeartBeatResponse;
 import com.tencent.rss.proto.RssProtos.ShuffleServerId;
 import com.tencent.rss.proto.RssProtos.StatusCode;
-import io.grpc.Context;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
 
 /**
  * Implementation class for services defined in protobuf

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorMetrics.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorMetrics.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.coordinator;
 
-import com.tencent.rss.common.metrics.MetricsManager;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+
+import com.tencent.rss.common.metrics.MetricsManager;
 
 public class CoordinatorMetrics {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
@@ -18,18 +18,19 @@
 
 package com.tencent.rss.coordinator;
 
+import java.io.FileNotFoundException;
+
+import io.prometheus.client.CollectorRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
 import com.tencent.rss.common.Arguments;
 import com.tencent.rss.common.metrics.GRPCMetrics;
 import com.tencent.rss.common.metrics.JvmMetrics;
 import com.tencent.rss.common.rpc.ServerInterface;
 import com.tencent.rss.common.web.CommonMetricsServlet;
 import com.tencent.rss.common.web.JettyServer;
-import io.prometheus.client.CollectorRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
-
-import java.io.FileNotFoundException;
 
 /**
  * The main entrance of coordinator service

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorUtils.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorUtils.java
@@ -18,12 +18,12 @@
 
 package com.tencent.rss.coordinator;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.proto.RssProtos;
 import com.tencent.rss.proto.RssProtos.GetShuffleAssignmentsResponse;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class CoordinatorUtils {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/PartitionBalanceAssignmentStrategy.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/PartitionBalanceAssignmentStrategy.java
@@ -18,19 +18,20 @@
 
 package com.tencent.rss.coordinator;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.tencent.rss.common.PartitionRange;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.PartitionRange;
 
 /**
  * PartitionBalanceAssignmentStrategy will consider allocating partitions from two aspects

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/PartitionRangeAssignment.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/PartitionRangeAssignment.java
@@ -18,14 +18,16 @@
 
 package com.tencent.rss.coordinator;
 
-import com.google.common.base.Objects;
-import com.tencent.rss.common.PartitionRange;
-import com.tencent.rss.proto.RssProtos;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
+
+import com.google.common.base.Objects;
+
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.proto.RssProtos;
 
 public class PartitionRangeAssignment {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ServerNode.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ServerNode.java
@@ -18,8 +18,9 @@
 
 package com.tencent.rss.coordinator;
 
-import com.tencent.rss.proto.RssProtos.ShuffleServerId;
 import java.util.Set;
+
+import com.tencent.rss.proto.RssProtos.ShuffleServerId;
 
 public class ServerNode implements Comparable<ServerNode> {
 

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/SimpleClusterManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/SimpleClusterManager.java
@@ -18,11 +18,6 @@
 
 package com.tencent.rss.coordinator;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -33,6 +28,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/internal-client/src/main/java/com/tencent/rss/client/factory/CoordinatorClientFactory.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/factory/CoordinatorClientFactory.java
@@ -18,14 +18,16 @@
 
 package com.tencent.rss.client.factory;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.impl.grpc.CoordinatorGrpcClient;
 import com.tencent.rss.client.util.ClientType;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CoordinatorClientFactory {
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorClientFactory.class);

--- a/internal-client/src/main/java/com/tencent/rss/client/factory/ShuffleServerClientFactory.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/factory/ShuffleServerClientFactory.java
@@ -18,12 +18,14 @@
 
 package com.tencent.rss.client.factory;
 
+import java.util.Map;
+
 import com.google.common.collect.Maps;
+
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.impl.grpc.ShuffleServerGrpcClient;
 import com.tencent.rss.client.util.ClientType;
 import com.tencent.rss.common.ShuffleServerInfo;
-import java.util.Map;
 
 public class ShuffleServerClientFactory {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -18,11 +18,22 @@
 
 package com.tencent.rss.client.impl.grpc;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.StatusRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
@@ -46,15 +57,6 @@ import com.tencent.rss.proto.RssProtos.ShuffleServerHeartBeatRequest;
 import com.tencent.rss.proto.RssProtos.ShuffleServerHeartBeatResponse;
 import com.tencent.rss.proto.RssProtos.ShuffleServerId;
 import com.tencent.rss.proto.RssProtos.StatusCode;
-import io.grpc.ManagedChannel;
-import io.grpc.StatusRuntimeException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClient {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/GrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/GrpcClient.java
@@ -18,9 +18,10 @@
 
 package com.tencent.rss.client.impl.grpc;
 
+import java.util.concurrent.TimeUnit;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
-import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -18,8 +18,16 @@
 
 package com.tencent.rss.client.impl.grpc;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssFinishShuffleRequest;
@@ -76,13 +84,6 @@ import com.tencent.rss.proto.RssProtos.ShuffleRegisterResponse;
 import com.tencent.rss.proto.RssProtos.StatusCode;
 import com.tencent.rss.proto.ShuffleServerGrpc;
 import com.tencent.rss.proto.ShuffleServerGrpc.ShuffleServerBlockingStub;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
 
 public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServerClient {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/request/RssRegisterShuffleRequest.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/request/RssRegisterShuffleRequest.java
@@ -18,8 +18,9 @@
 
 package com.tencent.rss.client.request;
 
-import com.tencent.rss.common.PartitionRange;
 import java.util.List;
+
+import com.tencent.rss.common.PartitionRange;
 
 public class RssRegisterShuffleRequest {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/request/RssSendShuffleDataRequest.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/request/RssSendShuffleDataRequest.java
@@ -18,9 +18,10 @@
 
 package com.tencent.rss.client.request;
 
-import com.tencent.rss.common.ShuffleBlockInfo;
 import java.util.List;
 import java.util.Map;
+
+import com.tencent.rss.common.ShuffleBlockInfo;
 
 public class RssSendShuffleDataRequest {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssGetInMemoryShuffleDataResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssGetInMemoryShuffleDataResponse.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.client.response;
 
-import com.tencent.rss.common.BufferSegment;
-
 import java.util.List;
+
+import com.tencent.rss.common.BufferSegment;
 
 public class RssGetInMemoryShuffleDataResponse extends ClientResponse {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssGetShuffleAssignmentsResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssGetShuffleAssignmentsResponse.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.client.response;
 
-import com.tencent.rss.common.PartitionRange;
-import com.tencent.rss.common.ShuffleServerInfo;
 import java.util.List;
 import java.util.Map;
+
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleServerInfo;
 
 public class RssGetShuffleAssignmentsResponse extends ClientResponse {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssGetShuffleResultResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssGetShuffleResultResponse.java
@@ -18,9 +18,11 @@
 
 package com.tencent.rss.client.response;
 
-import com.tencent.rss.common.util.RssUtils;
 import java.io.IOException;
+
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import com.tencent.rss.common.util.RssUtils;
 
 public class RssGetShuffleResultResponse extends ClientResponse {
 

--- a/server/src/main/java/com/tencent/rss/server/HealthCheck.java
+++ b/server/src/main/java/com/tencent/rss/server/HealthCheck.java
@@ -18,17 +18,17 @@
 
 package com.tencent.rss.server;
 
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.lang.reflect.Constructor;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * HealthCheck will check every server whether has the ability to process shuffle data. Currently, we only support disk

--- a/server/src/main/java/com/tencent/rss/server/LocalStorageChecker.java
+++ b/server/src/main/java/com/tencent/rss/server/LocalStorageChecker.java
@@ -17,15 +17,16 @@
 
 package com.tencent.rss.server;
 
+import java.io.File;
+import java.util.List;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.util.List;
+import com.tencent.rss.storage.util.StorageType;
 
 public class LocalStorageChecker extends Checker {
 

--- a/server/src/main/java/com/tencent/rss/server/MultiStorageManager.java
+++ b/server/src/main/java/com/tencent/rss/server/MultiStorageManager.java
@@ -18,7 +18,16 @@
 
 package com.tencent.rss.server;
 
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+
 import com.google.common.collect.Lists;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.common.DiskItem;
@@ -27,14 +36,6 @@ import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
 import com.tencent.rss.storage.request.CreateShuffleDeleteHandlerRequest;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import com.tencent.rss.storage.util.StorageType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.hadoop.conf.Configuration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
 
 public class MultiStorageManager {
 

--- a/server/src/main/java/com/tencent/rss/server/RegisterHeartBeat.java
+++ b/server/src/main/java/com/tencent/rss/server/RegisterHeartBeat.java
@@ -18,12 +18,6 @@
 
 package com.tencent.rss.server;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.tencent.rss.client.api.CoordinatorClient;
-import com.tencent.rss.client.factory.CoordinatorClientFactory;
-import com.tencent.rss.client.request.RssSendHeartBeatRequest;
-import com.tencent.rss.client.response.ResponseStatusCode;
-import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -32,8 +26,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.factory.CoordinatorClientFactory;
+import com.tencent.rss.client.request.RssSendHeartBeatRequest;
+import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 
 public class RegisterHeartBeat {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleDataFlushEvent.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleDataFlushEvent.java
@@ -18,11 +18,11 @@
 
 package com.tencent.rss.server;
 
-import com.tencent.rss.common.ShufflePartitionedBlock;
-import com.tencent.rss.server.buffer.ShuffleBuffer;
-
 import java.util.List;
 import java.util.function.Supplier;
+
+import com.tencent.rss.common.ShufflePartitionedBlock;
+import com.tencent.rss.server.buffer.ShuffleBuffer;
 
 public class ShuffleDataFlushEvent {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleFlushManager.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleFlushManager.java
@@ -18,6 +18,14 @@
 
 package com.tencent.rss.server;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
@@ -25,6 +33,11 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
 import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.hadoop.conf.Configuration;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.server.buffer.ShuffleBuffer;
@@ -34,18 +47,6 @@ import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
 import com.tencent.rss.storage.request.CreateShuffleDeleteHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
-import org.apache.hadoop.conf.Configuration;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
 
 public class ShuffleFlushManager {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServer.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServer.java
@@ -18,7 +18,15 @@
 
 package com.tencent.rss.server;
 
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import com.google.common.collect.Sets;
+import io.prometheus.client.CollectorRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
 import com.tencent.rss.common.Arguments;
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.metrics.GRPCMetrics;
@@ -30,13 +38,6 @@ import com.tencent.rss.common.web.CommonMetricsServlet;
 import com.tencent.rss.common.web.JettyServer;
 import com.tencent.rss.server.buffer.ShuffleBufferManager;
 import com.tencent.rss.storage.util.StorageType;
-import io.prometheus.client.CollectorRegistry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import picocli.CommandLine;
-
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Server that manages startup/shutdown of a {@code Greeter} server.

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
@@ -18,13 +18,14 @@
 
 package com.tencent.rss.server;
 
+import java.util.List;
+import java.util.Map;
+
 import com.tencent.rss.common.config.ConfigOption;
 import com.tencent.rss.common.config.ConfigOptions;
 import com.tencent.rss.common.config.ConfigUtils;
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.util.RssUtils;
-import java.util.List;
-import java.util.Map;
 
 public class ShuffleServerConf extends RssBaseConf {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServerGrpcService.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServerGrpcService.java
@@ -18,10 +18,19 @@
 
 package com.tencent.rss.server;
 
+import java.util.List;
+import java.util.Map;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.UnsafeByteOperations;
+import io.grpc.Context;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.common.ShuffleDataResult;
@@ -58,14 +67,6 @@ import com.tencent.rss.proto.RssProtos.ShufflePartitionRange;
 import com.tencent.rss.proto.RssProtos.ShuffleRegisterRequest;
 import com.tencent.rss.proto.RssProtos.ShuffleRegisterResponse;
 import com.tencent.rss.proto.ShuffleServerGrpc.ShuffleServerImplBase;
-import io.grpc.Context;
-import io.grpc.Status;
-import io.grpc.stub.StreamObserver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Map;
 
 public class ShuffleServerGrpcService extends ShuffleServerImplBase {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServerMetrics.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServerMetrics.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.server;
 
-import com.tencent.rss.common.metrics.MetricsManager;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+
+import com.tencent.rss.common.metrics.MetricsManager;
 
 public class ShuffleServerMetrics {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleTaskManager.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleTaskManager.java
@@ -18,12 +18,28 @@
 
 package com.tencent.rss.server;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.roaringbitmap.longlong.LongIterator;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleIndexResult;
@@ -37,21 +53,6 @@ import com.tencent.rss.server.buffer.ShuffleBufferManager;
 import com.tencent.rss.storage.factory.ShuffleHandlerFactory;
 import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
-import org.roaringbitmap.longlong.LongIterator;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class ShuffleTaskManager {
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleUploader.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleUploader.java
@@ -18,19 +18,6 @@
 
 package com.tencent.rss.server;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.common.util.concurrent.Uninterruptibles;
-import com.tencent.rss.common.util.ByteUnit;
-import com.tencent.rss.storage.common.DiskItem;
-import com.tencent.rss.storage.common.ShuffleFileInfo;
-import com.tencent.rss.storage.factory.ShuffleUploadHandlerFactory;
-import com.tencent.rss.storage.handler.api.ShuffleUploadHandler;
-import com.tencent.rss.storage.request.CreateShuffleUploadHandlerRequest;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import com.tencent.rss.storage.util.ShuffleUploadResult;
-import com.tencent.rss.storage.util.StorageType;
 import java.io.File;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -40,12 +27,27 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.stream.Collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.ByteUnit;
+import com.tencent.rss.storage.common.DiskItem;
+import com.tencent.rss.storage.common.ShuffleFileInfo;
+import com.tencent.rss.storage.factory.ShuffleUploadHandlerFactory;
+import com.tencent.rss.storage.handler.api.ShuffleUploadHandler;
+import com.tencent.rss.storage.request.CreateShuffleUploadHandlerRequest;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
+import com.tencent.rss.storage.util.ShuffleUploadResult;
+import com.tencent.rss.storage.util.StorageType;
 
 /**
  * ShuffleUploader contains force mode and normal mode, which is decided by the remain

--- a/server/src/main/java/com/tencent/rss/server/buffer/ShuffleBuffer.java
+++ b/server/src/main/java/com/tencent/rss/server/buffer/ShuffleBuffer.java
@@ -18,9 +18,17 @@
 
 package com.tencent.rss.server.buffer;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShufflePartitionedBlock;
@@ -28,13 +36,6 @@ import com.tencent.rss.common.ShufflePartitionedData;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
 import com.tencent.rss.server.ShuffleFlushManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Supplier;
 
 public class ShuffleBuffer {
 

--- a/server/src/main/java/com/tencent/rss/server/buffer/ShuffleBufferManager.java
+++ b/server/src/main/java/com/tencent/rss/server/buffer/ShuffleBufferManager.java
@@ -18,6 +18,14 @@
 
 package com.tencent.rss.server.buffer;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -25,6 +33,9 @@ import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.TreeRangeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShufflePartitionedData;
 import com.tencent.rss.common.util.Constants;
@@ -34,16 +45,6 @@ import com.tencent.rss.server.ShuffleFlushManager;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.server.ShuffleServerMetrics;
 import com.tencent.rss.server.StatusCode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class ShuffleBufferManager {
 

--- a/storage/src/main/java/com/tencent/rss/storage/common/DiskItem.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/DiskItem.java
@@ -18,21 +18,23 @@
 
 package com.tencent.rss.storage.common;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Queues;
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import java.util.Queue;
-import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReadWriteLock;
+
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class DiskItem {
 

--- a/storage/src/main/java/com/tencent/rss/storage/common/DiskMetaData.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/DiskMetaData.java
@@ -18,8 +18,6 @@
 
 package com.tencent.rss.storage.common;
 
-import com.google.common.collect.Maps;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -30,6 +28,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.Maps;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/storage/src/main/java/com/tencent/rss/storage/common/ShuffleFileInfo.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/ShuffleFileInfo.java
@@ -18,13 +18,14 @@
 
 package com.tencent.rss.storage.common;
 
-import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.List;
 
-import com.tencent.rss.common.util.ByteUnit;
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.ByteUnit;
 
 public class ShuffleFileInfo {
 

--- a/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
@@ -18,6 +18,9 @@
 
 package com.tencent.rss.storage.factory;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.factory.ShuffleServerClientFactory;
 import com.tencent.rss.client.util.ClientType;
@@ -40,9 +43,6 @@ import com.tencent.rss.storage.request.CreateShuffleDeleteHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
 import com.tencent.rss.storage.util.StorageType;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class ShuffleHandlerFactory {
 

--- a/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleUploadHandlerFactory.java
+++ b/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleUploadHandlerFactory.java
@@ -18,11 +18,12 @@
 
 package com.tencent.rss.storage.factory;
 
+import java.io.IOException;
+
 import com.tencent.rss.storage.handler.api.ShuffleUploadHandler;
 import com.tencent.rss.storage.handler.impl.HdfsShuffleUploadHandler;
 import com.tencent.rss.storage.request.CreateShuffleUploadHandlerRequest;
 import com.tencent.rss.storage.util.StorageType;
-import java.io.IOException;
 
 public class ShuffleUploadHandlerFactory {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/api/ShuffleUploadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/api/ShuffleUploadHandler.java
@@ -18,9 +18,10 @@
 
 package com.tencent.rss.storage.handler.api;
 
-import com.tencent.rss.storage.util.ShuffleUploadResult;
 import java.io.File;
 import java.util.List;
+
+import com.tencent.rss.storage.util.ShuffleUploadResult;
 
 public interface ShuffleUploadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/api/ShuffleWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/api/ShuffleWriteHandler.java
@@ -18,9 +18,10 @@
 
 package com.tencent.rss.storage.handler.api;
 
-import com.tencent.rss.common.ShufflePartitionedBlock;
 import java.io.IOException;
 import java.util.List;
+
+import com.tencent.rss.common.ShufflePartitionedBlock;
 
 public interface ShuffleWriteHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.common.ShuffleDataResult;
-import com.tencent.rss.storage.handler.api.ClientReadHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.ShuffleDataResult;
+import com.tencent.rss.storage.handler.api.ClientReadHandler;
 
 public class ComposedClientReadHandler implements ClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/DataFileSegment.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/DataFileSegment.java
@@ -18,10 +18,12 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.google.common.collect.Sets;
-import com.tencent.rss.common.BufferSegment;
 import java.util.List;
 import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+import com.tencent.rss.common.BufferSegment;
 
 public class DataFileSegment extends FileSegment {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+
 import com.google.common.collect.Lists;
-import com.tencent.rss.common.ShuffleDataResult;
-import com.tencent.rss.common.util.Constants;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -29,9 +30,9 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.Comparator;
-import java.util.List;
+import com.tencent.rss.common.ShuffleDataResult;
+import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class HdfsClientReadHandler extends AbstractClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsFileReader.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsFileReader.java
@@ -18,10 +18,9 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.storage.api.FileReader;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.io.Closeable;
 import java.io.IOException;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -29,6 +28,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.storage.api.FileReader;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class HdfsFileReader implements FileReader, Closeable {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsFileWriter.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsFileWriter.java
@@ -18,9 +18,6 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.common.util.ChecksumUtils;
-import com.tencent.rss.storage.common.FileBasedShuffleSegment;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.io.Closeable;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -34,6 +31,10 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.ChecksumUtils;
+import com.tencent.rss.storage.common.FileBasedShuffleSegment;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class HdfsFileWriter implements Closeable {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleDeleteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleDeleteHandler.java
@@ -18,13 +18,14 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class HdfsShuffleDeleteHandler implements ShuffleDeleteHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandler.java
@@ -18,18 +18,20 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.io.IOException;
+import java.util.List;
+
 import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleDataSegment;
 import com.tencent.rss.common.ShuffleIndexResult;
 import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import java.io.IOException;
-import java.util.List;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * HdfsShuffleFileReadHandler is a shuffle-specific file read handler, it contains two HdfsFileReader

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleUploadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleUploadHandler.java
@@ -18,22 +18,23 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
-import com.tencent.rss.storage.handler.api.ShuffleUploadHandler;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import com.tencent.rss.storage.util.ShuffleUploadResult;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.storage.handler.api.ShuffleUploadHandler;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
+import com.tencent.rss.storage.util.ShuffleUploadResult;
 
 /**
  *  Handler to upload local files to hdfs, it has two mode combine and not combine,

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleWriteHandler.java
@@ -18,20 +18,22 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.tencent.rss.common.ShufflePartitionedBlock;
-import com.tencent.rss.storage.common.FileBasedShuffleSegment;
-import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.ShufflePartitionedBlock;
+import com.tencent.rss.storage.common.FileBasedShuffleSegment;
+import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class HdfsShuffleWriteHandler implements ShuffleWriteHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileClientReadHandler.java
@@ -18,7 +18,12 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.util.List;
+
 import com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.request.RssGetShuffleDataRequest;
 import com.tencent.rss.client.request.RssGetShuffleIndexRequest;
@@ -28,10 +33,6 @@ import com.tencent.rss.common.ShuffleDataSegment;
 import com.tencent.rss.common.ShuffleIndexResult;
 import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.util.RssUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class LocalFileClientReadHandler extends AbstractClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileDeleteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileDeleteHandler.java
@@ -18,12 +18,14 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.io.File;
+
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class LocalFileDeleteHandler implements ShuffleDeleteHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileReader.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileReader.java
@@ -18,14 +18,16 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.storage.api.FileReader;
 import java.io.Closeable;
 import java.io.DataInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.storage.api.FileReader;
 
 public class LocalFileReader implements FileReader, Closeable {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileServerReadHandler.java
@@ -18,6 +18,12 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.io.File;
+import java.io.FilenameFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleIndexResult;
 import com.tencent.rss.common.config.RssBaseConf;
@@ -25,11 +31,6 @@ import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FilenameFilter;
 
 public class LocalFileServerReadHandler implements ServerReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriteHandler.java
@@ -18,16 +18,18 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LocalFileWriteHandler implements ShuffleWriteHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriter.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileWriter.java
@@ -18,12 +18,13 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import java.io.Closeable;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
+import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 
 public class LocalFileWriter implements Closeable {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/MemoryClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/MemoryClientReadHandler.java
@@ -18,6 +18,11 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.client.api.ShuffleServerClient;
 import com.tencent.rss.client.request.RssGetInMemoryShuffleDataRequest;
 import com.tencent.rss.client.response.RssGetInMemoryShuffleDataResponse;
@@ -25,10 +30,6 @@ import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.util.Constants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.List;
 
 public class MemoryClientReadHandler extends AbstractClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandler.java
@@ -18,16 +18,18 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.common.util.Constants;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.io.IOException;
 import java.util.Comparator;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class MultiStorageHdfsClientReadHandler extends HdfsClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandler.java
@@ -18,13 +18,15 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.tencent.rss.common.ShuffleIndexResult;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.ShuffleIndexResult;
 
 public class MultiStorageHdfsShuffleReadHandler extends HdfsShuffleReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/MultiStorageReadHandler.java
@@ -18,17 +18,18 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import java.io.IOException;
+
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.factory.ShuffleHandlerFactory;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.util.StorageType;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 public class MultiStorageReadHandler extends AbstractClientReadHandler {
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ShuffleIndexHeader.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ShuffleIndexHeader.java
@@ -18,14 +18,15 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import com.google.common.collect.Lists;
-import com.tencent.rss.common.util.ChecksumUtils;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
-
 import java.nio.ByteBuffer;
 import java.util.List;
+
+import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.ChecksumUtils;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public class ShuffleIndexHeader {
 

--- a/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
@@ -18,11 +18,13 @@
 
 package com.tencent.rss.storage.request;
 
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.config.RssBaseConf;
 import java.util.List;
+
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.config.RssBaseConf;
 
 public class CreateShuffleReadHandlerRequest {
 

--- a/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleUploadHandlerRequest.java
+++ b/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleUploadHandlerRequest.java
@@ -18,8 +18,9 @@
 
 package com.tencent.rss.storage.request;
 
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.hadoop.conf.Configuration;
+
+import com.tencent.rss.storage.util.StorageType;
 
 /**
  * CreateShuffleUploadHandlerRequest is used to hold the parameters to create remote storage for shuffle uploader.

--- a/storage/src/main/java/com/tencent/rss/storage/util/ShuffleStorageUtils.java
+++ b/storage/src/main/java/com/tencent/rss/storage/util/ShuffleStorageUtils.java
@@ -18,19 +18,13 @@
 
 package com.tencent.rss.storage.util;
 
-import com.google.common.collect.Lists;
-import com.tencent.rss.common.BufferSegment;
-import com.tencent.rss.common.util.Constants;
-import com.tencent.rss.storage.common.FileBasedShuffleSegment;
-import com.tencent.rss.storage.handler.impl.DataFileSegment;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import com.tencent.rss.storage.handler.impl.HdfsFileWriter;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -39,6 +33,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.hash.MurmurHash;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.BufferSegment;
+import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.common.FileBasedShuffleSegment;
+import com.tencent.rss.storage.handler.impl.DataFileSegment;
+import com.tencent.rss.storage.handler.impl.HdfsFileWriter;
 
 public class ShuffleStorageUtils {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Divide all imports into four groups: java std, 3rd party, firestorm, static
2. All imports in each group are ordered by alphabet 
3. All groups are separated by an empty line

### Why are the changes needed?
Current import order is non-strict.  

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
mvn package -Pspark2 (or -Pspark3)
