### PR TITLE
Shutdown non-daemon executor service to avoid hang when jvm destroy

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -252,6 +252,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       LOG.warn("Ignore the InterruptedException which should be caused by internal killed");
     } catch (Exception e) {
       throw new RuntimeException("Exception happened when get commit status", e);
+    } finally {
+      executor.shutdown();
     }
   }
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -268,6 +268,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       LOG.warn("Ignore the InterruptedException which should be caused by internal killed");
     } catch (Exception e) {
       throw new RuntimeException("Exception happened when get commit status", e);
+    } finally {
+      executor.shutdown();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
shut down non daemon executor service created in sendCommit by RssShuffleWriter

### Why are the changes needed?
non daemon thread will block jvm destroy, which will lead to hang after spark job finished

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
run simple spark job in local mode with RSS, for example:
`./bin/run-example --master local GroupByTest 10 50000 4000`
before this patch, the command will never exist until we interrupt it
after this patch, normal exist after spark job finished