### PR TITLE
Ignore InterruptedException when report shuffle result

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -267,7 +267,8 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
       // if failed when send data to shuffle server, mark task as failed
       if (failedBlockIds.size() > 0) {
         String errorMsg =
-            "Send failed: Task[" + taskId + "] failed because " + failedBlockIds.size()
+            "Send failed: appId[" + appId + "], shuffleId[" + shuffleId + "], taskId[" + taskId
+                + "] failed because " + failedBlockIds.size()
                 + " blocks can't be sent to shuffle server.";
         LOG.error(errorMsg);
         throw new RssException(errorMsg);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -314,7 +314,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         return Option.apply(mapStatus);
       } catch (Exception e) {
         LOG.error("Error when stop task.", e);
-        throw new RuntimeException(e);
+        throw e;
       }
     } else {
       return Option.empty();

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -307,7 +307,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
         return Option.apply(mapStatus);
       } catch (Exception e) {
         LOG.error("Error when stop task.", e);
-        throw new RuntimeException(e);
+        throw e;
       }
     } else {
       return Option.empty();

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -277,6 +277,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
         if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
           LOG.info("Report shuffle result to " + ssi + " for appId[" + appId
               + "], shuffleId[" + shuffleId + "] successfully");
+        } else if (response.getStatusCode() == ResponseStatusCode.INTERRUPTED) {
+          // ignore the interrupted exception
         } else {
           isSuccessful = false;
           LOG.warn("Report shuffle result to " + ssi + " for appId[" + appId
@@ -311,6 +313,9 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           blockIdBitmap = response.getBlockIdBitmap();
           isSuccessful = true;
           break;
+        } else if (response.getStatusCode() == ResponseStatusCode.INTERRUPTED) {
+          // ignore the interrupted exception
+          return Roaring64NavigableMap.bitmapOf();
         }
       } catch (Exception e) {
         LOG.warn("Get shuffle result is failed from " + ssi

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
-import static com.tencent.rss.proto.RssProtos.StatusCode.INTERRUPTED;
 import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +85,8 @@ import com.tencent.rss.proto.RssProtos.ShuffleRegisterResponse;
 import com.tencent.rss.proto.RssProtos.StatusCode;
 import com.tencent.rss.proto.ShuffleServerGrpc;
 import com.tencent.rss.proto.ShuffleServerGrpc.ShuffleServerBlockingStub;
+
+import static com.tencent.rss.proto.RssProtos.StatusCode.INTERRUPTED;
 
 public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServerClient {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/response/ResponseStatusCode.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/ResponseStatusCode.java
@@ -26,5 +26,6 @@ public enum ResponseStatusCode {
   NO_REGISTER,
   NO_PARTITION,
   INTERNAL_ERROR,
-  TIMEOUT
+  TIMEOUT,
+  INTERRUPTED
 }

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -231,6 +231,7 @@ enum StatusCode {
   NO_PARTITION = 5;
   INTERNAL_ERROR = 6;
   TIMEOUT = 7;
+  INTERRUPTED = 8;
   // add more status
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ignore InterruptedException when report shuffle result


### Why are the changes needed?
remove unnecessary warn in spark log


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UT
