### PR TITLE
[Improvement] Remove unnecssary logic to calculate bitmap split number

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -73,8 +73,10 @@ public class RssClientConfig {
   public static String RSS_OZONE_FS_HDFS_IMPL_DEFAULT_VALUE = "org.apache.hadoop.odfs.HdfsOdfsFilesystem";
   public static String RSS_OZONE_FS_ABSTRACT_FILE_SYSTEM_HDFS_IMPL = "spark.rss.ozone.fs.AbstractFileSystem.hdfs.impl";
   public static String RSS_OZONE_FS_ABSTRACT_FILE_SYSTEM_HDFS_IMPL_DEFAULT_VALUE = "org.apache.hadoop.odfs.HdfsOdfs";
-  public static String RSS_CLIENT_BLOCK_NUM_PER_TASK_PARTITION = "spark.rss.block.per.task.partition";
-  public static int RSS_CLIENT_BLOCK_NUM_PER_TASK_PARTITION_DEFAULT_VALUE = 20;
-  public static String RSS_CLIENT_BLOCK_NUM_PER_BITMAP = "spark.rss.block.per.bitmap";
-  public static long RSS_CLIENT_BLOCK_NUM_PER_BITMAP_DEFAULT_VALUE = 100000000;
+  // it is used in shuffle server to decide how many bitmap should be used to store blockId
+  // the target for this is to improve shuffle server's performance of report/get shuffle result
+  // currently, all blockIds are stored in multiple shuffle servers, update this config if there
+  // has huge amount blockIds, eg, 10B.
+  public static String RSS_CLIENT_BITMAP_SPLIT_NUM = "spark.rss.client.bitmap.splitNum";
+  public static int RSS_CLIENT_BITMAP_SPLIT_NUM_DEFAULT_VALUE = 1;
 }

--- a/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
+++ b/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
@@ -18,12 +18,13 @@
 
 package com.tencent.rss.client;
 
+import org.junit.Test;
+
+import com.tencent.rss.client.util.ClientUtils;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import com.tencent.rss.client.util.ClientUtils;
-import org.junit.Test;
 
 public class ClientUtilsTest {
 
@@ -57,31 +58,6 @@ public class ClientUtilsTest {
       fail(EXCEPTION_EXPECTED);
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Can't support sequence[524288], the max value should be 524287"));
-    }
-  }
-
-  @Test
-  public void getBitmapNumTest() {
-    // max value of taskNum, partitionNum, blockNumPerTaskPerPartition, it is unexpected in real job
-    assertEquals(
-        2147483647, ClientUtils.getBitmapNum(Integer.MAX_VALUE, Integer.MAX_VALUE, 1000000, 100000000L));
-    // taskNum * partitionNum * blockNumPerTaskPerPartition / blockNumPerBitmap > 0
-    assertEquals(
-        5001, ClientUtils.getBitmapNum(100000, 100000, 50, 100000000L));
-    // taskNum * partitionNum * blockNumPerTaskPerPartition / blockNumPerBitmap = 0
-    assertEquals(
-        1, ClientUtils.getBitmapNum(1999, 1999, 50, 100000000L));
-    try {
-      ClientUtils.getBitmapNum(1, 1, 1, 19999999L);
-      fail(EXCEPTION_EXPECTED);
-    } catch (Exception e) {
-      assertTrue(e.getMessage().contains("blockNumPerBitmap should be greater than"));
-    }
-    try {
-      ClientUtils.getBitmapNum(1, 1, 1000001, 20000000L);
-      fail(EXCEPTION_EXPECTED);
-    } catch (Exception e) {
-      assertTrue(e.getMessage().contains("blockNumPerTaskPerPartition should be less than"));
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, bitmap for saving blockIds exists in multiple shuffle server. The logic to calculate bitmap split number is not necessary any more, remove it to simplify the workflow.


### Why are the changes needed?
Simplify the workflow


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
exist UTs
