### PR TITLE
[Build] Only upload logs when test cases are failed

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,6 +45,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark2
+        if: failure()
         path: "**/target/surefire-reports/*.txt"
     - name: Build with Maven with Profile spark3
       run: mvn -B package --file pom.xml -Pspark3
@@ -52,4 +53,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark3
+        if: failure()
         path: "**/target/surefire-reports/*.txt"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Build with Maven with Profile spark2
       run: mvn -B package --file pom.xml -Pspark2
     - name: Upload spark2 test results to report
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark2
@@ -50,7 +50,7 @@ jobs:
     - name: Build with Maven with Profile spark3
       run: mvn -B package --file pom.xml -Pspark3
     - name: Upload spark3 test results to report
-      if: always()
+      if: failure()
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark3

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,16 +42,16 @@ jobs:
     - name: Build with Maven with Profile spark2
       run: mvn -B package --file pom.xml -Pspark2
     - name: Upload spark2 test results to report
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark2
-        if: always()
         path: "**/target/surefire-reports/*.txt"
     - name: Build with Maven with Profile spark3
       run: mvn -B package --file pom.xml -Pspark3
     - name: Upload spark3 test results to report
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark3
-        if: always()
         path: "**/target/surefire-reports/*.txt"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark2
-        if: failure()
+        if: always()
         path: "**/target/surefire-reports/*.txt"
     - name: Build with Maven with Profile spark3
       run: mvn -B package --file pom.xml -Pspark3
@@ -53,5 +53,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: test-results-of-rss-spark3
-        if: failure()
+        if: always()
         path: "**/target/surefire-reports/*.txt"

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
@@ -58,7 +58,7 @@ public class RssShuffleUtilsTest {
     conf.set(RssClientConfig.RSS_OZONE_FS_ABSTRACT_FILE_SYSTEM_HDFS_IMPL, "expect_odfs_abstract_impl");
     conf1 = RssShuffleUtils.newHadoopConfiguration(conf);
     assertEquals("expect_odfs_impl", conf1.get("fs.hdfs.impl"));
-    assertEquals("expect_odfs_abstract_impl", conf1.get("fs.AbstractFileSystem.hdfs.implxxxx"));
+    assertEquals("expect_odfs_abstract_impl", conf1.get("fs.AbstractFileSystem.hdfs.impl"));
   }
 
   private void singleTest(int size) {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
@@ -58,7 +58,7 @@ public class RssShuffleUtilsTest {
     conf.set(RssClientConfig.RSS_OZONE_FS_ABSTRACT_FILE_SYSTEM_HDFS_IMPL, "expect_odfs_abstract_impl");
     conf1 = RssShuffleUtils.newHadoopConfiguration(conf);
     assertEquals("expect_odfs_impl", conf1.get("fs.hdfs.impl"));
-    assertEquals("expect_odfs_abstract_impl", conf1.get("fs.AbstractFileSystem.hdfs.impl"));
+    assertEquals("expect_odfs_abstract_impl", conf1.get("fs.AbstractFileSystem.hdfs.implxxxx"));
   }
 
   private void singleTest(int size) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update CI workflow to upload logs after failures.

### Why are the changes needed?
CI does not upload logs after failures.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add error cases in UT. 
