### PR TITLE
[Improvement] Reduce memory cost in spark executor

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -119,7 +119,7 @@ public class RssShuffleUtils {
   public static ByteBuffer decompressData(ByteBuffer data, int uncompressLength) {
     LZ4FastDecompressor fastDecompressor = LZ4Factory.fastestInstance().fastDecompressor();
     ByteBuffer uncompressData = ByteBuffer.allocateDirect(uncompressLength);
-    fastDecompressor.decompress(data, 0, uncompressData, 0, uncompressLength);
+    fastDecompressor.decompress(data, data.position(), uncompressData, 0, uncompressLength);
     return uncompressData;
   }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/reader/RssShuffleDataIterator.java
@@ -106,7 +106,7 @@ public class RssShuffleDataIterator<K, C> extends AbstractIterator<Product2<K, C
       long fetchDuration = System.currentTimeMillis() - startFetch;
       shuffleReadMetrics.incFetchWaitTime(fetchDuration);
       if (compressedData != null) {
-        shuffleReadMetrics.incRemoteBytesRead(compressedData.capacity());
+        shuffleReadMetrics.incRemoteBytesRead(compressedData.limit() - compressedData.position());
         long startDecompress = System.currentTimeMillis();
         ByteBuffer uncompressedData = RssShuffleUtils.decompressData(
             compressedData, compressedBlock.getUncompressLength());

--- a/client/src/test/java/com/tencent/rss/client/TestUtils.java
+++ b/client/src/test/java/com/tencent/rss/client/TestUtils.java
@@ -18,11 +18,11 @@
 
 package com.tencent.rss.client;
 
-import com.tencent.rss.client.api.ShuffleReadClient;
-import com.tencent.rss.client.response.CompressedShuffleBlock;
-
 import java.nio.ByteBuffer;
 import java.util.Map;
+
+import com.tencent.rss.client.api.ShuffleReadClient;
+import com.tencent.rss.client.response.CompressedShuffleBlock;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -57,8 +57,9 @@ public class TestUtils {
   }
 
   public static boolean compareByte(byte[] expected, ByteBuffer buffer) {
+    int start = buffer.position();
     for (int i = 0; i < expected.length; i++) {
-      if (expected[i] != buffer.get(i)) {
+      if (expected[i] != buffer.get(start + i)) {
         return false;
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To reduce memory cost in Spark executor, the following improvements are included:
1. when shuffle read, don't copy byte[] for every block
2. when shuffle write, metadata should be cleared

### Why are the changes needed?
To reduce memory and get better performance


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Update exist UT
