### PR TITLE
Fix log4j-core dependabot, upgrade to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <java.version>1.8</java.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <junit.version>4.13.1</junit.version>
-    <log4j.core.version>2.17.0</log4j.core.version>
+    <log4j.core.version>2.17.1</log4j.core.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <metrics.version>3.1.0</metrics.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade log4j from 2.17.0 to 2.17.1

### Why are the changes needed?
log4j is unsafe again due to CVE-2021-44832.

Apache Log4j2 versions 2.0-beta7 through 2.17.0 (excluding security fix releases 2.3.2 and 2.12.4) are vulnerable to an attack where an attacker with permission to modify the logging configuration file can construct a malicious configuration using a JDBC Appender with a data source referencing a JNDI URI which can execute remote code. This issue is fixed by limiting JNDI data source names to the java protocol in Log4j2 versions 2.17.1, 2.12.4, and 2.3.2.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Run CI.
