### PR TITLE
[Follow Up] Support to skip unexpected and processed segments in HDFS

### DIFF
--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
@@ -199,7 +199,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
         "appId", 0, 1, 100, 2, 10, 1000,
         basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
     // index file is deleted after iterator initialization, it should be ok, all index infos are read already
-    Path indexFile = new Path(basePath + "/appId/0/0-1/test.index");
+    Path indexFile = new Path(basePath + "/appId/0/0-1/test_0.index");
     fs.delete(indexFile, true);
     readClient.close();
 

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -1,0 +1,235 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+
+import com.tencent.rss.client.impl.grpc.ShuffleServerGrpcClient;
+import com.tencent.rss.client.request.RssRegisterShuffleRequest;
+import com.tencent.rss.client.request.RssSendShuffleDataRequest;
+import com.tencent.rss.common.BufferSegment;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleDataResult;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.server.buffer.ShuffleBuffer;
+import com.tencent.rss.storage.handler.api.ClientReadHandler;
+import com.tencent.rss.storage.handler.impl.ComposedClientReadHandler;
+import com.tencent.rss.storage.handler.impl.HdfsClientReadHandler;
+import com.tencent.rss.storage.handler.impl.LocalFileQuorumClientReadHandler;
+import com.tencent.rss.storage.handler.impl.MemoryQuorumClientReadHandler;
+import com.tencent.rss.storage.util.StorageType;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
+
+  private ShuffleServerGrpcClient shuffleServerClient;
+
+  @BeforeClass
+  public static void setupServers() throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    File dataDir = new File(tmpDir, "data");
+    String basePath = dataDir.getAbsolutePath();
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE_HDFS.name());
+    shuffleServerConf.set(ShuffleServerConf.HDFS_BASE_PATH, HDFS_URI + "rss/test");
+    shuffleServerConf.setLong(ShuffleServerConf.FLUSH_COLD_STORAGE_THRESHOLD_SIZE, 450L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 5000L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE, 20.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_MEMORY_SHUFFLE_HIGHWATERMARK_PERCENTAGE, 40.0);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_BUFFER_CAPACITY, 500L);
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
+  @Before
+  public void createClient() {
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  }
+
+  @After
+  public void closeClient() {
+    shuffleServerClient.close();
+  }
+
+  @Test
+  public void memoryLocalFileHDFSReadWithFilterTest() throws Exception {
+    String testAppId = "memoryLocalFileHDFSReadWithFilterTest";
+    int shuffleId = 0;
+    int partitionId = 0;
+    RssRegisterShuffleRequest rrsr = new RssRegisterShuffleRequest(testAppId, 0,
+      Lists.newArrayList(new PartitionRange(0, 0)));
+    shuffleServerClient.registerShuffle(rrsr);
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
+    Map<Long, byte[]> dataMap = Maps.newHashMap();
+    Roaring64NavigableMap[] bitmaps = new Roaring64NavigableMap[1];
+    bitmaps[0] = Roaring64NavigableMap.bitmapOf();
+    List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+      shuffleId, partitionId, 0, 3, 25,
+      expectBlockIds, dataMap, mockSSI);
+    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(partitionId, blocks);
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(shuffleId, partitionToBlocks);
+
+    // send data to shuffle server's memory
+    RssSendShuffleDataRequest rssdr = new RssSendShuffleDataRequest(
+      testAppId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rssdr);
+
+    // read the 1-th segment from memory
+    MemoryQuorumClientReadHandler memoryQuorumClientReadHandler = new MemoryQuorumClientReadHandler(
+      testAppId, shuffleId, partitionId, 150, Lists.newArrayList(shuffleServerClient));
+    LocalFileQuorumClientReadHandler localFileQuorumClientReadHandler = new LocalFileQuorumClientReadHandler(
+      testAppId, shuffleId, partitionId, 0, 1, 3,
+      75, expectBlockIds, processBlockIds, Lists.newArrayList(shuffleServerClient));
+    HdfsClientReadHandler hdfsClientReadHandler = new HdfsClientReadHandler(
+      testAppId, shuffleId, partitionId, 0, 1, 3,
+      500, expectBlockIds, processBlockIds, HDFS_URI + "rss/test", conf);
+    ClientReadHandler[] handlers = new ClientReadHandler[3];
+    handlers[0] = memoryQuorumClientReadHandler;
+    handlers[1] = localFileQuorumClientReadHandler;
+    handlers[2] = hdfsClientReadHandler;
+    ComposedClientReadHandler composedClientReadHandler = new ComposedClientReadHandler(handlers);
+    ShuffleDataResult sdr  = composedClientReadHandler.readShuffleData();
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    expectedData.clear();
+    expectedData.put(blocks.get(0).getBlockId(), blocks.get(0).getData());
+    expectedData.put(blocks.get(1).getBlockId(), blocks.get(1).getData());
+    expectedData.put(blocks.get(2).getBlockId(), blocks.get(1).getData());
+    validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks.get(0).getBlockId());
+    processBlockIds.addLong(blocks.get(1).getBlockId());
+    processBlockIds.addLong(blocks.get(2).getBlockId());
+
+    // send data to shuffle server, and wait until flush to LocalFile
+    List<ShuffleBlockInfo> blocks2 = createShuffleBlockList(
+      shuffleId, partitionId, 0, 3, 50,
+      expectBlockIds, dataMap, mockSSI);
+    partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(partitionId, blocks2);
+    shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(shuffleId, partitionToBlocks);
+    rssdr = new RssSendShuffleDataRequest(
+      testAppId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rssdr);
+    waitFlush(testAppId, shuffleId);
+
+    // read the 2-th segment from localFile
+    // notice: the 1-th segment is skipped, because it is processed
+    sdr  = composedClientReadHandler.readShuffleData();
+    expectedData.clear();
+    expectedData.put(blocks2.get(0).getBlockId(), blocks2.get(0).getData());
+    expectedData.put(blocks2.get(1).getBlockId(), blocks2.get(1).getData());
+    validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks2.get(0).getBlockId());
+    processBlockIds.addLong(blocks2.get(1).getBlockId());
+
+    // read the 3-th segment from localFile
+    sdr  = composedClientReadHandler.readShuffleData();
+    expectedData.clear();
+    expectedData.put(blocks2.get(2).getBlockId(), blocks2.get(2).getData());
+    validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks2.get(2).getBlockId());
+
+    // send data to shuffle server, and wait until flush to HDFS
+    List<ShuffleBlockInfo> blocks3 = createShuffleBlockList(
+      shuffleId, partitionId, 0, 2, 200,
+      expectBlockIds, dataMap, mockSSI);
+    partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(partitionId, blocks3);
+    shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(shuffleId, partitionToBlocks);
+    rssdr = new RssSendShuffleDataRequest(
+      testAppId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rssdr);
+    waitFlush(testAppId, shuffleId);
+
+    // read the 4-th segment from HDFS
+    sdr  = composedClientReadHandler.readShuffleData();
+    expectedData.clear();
+    expectedData.put(blocks3.get(0).getBlockId(), blocks3.get(0).getData());
+    expectedData.put(blocks3.get(1).getBlockId(), blocks3.get(1).getData());
+    validateResult(expectedData, sdr);
+    processBlockIds.addLong(blocks3.get(0).getBlockId());
+    processBlockIds.addLong(blocks3.get(1).getBlockId());
+
+    // all segments are processed
+    sdr  = composedClientReadHandler.readShuffleData();
+    assertNull(sdr);
+  }
+
+  protected void waitFlush(String appId, int shuffleId) throws InterruptedException {
+    int retry = 0;
+    while (true) {
+      if (retry > 5) {
+        fail("Timeout for flush data");
+      }
+      ShuffleBuffer shuffleBuffer = shuffleServers.get(0).getShuffleBufferManager()
+        .getShuffleBuffer(appId, shuffleId, 0);
+      if (shuffleBuffer.getBlocks().size() == 0 && shuffleBuffer.getInFlushBlockMap().size() == 0) {
+        break;
+      }
+      Thread.sleep(1000);
+      retry++;
+    }
+  }
+
+  protected void validateResult(
+    Map<Long, byte[]> expectedData,
+    ShuffleDataResult sdr) {
+    byte[] buffer = sdr.getData();
+    List<BufferSegment> bufferSegments = sdr.getBufferSegments();
+    assertEquals(expectedData.size(), bufferSegments.size());
+    for (Map.Entry<Long, byte[]> entry : expectedData.entrySet()) {
+      BufferSegment bs = findBufferSegment(entry.getKey(), bufferSegments);
+      assertNotNull(bs);
+      byte[] data = new byte[bs.getLength()];
+      System.arraycopy(buffer, bs.getOffset(), data, 0, bs.getLength());
+    }
+  }
+
+  private BufferSegment findBufferSegment(long blockId, List<BufferSegment> bufferSegments) {
+    for (BufferSegment bs : bufferSegments) {
+      if (bs.getBlockId() == blockId) {
+        return bs;
+      }
+    }
+    return null;
+  }
+}

--- a/server/src/test/java/com/tencent/rss/server/ShuffleFlushManagerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleFlushManagerTest.java
@@ -276,10 +276,11 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
 
   private void validate(String appId, int shuffleId, int partitionId, List<ShufflePartitionedBlock> blocks,
       int partitionNumPerRange, String basePath) {
-    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
     Set<Long> remainIds = Sets.newHashSet();
     for (ShufflePartitionedBlock spb : blocks) {
-      blockIdBitmap.addLong(spb.getBlockId());
+      expectBlockIds.addLong(spb.getBlockId());
       remainIds.add(spb.getBlockId());
     }
     HdfsClientReadHandler handler = new HdfsClientReadHandler(
@@ -290,6 +291,8 @@ public class ShuffleFlushManagerTest extends HdfsTestBase {
         partitionNumPerRange,
         10,
         blocks.size() * 32,
+        expectBlockIds,
+        processBlockIds,
         basePath,
         new Configuration());
     ShuffleDataResult sdr = null;

--- a/server/src/test/java/com/tencent/rss/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleTaskManagerTest.java
@@ -344,14 +344,15 @@ public class ShuffleTaskManagerTest extends HdfsTestBase {
 
   private void validate(String appId, int shuffleId, int partitionId, List<ShufflePartitionedBlock> blocks,
       String basePath) {
-    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
     Set<Long> remainIds = Sets.newHashSet();
     for (ShufflePartitionedBlock spb : blocks) {
-      blockIdBitmap.addLong(spb.getBlockId());
+      expectBlockIds.addLong(spb.getBlockId());
       remainIds.add(spb.getBlockId());
     }
     HdfsClientReadHandler handler = new HdfsClientReadHandler(appId, shuffleId, partitionId,
-        100, 1, 10, 1000, basePath, new Configuration());
+        100, 1, 10, 1000, expectBlockIds, processBlockIds, basePath, new Configuration());
 
     ShuffleDataResult sdr = handler.readShuffleData();
     List<BufferSegment> bufferSegments = sdr.getBufferSegments();

--- a/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
@@ -64,6 +64,8 @@ public class ShuffleHandlerFactory {
           request.getPartitionNumPerRange(),
           request.getPartitionNum(),
           request.getReadBufferSize(),
+          request.getExpectBlockIds(),
+          request.getProcessBlockIds(),
           request.getStorageBasePath(),
           request.getHadoopConf());
     } else if (StorageType.LOCALFILE.name().equals(request.getStorageType())) {
@@ -102,6 +104,8 @@ public class ShuffleHandlerFactory {
             request.getPartitionNumPerRange(),
             request.getPartitionNum(),
             request.getReadBufferSize(),
+            request.getExpectBlockIds(),
+            request.getProcessBlockIds(),
             request.getStorageBasePath(),
             request.getHadoopConf());
       });
@@ -133,6 +137,8 @@ public class ShuffleHandlerFactory {
             request.getPartitionNumPerRange(),
             request.getPartitionNum(),
             request.getReadBufferSize(),
+            request.getExpectBlockIds(),
+            request.getProcessBlockIds(),
             request.getStorageBasePath(),
             request.getHadoopConf());
       }, () -> {
@@ -144,6 +150,8 @@ public class ShuffleHandlerFactory {
             request.getPartitionNumPerRange(),
             request.getPartitionNum(),
             request.getReadBufferSize(),
+            request.getExpectBlockIds(),
+            request.getProcessBlockIds(),
             request.getStorageBasePath(),
             request.getHadoopConf());
       });
@@ -187,6 +195,8 @@ public class ShuffleHandlerFactory {
             request.getPartitionNumPerRange(),
             request.getPartitionNum(),
             request.getReadBufferSize(),
+            request.getExpectBlockIds(),
+            request.getProcessBlockIds(),
             request.getStorageBasePath(),
             request.getHadoopConf());
       });
@@ -218,6 +228,8 @@ public class ShuffleHandlerFactory {
             request.getPartitionNumPerRange(),
             request.getPartitionNum(),
             request.getReadBufferSize(),
+            request.getExpectBlockIds(),
+            request.getProcessBlockIds(),
             request.getStorageBasePath(),
             request.getHadoopConf());
       });

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
@@ -44,35 +44,36 @@ public class ComposedClientReadHandler implements ClientReadHandler {
   private static final int COLD = 3;
   private static final int FROZEN = 4;
   private int currentHandler = HOT;
+  private final int upmostLevelOfHandler;
 
   public ComposedClientReadHandler(ClientReadHandler... handlers) {
-    int size = handlers.length;
-    if (size > 0) {
+    upmostLevelOfHandler = handlers.length;
+    if (upmostLevelOfHandler > 0) {
       this.hotDataReadHandler = handlers[0];
     }
-    if (size > 1) {
+    if (upmostLevelOfHandler > 1) {
       this.warmDataReadHandler = handlers[1];
     }
-    if (size > 2) {
+    if (upmostLevelOfHandler > 2) {
       this.coldDataReadHandler = handlers[2];
     }
-    if (size > 3) {
+    if (upmostLevelOfHandler > 3) {
       this.frozenDataReadHandler = handlers[3];
     }
   }
 
   public ComposedClientReadHandler(Callable<ClientReadHandler>... creators) {
-    int size = creators.length;
-    if (size > 0) {
+    upmostLevelOfHandler = creators.length;
+    if (upmostLevelOfHandler > 0) {
       this.hotHandlerCreator = creators[0];
     }
-    if (size > 1) {
+    if (upmostLevelOfHandler > 1) {
       this.warmHandlerCreator = creators[1];
     }
-    if (size > 2) {
+    if (upmostLevelOfHandler > 2) {
       this.coldHandlerCreator = creators[2];
     }
-    if (size > 3) {
+    if (upmostLevelOfHandler > 3) {
       this.frozenHandlerCreator = creators[3];
     }
   }
@@ -112,9 +113,14 @@ public class ComposedClientReadHandler implements ClientReadHandler {
     } catch (Exception e) {
       LOG.error("Failed to read shuffle data from " + getCurrentHandlerName() + " handler", e);
     }
-    // there is no data for current handler, try next one if there has
+    // when is no data for current handler, and the upmostLevel is not reached,
+    // then try next one if there has
     if (shuffleDataResult == null || shuffleDataResult.isEmpty()) {
-      currentHandler++;
+      if (currentHandler < upmostLevelOfHandler) {
+        currentHandler++;
+      } else {
+        return null;
+      }
       return readShuffleData();
     }
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
@@ -44,36 +44,36 @@ public class ComposedClientReadHandler implements ClientReadHandler {
   private static final int COLD = 3;
   private static final int FROZEN = 4;
   private int currentHandler = HOT;
-  private final int upmostLevelOfHandler;
+  private final int topLevelOfHandler;
 
   public ComposedClientReadHandler(ClientReadHandler... handlers) {
-    upmostLevelOfHandler = handlers.length;
-    if (upmostLevelOfHandler > 0) {
+    topLevelOfHandler = handlers.length;
+    if (topLevelOfHandler > 0) {
       this.hotDataReadHandler = handlers[0];
     }
-    if (upmostLevelOfHandler > 1) {
+    if (topLevelOfHandler > 1) {
       this.warmDataReadHandler = handlers[1];
     }
-    if (upmostLevelOfHandler > 2) {
+    if (topLevelOfHandler > 2) {
       this.coldDataReadHandler = handlers[2];
     }
-    if (upmostLevelOfHandler > 3) {
+    if (topLevelOfHandler > 3) {
       this.frozenDataReadHandler = handlers[3];
     }
   }
 
   public ComposedClientReadHandler(Callable<ClientReadHandler>... creators) {
-    upmostLevelOfHandler = creators.length;
-    if (upmostLevelOfHandler > 0) {
+    topLevelOfHandler = creators.length;
+    if (topLevelOfHandler > 0) {
       this.hotHandlerCreator = creators[0];
     }
-    if (upmostLevelOfHandler > 1) {
+    if (topLevelOfHandler > 1) {
       this.warmHandlerCreator = creators[1];
     }
-    if (upmostLevelOfHandler > 2) {
+    if (topLevelOfHandler > 2) {
       this.coldHandlerCreator = creators[2];
     }
-    if (upmostLevelOfHandler > 3) {
+    if (topLevelOfHandler > 3) {
       this.frozenHandlerCreator = creators[3];
     }
   }
@@ -116,7 +116,7 @@ public class ComposedClientReadHandler implements ClientReadHandler {
     // when is no data for current handler, and the upmostLevel is not reached,
     // then try next one if there has
     if (shuffleDataResult == null || shuffleDataResult.isEmpty()) {
-      if (currentHandler < upmostLevelOfHandler) {
+      if (currentHandler < topLevelOfHandler) {
         currentHandler++;
       } else {
         return null;

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -72,10 +72,6 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
     this.storageBasePath = storageBasePath;
     this.hadoopConf = hadoopConf;
     this.readHandlerIndex = 0;
-    String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
-        ShuffleStorageUtils.getShuffleDataPathWithRange(appId,
-            shuffleId, partitionId, partitionNumPerRange, partitionNum));
-    init(fullShufflePath);
   }
 
   protected void init(String fullShufflePath) {
@@ -119,6 +115,14 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
 
   @Override
   public ShuffleDataResult readShuffleData() {
+    // init lazily like LocalFileClientRead
+    if (readHandlers.size() == 0) {
+      String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
+        ShuffleStorageUtils.getShuffleDataPathWithRange(appId,
+          shuffleId, partitionId, partitionNumPerRange, partitionNum));
+      init(fullShufflePath);
+    }
+
     if (readHandlerIndex >= readHandlers.size()) {
       return new ShuffleDataResult();
     }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   protected final int partitionNumPerRange;
   protected final int partitionNum;
   protected final int readBufferSize;
+  protected Roaring64NavigableMap expectBlockIds;
+  protected Roaring64NavigableMap processBlockIds;
   protected final String storageBasePath;
   protected final Configuration hadoopConf;
   protected final List<HdfsShuffleReadHandler> readHandlers = Lists.newArrayList();
@@ -54,6 +57,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
       int partitionNumPerRange,
       int partitionNum,
       int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
       String storageBasePath,
       Configuration hadoopConf) {
     this.appId = appId;
@@ -62,6 +67,8 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
     this.partitionNumPerRange = partitionNumPerRange;
     this.partitionNum = partitionNum;
     this.readBufferSize = readBufferSize;
+    this.expectBlockIds = expectBlockIds;
+    this.processBlockIds = processBlockIds;
     this.storageBasePath = storageBasePath;
     this.hadoopConf = hadoopConf;
     this.readHandlerIndex = 0;
@@ -98,7 +105,9 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
             + partitionId + "] " + status.getPath());
         String filePrefix = getFileNamePrefix(status.getPath().toUri().toString());
         try {
-          HdfsShuffleReadHandler handler = new HdfsShuffleReadHandler(filePrefix, readBufferSize, hadoopConf);
+          HdfsShuffleReadHandler handler = new HdfsShuffleReadHandler(
+              appId, shuffleId, partitionId, filePrefix,
+              readBufferSize, expectBlockIds, processBlockIds, hadoopConf);
           readHandlers.add(handler);
         } catch (Exception e) {
           LOG.warn("Can't create ShuffleReaderHandler for " + filePrefix, e);

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -116,7 +116,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   @Override
   public ShuffleDataResult readShuffleData() {
     // init lazily like LocalFileClientRead
-    if (readHandlers.size() == 0) {
+    if (readHandlers.isEmpty()) {
       String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
         ShuffleStorageUtils.getShuffleDataPathWithRange(appId,
           shuffleId, partitionId, partitionNumPerRange, partitionNum));

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandler.java
@@ -21,59 +21,58 @@ package com.tencent.rss.storage.handler.impl;
 import java.io.IOException;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleDataSegment;
 import com.tencent.rss.common.ShuffleIndexResult;
-import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 /**
  * HdfsShuffleFileReadHandler is a shuffle-specific file read handler, it contains two HdfsFileReader
  * instances created by using the index file and its indexed data file.
  */
-public class HdfsShuffleReadHandler {
+public class HdfsShuffleReadHandler extends DataSkippableReadHandler {
   private static final Logger LOG = LoggerFactory.getLogger(HdfsShuffleReadHandler.class);
 
   protected final String filePrefix;
   protected final HdfsFileReader indexReader;
   protected final HdfsFileReader dataReader;
-  protected final int readBufferSize;
-
-  protected final List<ShuffleDataSegment> shuffleDataSegments = Lists.newArrayList();
-  protected int segmentIndex;
 
   public HdfsShuffleReadHandler(
+      String appId,
+      int shuffleId,
+      int partitionId,
       String filePrefix,
       int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
       Configuration conf) throws IOException {
+    super(appId, shuffleId, partitionId, readBufferSize, expectBlockIds, processBlockIds);
     this.filePrefix = filePrefix;
-    this.readBufferSize = readBufferSize;
     this.indexReader = createHdfsReader(ShuffleStorageUtils.generateIndexFileName(filePrefix), conf);
     this.dataReader = createHdfsReader(ShuffleStorageUtils.generateDataFileName(filePrefix), conf);
   }
 
-  public ShuffleDataResult readShuffleData() {
-    if (shuffleDataSegments.isEmpty()) {
-      ShuffleIndexResult shuffleIndexResult = readShuffleIndex();
-      if (shuffleIndexResult == null || shuffleIndexResult.isEmpty()) {
-        return null;
-      }
-
-      List<ShuffleDataSegment> cur = RssUtils.transIndexDataToSegments(shuffleIndexResult, readBufferSize);
-      shuffleDataSegments.addAll(cur);
+  @Override
+  protected ShuffleIndexResult readShuffleIndex() {
+    long start = System.currentTimeMillis();
+    try {
+      byte[] indexData = indexReader.read();
+      LOG.info("Read index files {}.index for {} ms", filePrefix, System.currentTimeMillis() - start);
+      return new ShuffleIndexResult(indexData);
+    } catch (Exception e) {
+      LOG.info("Fail to read index files {}.index", filePrefix);
     }
+    return new ShuffleIndexResult();
+  }
 
-    if (segmentIndex >= shuffleDataSegments.size()) {
-      return null;
-    }
-    ShuffleDataSegment shuffleDataSegment = shuffleDataSegments.get(segmentIndex++);
-
+  @Override
+  protected ShuffleDataResult readShuffleData(ShuffleDataSegment shuffleDataSegment) {
     // Here we make an assumption that the rest of the file is corrupted, if an unexpected data is read.
     int expectedLength = shuffleDataSegment.getLength();
     if (expectedLength <= 0) {
@@ -84,14 +83,14 @@ public class HdfsShuffleReadHandler {
     byte[] data = readShuffleData(shuffleDataSegment.getOffset(), expectedLength);
     if (data.length == 0) {
       LOG.warn("Fail to read expected[{}] data, actual[{}] and segment is {} from file {}.data",
-          expectedLength, data.length, shuffleDataSegment, filePrefix);
+        expectedLength, data.length, shuffleDataSegment, filePrefix);
       return null;
     }
 
     ShuffleDataResult shuffleDataResult = new ShuffleDataResult(data, shuffleDataSegment.getBufferSegments());
     if (shuffleDataResult.isEmpty()) {
       LOG.warn("Shuffle data is empty, expected length {}, data length {}, segment {} in file {}.data",
-          expectedLength, data.length, shuffleDataSegment, filePrefix);
+        expectedLength, data.length, shuffleDataSegment, filePrefix);
       return null;
     }
 
@@ -106,18 +105,6 @@ public class HdfsShuffleReadHandler {
       return new byte[0];
     }
     return data;
-  }
-
-  protected ShuffleIndexResult readShuffleIndex() {
-    long start = System.currentTimeMillis();
-    try {
-      byte[] indexData = indexReader.read();
-      LOG.info("Read index files {}.index for {} ms", filePrefix, System.currentTimeMillis() - start);
-      return new ShuffleIndexResult(indexData);
-    } catch (Exception e) {
-      LOG.info("Fail to read index files {}.index", filePrefix);
-    }
-    return new ShuffleIndexResult();
   }
 
   public synchronized void close() {

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +44,8 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
       int partitionNumPerRange,
       int partitionNum,
       int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
       String storageBasePath,
       Configuration hadoopConf) {
     super(appId,
@@ -52,6 +55,8 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
         partitionNumPerRange,
         partitionNum,
         readBufferSize,
+        expectBlockIds,
+        processBlockIds,
         storageBasePath,
         hadoopConf);
     String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
@@ -90,7 +95,8 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
         String fileNamePrefix = getFileNamePrefix(status.getPath().toUri().toString());
         try {
           HdfsShuffleReadHandler handler = new UploadedStorageHdfsShuffleReadHandler(
-              partitionId, fileNamePrefix, readBufferSize, hadoopConf);
+              appId, shuffleId, partitionId, fileNamePrefix, readBufferSize,
+              expectBlockIds, processBlockIds, hadoopConf);
           readHandlers.add(handler);
         } catch (Exception e) {
           LOG.warn("Can't create ShuffleReaderHandler for " + fileNamePrefix, e);

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
@@ -29,6 +29,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
@@ -59,13 +60,7 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
         processBlockIds,
         storageBasePath,
         hadoopConf);
-    String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
-        ShuffleStorageUtils.getUploadShuffleDataPath(appId, shuffleId, partitionId));
-    init(fullShufflePath);
-    String combinePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
-        ShuffleStorageUtils.getCombineDataPath(appId, shuffleId));
-    init(combinePath);
-  }
+    }
 
   @Override
   protected void init(String fullShufflePath) {
@@ -104,5 +99,19 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
       }
       readHandlers.sort(Comparator.comparing(HdfsShuffleReadHandler::getFilePrefix));
     }
+  }
+
+  @Override
+  public ShuffleDataResult readShuffleData() {
+    // init lazily like LocalFileClientRead
+    if (readHandlers.size() == 0) {
+      String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
+        ShuffleStorageUtils.getUploadShuffleDataPath(appId, shuffleId, partitionId));
+      init(fullShufflePath);
+      String combinePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
+        ShuffleStorageUtils.getCombineDataPath(appId, shuffleId));
+      init(combinePath);
+    }
+    return super.readShuffleData();
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedHdfsClientReadHandler.java
@@ -104,7 +104,7 @@ public class UploadedHdfsClientReadHandler extends HdfsClientReadHandler {
   @Override
   public ShuffleDataResult readShuffleData() {
     // init lazily like LocalFileClientRead
-    if (readHandlers.size() == 0) {
+    if (readHandlers.isEmpty()) {
       String fullShufflePath = ShuffleStorageUtils.getFullShuffleDataFolder(storageBasePath,
         ShuffleStorageUtils.getUploadShuffleDataPath(appId, shuffleId, partitionId));
       init(fullShufflePath);

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedStorageHdfsShuffleReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedStorageHdfsShuffleReadHandler.java
@@ -49,6 +49,7 @@ public class UploadedStorageHdfsShuffleReadHandler extends HdfsShuffleReadHandle
     this.partitionId = partitionId;
   }
 
+  @Override
   protected byte[] readShuffleData(long offset, int expectedLength) {
     byte[] data = dataReader.read(dataFileOffset + offset, expectedLength);
     if (data.length != expectedLength) {
@@ -59,6 +60,7 @@ public class UploadedStorageHdfsShuffleReadHandler extends HdfsShuffleReadHandle
     return data;
   }
 
+  @Override
   protected ShuffleIndexResult readShuffleIndex() {
     long start = System.currentTimeMillis();
     try {

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedStorageHdfsShuffleReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/UploadedStorageHdfsShuffleReadHandler.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.apache.hadoop.conf.Configuration;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,11 +37,15 @@ public class UploadedStorageHdfsShuffleReadHandler extends HdfsShuffleReadHandle
   private long dataFileOffset;
 
   public UploadedStorageHdfsShuffleReadHandler(
+      String appId,
+      int shuffleId,
       int partitionId,
       String filePrefix,
       int readBufferSize,
+      Roaring64NavigableMap expectBlockIds,
+      Roaring64NavigableMap processBlockIds,
       Configuration conf)  throws IOException {
-    super(filePrefix, readBufferSize, conf);
+    super(appId, shuffleId, partitionId, filePrefix, readBufferSize, expectBlockIds, processBlockIds, conf);
     this.partitionId = partitionId;
   }
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
@@ -24,6 +24,7 @@ import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.storage.HdfsShuffleHandlerTestBase;
 import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.util.Map;
 import java.util.Random;
@@ -50,6 +51,8 @@ public class HdfsClientReadHandlerTest extends HdfsShuffleHandlerTestBase {
               conf);
 
       Map<Long, byte[]> expectedData = Maps.newHashMap();
+      Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+      Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
 
       int readBufferSize = 13;
       int total = 0;
@@ -61,6 +64,7 @@ public class HdfsClientReadHandlerTest extends HdfsShuffleHandlerTestBase {
         writeTestData(writeHandler,  num, 3, 0, expectedData);
         total += calcExpectedSegmentNum(num, 3, readBufferSize);
         expectTotalBlockNum += num;
+        expectedData.forEach((id, block) -> expectBlockIds.addLong(id));
       }
 
       HdfsClientReadHandler handler = new HdfsClientReadHandler(
@@ -71,6 +75,8 @@ public class HdfsClientReadHandlerTest extends HdfsShuffleHandlerTestBase {
           1,
           10,
           readBufferSize,
+          expectBlockIds,
+          processBlockIds,
           basePath,
           conf);
       Set<Long> actualBlockIds = Sets.newHashSet();

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsHandlerTest.java
@@ -103,14 +103,15 @@ public class HdfsHandlerTest extends HdfsTestBase {
       String basePath,
       List<byte[]> expectedData,
       List<Long> expectedBlockId) throws IllegalStateException {
-    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
     for (long blockId : expectedBlockId) {
-      blockIdBitmap.addLong(blockId);
+      expectBlockIds.addLong(blockId);
     }
     // read directly and compare
     HdfsClientReadHandler readHandler = new HdfsClientReadHandler(
         appId, shuffleId, partitionId, 100, 1, 10,
-        10000, basePath, new Configuration());
+        10000, expectBlockIds, processBlockIds, basePath, new Configuration());
     try {
       List<ByteBuffer> actual = readData(readHandler, Sets.newHashSet(expectedBlockId));
       compareBytes(expectedData, actual);

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandlerTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Random;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 public class MultiStorageHdfsShuffleReadHandlerTest extends HdfsShuffleHandlerTestBase {
 
@@ -115,13 +116,17 @@ public class MultiStorageHdfsShuffleReadHandlerTest extends HdfsShuffleHandlerTe
 
       for (int partitionId = 1; partitionId <= 9; partitionId += 2) {
         String fileNamePrefix = basePath + "/app1/0/test/1-3";
+        Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+        Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
         HdfsShuffleReadHandler handler = new UploadedStorageHdfsShuffleReadHandler(
-            partitionId, fileNamePrefix, readBufferSize, conf);
+            "app1", 0, partitionId, fileNamePrefix, readBufferSize,
+            expectBlockIds, processBlockIds, conf);
 
         int sliceNum = partitionSliceNum.get(partitionId);
         byte[] expectedDataBuf = new byte[0];
         for (ShufflePartitionedBlock spb : expectedBlocks.get(partitionId)) {
           Bytes.concat(expectedDataBuf, spb.getData());
+          expectBlockIds.addLong(spb.getBlockId());
         }
 
         if (partitionId <= 5) {
@@ -216,13 +221,17 @@ public class MultiStorageHdfsShuffleReadHandlerTest extends HdfsShuffleHandlerTe
 
       for (int partitionId = 1; partitionId <= 3; partitionId++) {
         String fileNamePrefix = basePath + "/app1/0/test/1-3";
+        Roaring64NavigableMap expectBlockIds = Roaring64NavigableMap.bitmapOf();
+        Roaring64NavigableMap processBlockIds = Roaring64NavigableMap.bitmapOf();
         HdfsShuffleReadHandler handler = new UploadedStorageHdfsShuffleReadHandler(
-            partitionId, fileNamePrefix, readBufferSize, conf);
+          "app1", 0, partitionId, fileNamePrefix, readBufferSize,
+            expectBlockIds, processBlockIds, conf);
 
         int sliceNum = partitionSliceNum.get(partitionId);
         byte[] expectedDataBuf = new byte[0];
         for (ShufflePartitionedBlock spb : expectedBlocks.get(partitionId)) {
           Bytes.concat(expectedDataBuf, spb.getData());
+          expectBlockIds.addLong(spb.getBlockId());
         }
 
         if (partitionId <= 3) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor HdfsClientReadHandler/UploadedHdfsClientReadHandler based on DataSkippableReadHandler

### Why are the changes needed?
This is "[Feature] Support to skip unexpected and processed segments in LocalFileReadClient (#55)" 's follow-up pull request, we implement the segment filter based on DataSkippableReadHandler.
In this PR, we extends to HdfsClientReadHandler/UploadedHdfsClientReadHandler. 
 
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Run all existing UT & IT.