### PR TITLE
[Feature]Access check in client

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -79,11 +79,8 @@ public class RssClientConfig {
   // has huge amount blockIds, eg, 10B.
   public static String RSS_CLIENT_BITMAP_SPLIT_NUM = "spark.rss.client.bitmap.splitNum";
   public static int RSS_CLIENT_BITMAP_SPLIT_NUM_DEFAULT_VALUE = 1;
-  public static String RSS_ACCESS_ID_KEY = "spark.rss.accessIdKey";
-  public static String RSS_ACCESS_ID_KEY_DEFAULT_VALUE = "";
+  public static String RSS_ACCESS_ID = "spark.rss.access.id";
   public static String RSS_ACCESS_ID_DEFAULT_VALUE = "";
-  public static String RSS_ACCESS_ID_PATTERN = "spark.rss.accessIdPattern";
-  public static String RSS_ACCESS_ID_PATTERN_DEFAULT_VALUE = "(\\w+)";
   public static String RSS_ACCESS_TIMEOUT_MS = "spark.rss.access.timeout.ms";
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = 10000;
   public static String RSS_USE_RSS_SHUFFLE_MANAGER = "spark.rss.useRssShuffleManager";

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -80,11 +80,10 @@ public class RssClientConfig {
   public static String RSS_CLIENT_BITMAP_SPLIT_NUM = "spark.rss.client.bitmap.splitNum";
   public static int RSS_CLIENT_BITMAP_SPLIT_NUM_DEFAULT_VALUE = 1;
   public static String RSS_ACCESS_ID = "spark.rss.access.id";
-  public static String RSS_ACCESS_ID_DEFAULT_VALUE = "";
   public static String RSS_ACCESS_TIMEOUT_MS = "spark.rss.access.timeout.ms";
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = 10000;
   public static String RSS_USE_RSS_SHUFFLE_MANAGER = "spark.rss.useRssShuffleManager";
-  public static String RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = "false";
+  public static boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
   public static String RSS_SORT_SHUFFLE_MANAGER_IMPL = "spark.rss.sort.shuffle.manager.impl";
   public static String RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE = "org.apache.spark.shuffle.sort.SortShuffleManager";
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -79,4 +79,11 @@ public class RssClientConfig {
   // has huge amount blockIds, eg, 10B.
   public static String RSS_CLIENT_BITMAP_SPLIT_NUM = "spark.rss.client.bitmap.splitNum";
   public static int RSS_CLIENT_BITMAP_SPLIT_NUM_DEFAULT_VALUE = 1;
+  public static String RSS_ACCESS_INFO_KEY = "spark.rss.accessInfoKey";
+  public static String RSS_ACCESS_INFO_KEY_DEFAULT_VALUE = "";
+  public static String RSS_ACCESS_INFO_DEFAULT_VALUE = "";
+  public static String RSS_USE_RSS_SHUFFLE_MANAGER = "spark.rss.useRssShuffleManager";
+  public static boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
+  public static String RSS_SORT_SHUFFLE_MANAGER_IMPL = "spark.rss.sort.shuffle.manager.impl";
+  public static String RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE = "org.apache.spark.shuffle.sort.SortShuffleManager";
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -79,11 +79,15 @@ public class RssClientConfig {
   // has huge amount blockIds, eg, 10B.
   public static String RSS_CLIENT_BITMAP_SPLIT_NUM = "spark.rss.client.bitmap.splitNum";
   public static int RSS_CLIENT_BITMAP_SPLIT_NUM_DEFAULT_VALUE = 1;
-  public static String RSS_ACCESS_INFO_KEY = "spark.rss.accessInfoKey";
-  public static String RSS_ACCESS_INFO_KEY_DEFAULT_VALUE = "";
-  public static String RSS_ACCESS_INFO_DEFAULT_VALUE = "";
+  public static String RSS_ACCESS_ID_KEY = "spark.rss.accessIdKey";
+  public static String RSS_ACCESS_ID_KEY_DEFAULT_VALUE = "";
+  public static String RSS_ACCESS_ID_DEFAULT_VALUE = "";
+  public static String RSS_ACCESS_ID_PATTERN = "spark.rss.accessIdPattern";
+  public static String RSS_ACCESS_ID_PATTERN_DEFAULT_VALUE = "(\\w+)";
+  public static String RSS_ACCESS_TIMEOUT_MS = "spark.rss.access.timeout.ms";
+  public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = 10000;
   public static String RSS_USE_RSS_SHUFFLE_MANAGER = "spark.rss.useRssShuffleManager";
-  public static boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
+  public static String RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = "false";
   public static String RSS_SORT_SHUFFLE_MANAGER_IMPL = "spark.rss.sort.shuffle.manager.impl";
   public static String RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE = "org.apache.spark.shuffle.sort.SortShuffleManager";
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -82,8 +82,6 @@ public class RssClientConfig {
   public static String RSS_ACCESS_ID = "spark.rss.access.id";
   public static String RSS_ACCESS_TIMEOUT_MS = "spark.rss.access.timeout.ms";
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = 10000;
-  public static String RSS_USE_RSS_SHUFFLE_MANAGER = "spark.rss.useRssShuffleManager";
+  public static String RSS_ENABLED = "spark.rss.enabled";
   public static boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
-  public static String RSS_SORT_SHUFFLE_MANAGER_IMPL = "spark.rss.sort.shuffle.manager.impl";
-  public static String RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE = "org.apache.spark.shuffle.sort.SortShuffleManager";
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -21,6 +21,7 @@ package org.apache.spark.shuffle;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -36,6 +37,9 @@ import org.apache.spark.io.CompressionCodec;
 import org.apache.spark.package$;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.factory.CoordinatorClientFactory;
 
 public class RssShuffleUtils {
 
@@ -149,4 +153,28 @@ public class RssShuffleUtils {
   public static String getSparkVersion() {
     return package$.MODULE$.SPARK_VERSION();
   }
+
+  public static ShuffleManager loadShuffleManager(String name, SparkConf conf, boolean isDriver) throws Exception {
+    Class<?> klass = Class.forName(name);
+
+    Constructor<?> constructor;
+    ShuffleManager instance;
+    try {
+      constructor = klass.getConstructor(conf.getClass(), Boolean.TYPE);
+      instance = (ShuffleManager) constructor.newInstance(conf, isDriver);
+    } catch (NoSuchMethodException e) {
+      constructor = klass.getConstructor(conf.getClass());
+      instance = (ShuffleManager) constructor.newInstance(conf);
+    }
+    return instance;
+  }
+
+  public static List<CoordinatorClient> createCoordinatorClients(SparkConf sparkConf) throws RuntimeException {
+    String clientType = sparkConf.get(RssClientConfig.RSS_CLIENT_TYPE,
+        RssClientConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
+    String coordinators = sparkConf.get(RssClientConfig.RSS_COORDINATOR_QUORUM);
+    CoordinatorClientFactory coordinatorClientFactory = new CoordinatorClientFactory(clientType);
+    return coordinatorClientFactory.createCoordinatorClient(coordinators);
+  }
+
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -156,7 +156,6 @@ public class RssShuffleUtils {
 
   public static ShuffleManager loadShuffleManager(String name, SparkConf conf, boolean isDriver) throws Exception {
     Class<?> klass = Class.forName(name);
-
     Constructor<?> constructor;
     ShuffleManager instance;
     try {
@@ -176,5 +175,4 @@ public class RssShuffleUtils {
     CoordinatorClientFactory coordinatorClientFactory = new CoordinatorClientFactory(clientType);
     return coordinatorClientFactory.createCoordinatorClient(coordinators);
   }
-
 }

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -19,37 +19,50 @@
 package org.apache.spark.shuffle;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.request.RssAccessClusterRequest;
+import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.common.exception.RssException;
-
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE;
+import com.tencent.rss.common.util.Constants;
 
 public class DelegationRssShuffleManager implements ShuffleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DelegationRssShuffleManager.class);
 
   private final ShuffleManager delegate;
   private final String sortShuffleManagerName;
   private final List<CoordinatorClient> coordinatorClients;
+  private final int accessTimeoutMs;
+  private final SparkConf sparkConf;
+  private String accessId;
 
   public DelegationRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
-    sortShuffleManagerName = sparkConf.get(RSS_SORT_SHUFFLE_MANAGER_IMPL, RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    this.sparkConf = sparkConf;
+    sortShuffleManagerName = sparkConf.get(
+        RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL,
+        RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    accessTimeoutMs = sparkConf.getInt(
+        RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
+        RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE);
     if (isDriver) {
-      delegate = createShuffleManagerInDriver(sparkConf);
       coordinatorClients = RssShuffleUtils.createCoordinatorClients(sparkConf);
+      delegate = createShuffleManagerInDriver();
     } else {
-      delegate = createShuffleManagerInExecutor(sparkConf);
-      coordinatorClients = null;
+      coordinatorClients = Lists.newArrayList();
+      delegate = createShuffleManagerInExecutor();
     }
 
     if (delegate == null) {
@@ -57,37 +70,116 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     }
   }
 
-  private ShuffleManager createShuffleManagerInDriver(SparkConf sparkConf) throws RssException {
+  private ShuffleManager createShuffleManagerInDriver() throws RssException {
     ShuffleManager shuffleManager;
-    String accessInfoKey = sparkConf.get(RSS_ACCESS_INFO_KEY, RSS_ACCESS_INFO_KEY_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessInfoKey)) {
-      return null;
-    }
-    String accessInfo = sparkConf.get(accessInfoKey, RSS_ACCESS_INFO_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessInfo)) {
-      return null;
+
+    boolean canAccess = tryAccessCluster();
+    if (canAccess) {
+      try {
+        shuffleManager = new RssShuffleManager(sparkConf, true);
+        sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+        return shuffleManager;
+      } catch (Exception exception) {
+        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager");
+      }
     }
 
-    // TODO: send access request
-    if (true) {
-      shuffleManager = new RssShuffleManager(sparkConf, true);
-      sparkConf.set(RSS_USE_RSS_SHUFFLE_MANAGER, "true");
-    } else {
-      try {
-        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
-      } catch (Exception e) {
-        throw new RssException(e.getMessage());
-      }
+    try {
+      shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, true);
+      sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+    } catch (Exception e) {
+      throw new RssException(e.getMessage());
     }
 
     return shuffleManager;
   }
 
-  private ShuffleManager createShuffleManagerInExecutor(SparkConf sparkConf) throws RssException {
+  private boolean tryAccessCluster() {
+    String accessIdStr = getAndCheckAccessIdStr();
+    if (StringUtils.isEmpty(accessIdStr)) {
+      return false;
+    }
+
+    if (!extractAccessId(accessIdStr)) {
+      return false;
+    }
+
+    for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      try {
+        RssAccessClusterResponse response =
+            coordinatorClient.accessCluster(new RssAccessClusterRequest(
+                accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), accessTimeoutMs));
+        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+          LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
+          return true;
+        }
+        LOG.warn("Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(), accessId, response.getMessage());
+      } catch (Exception e) {
+        LOG.warn("Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(), accessId, e.getMessage());
+      }
+    }
+
+    return false;
+  }
+
+  private String getAndCheckAccessIdStr() {
+    String accessInfoKey = sparkConf.get(
+        RssClientConfig.RSS_ACCESS_ID_KEY,
+        RssClientConfig.RSS_ACCESS_ID_KEY_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfoKey)) {
+      LOG.warn("Access id key is empty");
+      return null;
+    }
+
+    String accessId = sparkConf.get(accessInfoKey, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessId)) {
+      LOG.warn("Access id is empty");
+      return null;
+    }
+
+    return accessId;
+  }
+
+  private boolean extractAccessId(String accessIdStr) {
+    String patternStr = sparkConf.get(RssClientConfig.RSS_ACCESS_ID_PATTERN,
+        RssClientConfig.RSS_ACCESS_ID_PATTERN_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(patternStr)) {
+      LOG.warn("Access pattern is empty");
+      return false;
+    }
+
+    try {
+      Pattern pattern = Pattern.compile(patternStr);
+      Matcher matcher = pattern.matcher(accessIdStr);
+      if (matcher.find()) {
+        accessId = matcher.group(1);
+      } else {
+        LOG.warn("No match found for access id str {} in pattern {} may be wrong", accessIdStr, patternStr);
+        return false;
+      }
+
+      if (StringUtils.isEmpty(accessId)) {
+        LOG.warn("Access id is empty");
+        return false;
+      }
+    } catch (Exception e) {
+      LOG.warn("Fail to extract access id {} using pattern {} for {}", accessIdStr, patternStr, e.getMessage());
+      return false;
+    }
+
+    return true;
+  }
+
+  private ShuffleManager createShuffleManagerInExecutor() throws RssException {
     ShuffleManager shuffleManager;
     // get useRSS from spark conf
-    boolean useRSS = sparkConf.getBoolean(RSS_USE_RSS_SHUFFLE_MANAGER, RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
+    boolean useRSS = Boolean.parseBoolean(sparkConf.get(
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER,
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE));
     if (useRSS) {
+      // Executor will not do any fallback
       shuffleManager = new RssShuffleManager(sparkConf, false);
     } else {
       try {
@@ -97,6 +189,14 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       }
     }
     return shuffleManager;
+  }
+
+  public ShuffleManager getDelegate() {
+    return delegate;
+  }
+
+  public String getAccessId() {
+    return accessId;
   }
 
   @Override

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -19,8 +19,6 @@
 package org.apache.spark.shuffle;
 
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -47,7 +45,6 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   private final List<CoordinatorClient> coordinatorClients;
   private final int accessTimeoutMs;
   private final SparkConf sparkConf;
-  private String accessId;
 
   public DelegationRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
     this.sparkConf = sparkConf;
@@ -78,6 +75,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       try {
         shuffleManager = new RssShuffleManager(sparkConf, true);
         sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+        LOG.info("Use RssShuffleManager");
         return shuffleManager;
       } catch (Exception exception) {
         LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager");
@@ -87,6 +85,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     try {
       shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, true);
       sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+      LOG.info("Use SortShuffleManager");
     } catch (Exception e) {
       throw new RssException(e.getMessage());
     }
@@ -95,12 +94,10 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   }
 
   private boolean tryAccessCluster() {
-    String accessIdStr = getAndCheckAccessIdStr();
-    if (StringUtils.isEmpty(accessIdStr)) {
-      return false;
-    }
-
-    if (!extractAccessId(accessIdStr)) {
+    String accessId = sparkConf.get(
+        RssClientConfig.RSS_ACCESS_ID, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE).trim();
+    if (StringUtils.isEmpty(accessId)) {
+      LOG.warn("Access id key is empty");
       return false;
     }
 
@@ -112,9 +109,13 @@ public class DelegationRssShuffleManager implements ShuffleManager {
         if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
           LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
           return true;
+        } else if (response.getStatusCode() == ResponseStatusCode.ACCESS_DENIED) {
+          LOG.warn("Request to access cluster {} is denied using {} for {}",
+              coordinatorClient.getDesc(), accessId, response.getMessage());
+          return false;
+        } else {
+          LOG.warn("Fail to reach cluster {} for {}", coordinatorClient.getDesc(), response.getMessage());
         }
-        LOG.warn("Fail to access cluster {} using {} for {}",
-            coordinatorClient.getDesc(), accessId, response.getMessage());
       } catch (Exception e) {
         LOG.warn("Fail to access cluster {} using {} for {}",
             coordinatorClient.getDesc(), accessId, e.getMessage());
@@ -122,54 +123,6 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     }
 
     return false;
-  }
-
-  private String getAndCheckAccessIdStr() {
-    String accessInfoKey = sparkConf.get(
-        RssClientConfig.RSS_ACCESS_ID_KEY,
-        RssClientConfig.RSS_ACCESS_ID_KEY_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessInfoKey)) {
-      LOG.warn("Access id key is empty");
-      return null;
-    }
-
-    String accessId = sparkConf.get(accessInfoKey, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessId)) {
-      LOG.warn("Access id is empty");
-      return null;
-    }
-
-    return accessId;
-  }
-
-  private boolean extractAccessId(String accessIdStr) {
-    String patternStr = sparkConf.get(RssClientConfig.RSS_ACCESS_ID_PATTERN,
-        RssClientConfig.RSS_ACCESS_ID_PATTERN_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(patternStr)) {
-      LOG.warn("Access pattern is empty");
-      return false;
-    }
-
-    try {
-      Pattern pattern = Pattern.compile(patternStr);
-      Matcher matcher = pattern.matcher(accessIdStr);
-      if (matcher.find()) {
-        accessId = matcher.group(1);
-      } else {
-        LOG.warn("No match found for access id str {} in pattern {} may be wrong", accessIdStr, patternStr);
-        return false;
-      }
-
-      if (StringUtils.isEmpty(accessId)) {
-        LOG.warn("Access id is empty");
-        return false;
-      }
-    } catch (Exception e) {
-      LOG.warn("Fail to extract access id {} using pattern {} for {}", accessIdStr, patternStr, e.getMessage());
-      return false;
-    }
-
-    return true;
   }
 
   private ShuffleManager createShuffleManagerInExecutor() throws RssException {
@@ -181,9 +134,11 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     if (useRSS) {
       // Executor will not do any fallback
       shuffleManager = new RssShuffleManager(sparkConf, false);
+      LOG.info("Use RssShuffleManager");
     } else {
       try {
         shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
+        LOG.info("Use SortShuffleManager");
       } catch (Exception e) {
         throw new RssException(e.getMessage());
       }
@@ -193,10 +148,6 @@ public class DelegationRssShuffleManager implements ShuffleManager {
 
   public ShuffleManager getDelegate() {
     return delegate;
-  }
-
-  public String getAccessId() {
-    return accessId;
   }
 
   @Override

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -1,0 +1,132 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.common.exception.RssException;
+
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE;
+
+public class DelegationRssShuffleManager implements ShuffleManager {
+
+  private final ShuffleManager delegate;
+  private final String sortShuffleManagerName;
+  private final List<CoordinatorClient> coordinatorClients;
+
+  public DelegationRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
+    sortShuffleManagerName = sparkConf.get(RSS_SORT_SHUFFLE_MANAGER_IMPL, RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    if (isDriver) {
+      delegate = createShuffleManagerInDriver(sparkConf);
+      coordinatorClients = RssShuffleUtils.createCoordinatorClients(sparkConf);
+    } else {
+      delegate = createShuffleManagerInExecutor(sparkConf);
+      coordinatorClients = null;
+    }
+
+    if (delegate == null) {
+      throw new RssException("Fail to create shuffle manager!");
+    }
+  }
+
+  private ShuffleManager createShuffleManagerInDriver(SparkConf sparkConf) throws RssException {
+    ShuffleManager shuffleManager;
+    String accessInfoKey = sparkConf.get(RSS_ACCESS_INFO_KEY, RSS_ACCESS_INFO_KEY_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfoKey)) {
+      return null;
+    }
+    String accessInfo = sparkConf.get(accessInfoKey, RSS_ACCESS_INFO_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfo)) {
+      return null;
+    }
+
+    // TODO: send access request
+    if (true) {
+      shuffleManager = new RssShuffleManager(sparkConf, true);
+      sparkConf.set(RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    } else {
+      try {
+        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
+      } catch (Exception e) {
+        throw new RssException(e.getMessage());
+      }
+    }
+
+    return shuffleManager;
+  }
+
+  private ShuffleManager createShuffleManagerInExecutor(SparkConf sparkConf) throws RssException {
+    ShuffleManager shuffleManager;
+    // get useRSS from spark conf
+    boolean useRSS = sparkConf.getBoolean(RSS_USE_RSS_SHUFFLE_MANAGER, RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
+    if (useRSS) {
+      shuffleManager = new RssShuffleManager(sparkConf, false);
+    } else {
+      try {
+        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
+      } catch (Exception e) {
+        throw new RssException(e.getMessage());
+      }
+    }
+    return shuffleManager;
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+    return delegate.registerShuffle(shuffleId, numMaps, dependency);
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(ShuffleHandle handle, int mapId, TaskContext context) {
+    return delegate.getWriter(handle, mapId, context);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
+    return delegate.getReader(handle, startPartition, endPartition, context);
+  }
+
+  @Override
+  public boolean unregisterShuffle(int shuffleId) {
+    return delegate.unregisterShuffle(shuffleId);
+  }
+
+  @Override
+  public void stop() {
+    delegate.stop();
+  }
+
+  @Override
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return delegate.shuffleBlockResolver();
+  }
+}

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -95,7 +95,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
 
   private boolean tryAccessCluster() {
     String accessId = sparkConf.get(
-        RssClientConfig.RSS_ACCESS_ID, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE).trim();
+        RssClientConfig.RSS_ACCESS_ID, "").trim();
     if (StringUtils.isEmpty(accessId)) {
       LOG.warn("Access id key is empty");
       return false;
@@ -128,9 +128,9 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   private ShuffleManager createShuffleManagerInExecutor() throws RssException {
     ShuffleManager shuffleManager;
     // get useRSS from spark conf
-    boolean useRSS = Boolean.parseBoolean(sparkConf.get(
+    boolean useRSS = sparkConf.getBoolean(
         RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER,
-        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE));
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
     if (useRSS) {
       // Executor will not do any fallback
       shuffleManager = new RssShuffleManager(sparkConf, false);

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -108,13 +108,13 @@ public class DelegationRssShuffleManagerTest {
 
     SparkConf conf = new SparkConf();
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
-    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    conf.set(RssClientConfig.RSS_ENABLED, "true");
 
     // fall back to SortShuffleManager in driver
     assertCreateSortShuffleManager(conf);
 
     // No fall back in executor
-    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    conf.set(RssClientConfig.RSS_ENABLED, "true");
     boolean hasException = false;
     try {
       new DelegationRssShuffleManager(conf, false);
@@ -129,7 +129,7 @@ public class DelegationRssShuffleManagerTest {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
-    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
     return delegationRssShuffleManager;
   }
 
@@ -137,7 +137,7 @@ public class DelegationRssShuffleManagerTest {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
-    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
     return delegationRssShuffleManager;
   }
 }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.google.common.collect.Lists;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.sort.SortShuffleManager;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
+
+import static com.tencent.rss.client.response.ResponseStatusCode.ACCESS_DENIED;
+import static com.tencent.rss.client.response.ResponseStatusCode.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class DelegationRssShuffleManagerTest {
+  private static MockedStatic<RssShuffleUtils> mockedStaticRssShuffleUtils;
+
+  @BeforeClass
+  public static void setUp() {
+    mockedStaticRssShuffleUtils = mockStatic(RssShuffleUtils.class, Mockito.CALLS_REAL_METHODS);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    mockedStaticRssShuffleUtils.close();
+  }
+
+  @Test
+  public void testCreateInDriverDenied() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf);
+  }
+
+  @Test
+  public void testCreateInDriver() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_KEY, "mockKey");
+    assertCreateSortShuffleManager(conf);
+
+    conf.set("mockKey", "value");
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+    conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    assertCreateRssShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "");
+    assertCreateSortShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "(\\d+)");
+    assertCreateSortShuffleManager(conf);
+    conf.set("mockKey", "123");
+    DelegationRssShuffleManager delegationRssShuffleManager = assertCreateRssShuffleManager(conf);
+    assertEquals("123", delegationRssShuffleManager.getAccessId());
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "(\\d+)(\\w+)");
+    conf.set("mockKey", "9527_22_33");
+    delegationRssShuffleManager = assertCreateRssShuffleManager(conf);
+    assertEquals("9527", delegationRssShuffleManager.getAccessId());
+  }
+
+  @Test
+  public void testCreateInExecutor() throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager;
+    SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(conf, false);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+  }
+
+  @Test
+  public void testCreateFallback() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+    DelegationRssShuffleManager delegationRssShuffleManager;
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_ACCESS_ID_KEY, "mockKey");
+    conf.set("mockKey", "value");
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+
+    // fall back to SortShuffleManager in driver
+    assertCreateSortShuffleManager(conf);
+
+    // No fall back in executor
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    try {
+      new DelegationRssShuffleManager(conf, false);
+    } catch (NoSuchElementException e) {
+      assertTrue(e.getMessage().startsWith("spark.rss.coordinator.quorum"));
+    }
+  }
+
+  private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    return delegationRssShuffleManager;
+  }
+
+  private DelegationRssShuffleManager assertCreateRssShuffleManager(SparkConf conf) throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    return delegationRssShuffleManager;
+  }
+}

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -1,0 +1,151 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.spark.ShuffleDependency;
+import org.apache.spark.SparkConf;
+import org.apache.spark.TaskContext;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.common.exception.RssException;
+
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER;
+import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE;
+
+public class DelegationRssShuffleManager implements ShuffleManager {
+
+  private final ShuffleManager delegate;
+  private final String sortShuffleManagerName;
+  private final List<CoordinatorClient> coordinatorClients;
+
+  public DelegationRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
+    sortShuffleManagerName = sparkConf.get(RSS_SORT_SHUFFLE_MANAGER_IMPL, RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    if (isDriver) {
+      delegate = createShuffleManagerInDriver(sparkConf);
+      coordinatorClients = RssShuffleUtils.createCoordinatorClients(sparkConf);
+    } else {
+      delegate = createShuffleManagerInExecutor(sparkConf);
+      coordinatorClients = null;
+    }
+
+    if (delegate == null) {
+      throw new RssException("Fail to create shuffle manager!");
+    }
+  }
+
+  private ShuffleManager createShuffleManagerInDriver(SparkConf sparkConf) throws RssException {
+    ShuffleManager shuffleManager;
+    String accessInfoKey = sparkConf.get(RSS_ACCESS_INFO_KEY, RSS_ACCESS_INFO_KEY_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfoKey)) {
+      return null;
+    }
+    String accessInfo = sparkConf.get(accessInfoKey, RSS_ACCESS_INFO_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfo)) {
+      return null;
+    }
+
+    // TODO: send access request
+    if (true) {
+      shuffleManager = new RssShuffleManager(sparkConf, true);
+      sparkConf.set(RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    } else {
+      try {
+        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
+      } catch (Exception e) {
+        throw new RssException(e.getMessage());
+      }
+    }
+
+    return shuffleManager;
+  }
+
+  private ShuffleManager createShuffleManagerInExecutor(SparkConf sparkConf) throws RssException {
+    ShuffleManager shuffleManager;
+    // get useRSS from spark conf
+    boolean useRSS = sparkConf.getBoolean(RSS_USE_RSS_SHUFFLE_MANAGER, RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
+    if (useRSS) {
+      shuffleManager = new RssShuffleManager(sparkConf, false);
+    } else {
+      try {
+        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
+      } catch (Exception e) {
+        throw new RssException(e.getMessage());
+      }
+    }
+    return shuffleManager;
+  }
+
+  @Override
+  public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, ShuffleDependency<K, V, C> dependency) {
+    return delegate.registerShuffle(shuffleId, dependency);
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(
+      ShuffleHandle handle,
+      long mapId,
+      TaskContext context,
+      ShuffleWriteMetricsReporter metrics) {
+    return delegate.getWriter(handle, mapId, context, metrics);
+  }
+
+  @Override
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    return delegate.getReader(handle, startPartition, endPartition, context, metrics);
+  }
+
+  public <K, C> ShuffleReader<K, C> getReader(
+      ShuffleHandle handle,
+      int startMapIndex,
+      int endMapIndex,
+      int startPartition,
+      int endPartition,
+      TaskContext context,
+      ShuffleReadMetricsReporter metrics) {
+    return delegate.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+  }
+
+  @Override
+  public boolean unregisterShuffle(int shuffleId) {
+    return delegate.unregisterShuffle(shuffleId);
+  }
+
+  @Override
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return delegate.shuffleBlockResolver();
+  }
+
+  @Override
+  public void stop() {
+    delegate.stop();
+  }
+}

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -19,37 +19,50 @@
 package org.apache.spark.shuffle;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.request.RssAccessClusterRequest;
+import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.common.exception.RssException;
-
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_ACCESS_INFO_KEY_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER;
-import static org.apache.spark.shuffle.RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE;
+import com.tencent.rss.common.util.Constants;
 
 public class DelegationRssShuffleManager implements ShuffleManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DelegationRssShuffleManager.class);
 
   private final ShuffleManager delegate;
   private final String sortShuffleManagerName;
   private final List<CoordinatorClient> coordinatorClients;
+  private final int accessTimeoutMs;
+  private final SparkConf sparkConf;
+  private String accessId;
 
   public DelegationRssShuffleManager(SparkConf sparkConf, boolean isDriver) throws Exception {
-    sortShuffleManagerName = sparkConf.get(RSS_SORT_SHUFFLE_MANAGER_IMPL, RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    this.sparkConf = sparkConf;
+    sortShuffleManagerName = sparkConf.get(
+        RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL,
+        RssClientConfig.RSS_SORT_SHUFFLE_MANAGER_IMPL_DEFAULT_VALUE);
+    accessTimeoutMs = sparkConf.getInt(
+        RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
+        RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE);
     if (isDriver) {
-      delegate = createShuffleManagerInDriver(sparkConf);
       coordinatorClients = RssShuffleUtils.createCoordinatorClients(sparkConf);
+      delegate = createShuffleManagerInDriver();
     } else {
-      delegate = createShuffleManagerInExecutor(sparkConf);
-      coordinatorClients = null;
+      coordinatorClients = Lists.newArrayList();
+      delegate = createShuffleManagerInExecutor();
     }
 
     if (delegate == null) {
@@ -57,37 +70,116 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     }
   }
 
-  private ShuffleManager createShuffleManagerInDriver(SparkConf sparkConf) throws RssException {
+  private ShuffleManager createShuffleManagerInDriver() throws RssException {
     ShuffleManager shuffleManager;
-    String accessInfoKey = sparkConf.get(RSS_ACCESS_INFO_KEY, RSS_ACCESS_INFO_KEY_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessInfoKey)) {
-      return null;
-    }
-    String accessInfo = sparkConf.get(accessInfoKey, RSS_ACCESS_INFO_DEFAULT_VALUE);
-    if (StringUtils.isEmpty(accessInfo)) {
-      return null;
+
+    boolean canAccess = tryAccessCluster();
+    if (canAccess) {
+      try {
+        shuffleManager = new RssShuffleManager(sparkConf, true);
+        sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+        return shuffleManager;
+      } catch (Exception exception) {
+        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager");
+      }
     }
 
-    // TODO: send access request
-    if (true) {
-      shuffleManager = new RssShuffleManager(sparkConf, true);
-      sparkConf.set(RSS_USE_RSS_SHUFFLE_MANAGER, "true");
-    } else {
-      try {
-        shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, false);
-      } catch (Exception e) {
-        throw new RssException(e.getMessage());
-      }
+    try {
+      shuffleManager = RssShuffleUtils.loadShuffleManager(sortShuffleManagerName, sparkConf, true);
+      sparkConf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+    } catch (Exception e) {
+      throw new RssException(e.getMessage());
     }
 
     return shuffleManager;
   }
 
-  private ShuffleManager createShuffleManagerInExecutor(SparkConf sparkConf) throws RssException {
+  private boolean tryAccessCluster() {
+    String accessIdStr = getAndCheckAccessIdStr();
+    if (StringUtils.isEmpty(accessIdStr)) {
+      return false;
+    }
+
+    if (!extractAccessId(accessIdStr)) {
+      return false;
+    }
+
+    for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      try {
+        RssAccessClusterResponse response =
+            coordinatorClient.accessCluster(new RssAccessClusterRequest(
+                accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), accessTimeoutMs));
+        if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+          LOG.warn("Success to access cluster {} using {}", coordinatorClient.getDesc(), accessId);
+          return true;
+        }
+        LOG.warn("Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(), accessId, response.getMessage());
+      } catch (Exception e) {
+        LOG.warn("Fail to access cluster {} using {} for {}",
+            coordinatorClient.getDesc(), accessId, e.getMessage());
+      }
+    }
+
+    return false;
+  }
+
+  private String getAndCheckAccessIdStr() {
+    String accessInfoKey = sparkConf.get(
+        RssClientConfig.RSS_ACCESS_ID_KEY,
+        RssClientConfig.RSS_ACCESS_ID_KEY_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessInfoKey)) {
+      LOG.warn("Access id key is empty");
+      return null;
+    }
+
+    String accessId = sparkConf.get(accessInfoKey, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(accessId)) {
+      LOG.warn("Access id is empty");
+      return null;
+    }
+
+    return accessId;
+  }
+
+  private boolean extractAccessId(String accessIdStr) {
+    String patternStr = sparkConf.get(RssClientConfig.RSS_ACCESS_ID_PATTERN,
+        RssClientConfig.RSS_ACCESS_ID_PATTERN_DEFAULT_VALUE);
+    if (StringUtils.isEmpty(patternStr)) {
+      LOG.warn("Access pattern is empty");
+      return false;
+    }
+
+    try {
+      Pattern pattern = Pattern.compile(patternStr);
+      Matcher matcher = pattern.matcher(accessIdStr);
+      if (matcher.find()) {
+        accessId = matcher.group(1);
+      } else {
+        LOG.warn("No match found for access id str {} in pattern {} may be wrong", accessIdStr, patternStr);
+        return false;
+      }
+
+      if (StringUtils.isEmpty(accessId)) {
+        LOG.warn("Access id is empty");
+        return false;
+      }
+    } catch (Exception e) {
+      LOG.warn("Fail to extract access id {} using pattern {} for {}", accessIdStr, patternStr, e.getMessage());
+      return false;
+    }
+
+    return true;
+  }
+
+  private ShuffleManager createShuffleManagerInExecutor() throws RssException {
     ShuffleManager shuffleManager;
     // get useRSS from spark conf
-    boolean useRSS = sparkConf.getBoolean(RSS_USE_RSS_SHUFFLE_MANAGER, RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
+    boolean useRSS = Boolean.parseBoolean(sparkConf.get(
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER,
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE));
     if (useRSS) {
+      // Executor will not do any fallback
       shuffleManager = new RssShuffleManager(sparkConf, false);
     } else {
       try {
@@ -99,39 +191,28 @@ public class DelegationRssShuffleManager implements ShuffleManager {
     return shuffleManager;
   }
 
-  @Override
-  public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, ShuffleDependency<K, V, C> dependency) {
-    return delegate.registerShuffle(shuffleId, dependency);
+  public ShuffleManager getDelegate() {
+    return delegate;
+  }
+
+  public String getAccessId() {
+    return accessId;
   }
 
   @Override
-  public <K, V> ShuffleWriter<K, V> getWriter(
-      ShuffleHandle handle,
-      long mapId,
-      TaskContext context,
-      ShuffleWriteMetricsReporter metrics) {
-    return delegate.getWriter(handle, mapId, context, metrics);
+  public <K, V, C> ShuffleHandle registerShuffle(int shuffleId, int numMaps, ShuffleDependency<K, V, C> dependency) {
+    return delegate.registerShuffle(shuffleId, numMaps, dependency);
+  }
+
+  @Override
+  public <K, V> ShuffleWriter<K, V> getWriter(ShuffleHandle handle, int mapId, TaskContext context) {
+    return delegate.getWriter(handle, mapId, context);
   }
 
   @Override
   public <K, C> ShuffleReader<K, C> getReader(
-      ShuffleHandle handle,
-      int startPartition,
-      int endPartition,
-      TaskContext context,
-      ShuffleReadMetricsReporter metrics) {
-    return delegate.getReader(handle, startPartition, endPartition, context, metrics);
-  }
-
-  public <K, C> ShuffleReader<K, C> getReader(
-      ShuffleHandle handle,
-      int startMapIndex,
-      int endMapIndex,
-      int startPartition,
-      int endPartition,
-      TaskContext context,
-      ShuffleReadMetricsReporter metrics) {
-    return delegate.getReader(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics);
+      ShuffleHandle handle, int startPartition, int endPartition, TaskContext context) {
+    return delegate.getReader(handle, startPartition, endPartition, context);
   }
 
   @Override
@@ -140,12 +221,12 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   }
 
   @Override
-  public ShuffleBlockResolver shuffleBlockResolver() {
-    return delegate.shuffleBlockResolver();
+  public void stop() {
+    delegate.stop();
   }
 
   @Override
-  public void stop() {
-    delegate.stop();
+  public ShuffleBlockResolver shuffleBlockResolver() {
+    return delegate.shuffleBlockResolver();
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -95,7 +95,7 @@ public class DelegationRssShuffleManager implements ShuffleManager {
 
   private boolean tryAccessCluster() {
     String accessId = sparkConf.get(
-        RssClientConfig.RSS_ACCESS_ID, RssClientConfig.RSS_ACCESS_ID_DEFAULT_VALUE).trim();
+        RssClientConfig.RSS_ACCESS_ID, "").trim();
     if (StringUtils.isEmpty(accessId)) {
       LOG.warn("Access id key is empty");
       return false;
@@ -128,9 +128,9 @@ public class DelegationRssShuffleManager implements ShuffleManager {
   private ShuffleManager createShuffleManagerInExecutor() throws RssException {
     ShuffleManager shuffleManager;
     // get useRSS from spark conf
-    boolean useRSS = Boolean.parseBoolean(sparkConf.get(
+    boolean useRSS = sparkConf.getBoolean(
         RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER,
-        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE));
+        RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE);
     if (useRSS) {
       // Executor will not do any fallback
       shuffleManager = new RssShuffleManager(sparkConf, false);

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -108,13 +108,13 @@ public class DelegationRssShuffleManagerTest {
 
     SparkConf conf = new SparkConf();
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
-    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    conf.set(RssClientConfig.RSS_ENABLED, "true");
 
     // fall back to SortShuffleManager in driver
     assertCreateSortShuffleManager(conf);
 
     // No fall back in executor
-    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    conf.set(RssClientConfig.RSS_ENABLED, "true");
     boolean hasException = false;
     try {
       new DelegationRssShuffleManager(conf, false);
@@ -129,7 +129,7 @@ public class DelegationRssShuffleManagerTest {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
-    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
     return delegationRssShuffleManager;
   }
 
@@ -137,7 +137,7 @@ public class DelegationRssShuffleManagerTest {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
-    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
     return delegationRssShuffleManager;
   }
 }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -1,0 +1,158 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.spark.shuffle;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import com.google.common.collect.Lists;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.sort.SortShuffleManager;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
+
+import static com.tencent.rss.client.response.ResponseStatusCode.ACCESS_DENIED;
+import static com.tencent.rss.client.response.ResponseStatusCode.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+public class DelegationRssShuffleManagerTest {
+  private static MockedStatic<RssShuffleUtils> mockedStaticRssShuffleUtils;
+
+  @BeforeClass
+  public static void setUp() {
+    mockedStaticRssShuffleUtils = mockStatic(RssShuffleUtils.class, Mockito.CALLS_REAL_METHODS);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    mockedStaticRssShuffleUtils.close();
+  }
+
+  @Test
+  public void testCreateInDriverDenied() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(ACCESS_DENIED, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf);
+  }
+
+  @Test
+  public void testCreateInDriver() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+
+    SparkConf conf = new SparkConf();
+    assertCreateSortShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_KEY, "mockKey");
+    assertCreateSortShuffleManager(conf);
+
+    conf.set("mockKey", "value");
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+    conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    assertCreateRssShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "");
+    assertCreateSortShuffleManager(conf);
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "(\\d+)");
+    assertCreateSortShuffleManager(conf);
+    conf.set("mockKey", "123");
+    DelegationRssShuffleManager delegationRssShuffleManager = assertCreateRssShuffleManager(conf);
+    assertEquals("123", delegationRssShuffleManager.getAccessId());
+
+    conf.set(RssClientConfig.RSS_ACCESS_ID_PATTERN, "(\\d+)(\\w+)");
+    conf.set("mockKey", "9527_22_33");
+    delegationRssShuffleManager = assertCreateRssShuffleManager(conf);
+    assertEquals("9527", delegationRssShuffleManager.getAccessId());
+  }
+
+  @Test
+  public void testCreateInExecutor() throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager;
+    SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(conf, false);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+  }
+
+  @Test
+  public void testCreateFallback() throws Exception {
+    CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
+    coordinatorClients.add(mockCoordinatorClient);
+    mockedStaticRssShuffleUtils.when(() ->
+        RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
+    DelegationRssShuffleManager delegationRssShuffleManager;
+
+    SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_ACCESS_ID_KEY, "mockKey");
+    conf.set("mockKey", "value");
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "false");
+
+    // fall back to SortShuffleManager in driver
+    assertCreateSortShuffleManager(conf);
+
+    // No fall back in executor
+    conf.set(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER, "true");
+    try {
+      new DelegationRssShuffleManager(conf, false);
+    } catch (NoSuchElementException e) {
+      assertTrue(e.getMessage().startsWith("spark.rss.coordinator.quorum"));
+    }
+  }
+
+  private DelegationRssShuffleManager assertCreateSortShuffleManager(SparkConf conf) throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    return delegationRssShuffleManager;
+  }
+
+  private DelegationRssShuffleManager assertCreateRssShuffleManager(SparkConf conf) throws Exception {
+    DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
+    assertFalse(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
+    assertTrue(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
+    assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_USE_RSS_SHUFFLE_MANAGER)));
+    return delegationRssShuffleManager;
+  }
+}

--- a/common/src/main/java/com/tencent/rss/common/util/Constants.java
+++ b/common/src/main/java/com/tencent/rss/common/util/Constants.java
@@ -34,4 +34,6 @@ public class Constants {
   public static long MAX_TASK_ATTEMPT_ID = (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) - 1;
   public static long INVALID_BLOCK_ID = -1L;
   public static final String KEY_SPLIT_CHAR = "/";
+  public static final String COMMON_SUCCESS_MESSAGE = "SUCCESS";
+  public static final String SORT_SHUFFLE_MANAGER_NAME = "org.apache.spark.shuffle.sort.SortShuffleManager";
 }

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
@@ -59,7 +59,7 @@ public class AccessCandidatesChecker implements AccessChecker {
   public AccessCheckResult check(AccessInfo accessInfo) {
     String accessId = accessInfo.getAccessId().trim();
     if (!candidates.get().contains(accessId)) {
-      String msg = String.format("Reject accessInfo[%s] accessId[%s] access request.", accessInfo, accessId);
+      String msg = String.format("Denied by AccessCandidatesChecker, accessInfo[%s].", accessInfo);
       LOG.debug("Candidates is {}, {}", candidates.get(), msg);
       return new AccessCheckResult(false, msg);
     }

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
@@ -34,6 +34,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.util.Constants;
+
 /**
  * AccessCandidatesChecker maintain a list of candidate access id and update it periodically,
  * it checks the access id in the access request and reject if the id is not in the candidate list.
@@ -64,7 +66,7 @@ public class AccessCandidatesChecker implements AccessChecker {
       return new AccessCheckResult(false, msg);
     }
 
-    return new AccessCheckResult(true, "SUCCESS");
+    return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);
   }
 
   public void close() {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
@@ -60,11 +60,11 @@ public class AccessCandidatesChecker implements AccessChecker {
     String accessId = accessInfo.getAccessId().trim();
     if (!candidates.get().contains(accessId)) {
       String msg = String.format("Reject accessInfo[%s] accessId[%s] access request.", accessInfo, accessId);
-      LOG.debug(msg);
+      LOG.debug("Candidates is {}, {}", candidates.get(), msg);
       return new AccessCheckResult(false, msg);
     }
 
-    return new AccessCheckResult(true, "");
+    return new AccessCheckResult(true, "SUCCESS");
   }
 
   public void close() {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessClusterLoadChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessClusterLoadChecker.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.util.Constants;
+
 /**
  * AccessClusterLoadChecker use the cluster load metrics including memory and healthy to
  * filter and count available nodes numbers and reject if the number do not reach the threshold.
@@ -35,7 +37,6 @@ public class AccessClusterLoadChecker implements AccessChecker {
   private final ClusterManager clusterManager;
   private final double memoryPercentThreshold;
   private final int availableServerNumThreshold;
-  private static final String SUCCESS_MESSAGE = "SUCCESS";
 
   public AccessClusterLoadChecker(AccessManager accessManager) {
     clusterManager = accessManager.getClusterManager();
@@ -51,7 +52,7 @@ public class AccessClusterLoadChecker implements AccessChecker {
     List<ServerNode> servers = clusterManager.getServerList(tags);
     int size = (int) servers.stream().filter(ServerNode::isHealthy).filter(this::checkMemory).count();
     if (size >= availableServerNumThreshold) {
-      return new AccessCheckResult(true, SUCCESS_MESSAGE);
+      return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);
     } else {
       String msg = String.format("Denied by AccessClusterLoadChecker accessInfo[%s], "
               + "total %s nodes, %s available nodes, "

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessClusterLoadChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessClusterLoadChecker.java
@@ -35,6 +35,7 @@ public class AccessClusterLoadChecker implements AccessChecker {
   private final ClusterManager clusterManager;
   private final double memoryPercentThreshold;
   private final int availableServerNumThreshold;
+  private static final String SUCCESS_MESSAGE = "SUCCESS";
 
   public AccessClusterLoadChecker(AccessManager accessManager) {
     clusterManager = accessManager.getClusterManager();
@@ -50,9 +51,10 @@ public class AccessClusterLoadChecker implements AccessChecker {
     List<ServerNode> servers = clusterManager.getServerList(tags);
     int size = (int) servers.stream().filter(ServerNode::isHealthy).filter(this::checkMemory).count();
     if (size >= availableServerNumThreshold) {
-      return new AccessCheckResult(true, "SUCCESS");
+      return new AccessCheckResult(true, SUCCESS_MESSAGE);
     } else {
-      String msg = String.format("%s cluster load check failed total %s nodes, %s available nodes, "
+      String msg = String.format("Denied by AccessClusterLoadChecker accessInfo[%s], "
+              + "total %s nodes, %s available nodes, "
               + "memory percent threshold %s, available num threshold %s.",
           accessInfo, servers.size(), size, memoryPercentThreshold, availableServerNumThreshold);
       LOG.warn(msg);

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.common.util.RssUtils;
 
 public class AccessManager {
@@ -62,7 +63,7 @@ public class AccessManager {
       }
     }
 
-    return new AccessCheckResult(true, "SUCCESS");
+    return new AccessCheckResult(true, Constants.COMMON_SUCCESS_MESSAGE);
   }
 
   public CoordinatorConf getCoordinatorConf() {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
@@ -62,7 +62,7 @@ public class AccessManager {
       }
     }
 
-    return new AccessCheckResult(true, "");
+    return new AccessCheckResult(true, "SUCCESS");
   }
 
   public CoordinatorConf getCoordinatorConf() {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -66,7 +66,8 @@ public class CoordinatorConf extends RssBaseConf {
   public static final ConfigOption<String> COORDINATOR_ACCESS_CHECKERS = ConfigOptions
       .key("rss.coordinator.access.checkers")
       .stringType()
-      .noDefaultValue()
+      .defaultValue("com.tencent.rss.coordinator.AccessCandidatesChecker,"
+          + "com.tencent.rss.coordinator.AccessClusterLoadChecker")
       .withDescription("Access checkers");
   public static final ConfigOption<Integer> COORDINATOR_ACCESS_CANDIDATES_UPDATE_INTERVAL_SEC = ConfigOptions
       .key("rss.coordinator.access.candidates.update.interval.sec")

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -66,8 +66,7 @@ public class CoordinatorConf extends RssBaseConf {
   public static final ConfigOption<String> COORDINATOR_ACCESS_CHECKERS = ConfigOptions
       .key("rss.coordinator.access.checkers")
       .stringType()
-      .defaultValue("com.tencent.rss.coordinator.AccessCandidatesChecker,"
-          + "com.tencent.rss.coordinator.AccessClusterLoadChecker")
+      .defaultValue("com.tencent.rss.coordinator.AccessClusterLoadChecker")
       .withDescription("Access checkers");
   public static final ConfigOption<Integer> COORDINATOR_ACCESS_CANDIDATES_UPDATE_INTERVAL_SEC = ConfigOptions
       .key("rss.coordinator.access.candidates.update.interval.sec")

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
@@ -1,0 +1,105 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.factory.CoordinatorClientFactory;
+import com.tencent.rss.client.request.RssAccessClusterRequest;
+import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
+import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServer;
+import com.tencent.rss.server.ShuffleServerConf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AccessClusterTest extends CoordinatorTestBase {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void test() throws Exception {
+    File cfgFile = tmpFolder.newFile();
+    FileWriter fileWriter = new FileWriter(cfgFile);
+    PrintWriter printWriter = new PrintWriter(fileWriter);
+    printWriter.println("9527");
+    printWriter.println(" 135 ");
+    printWriter.println("2 ");
+    printWriter.flush();
+    printWriter.close();
+
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setInteger("rss.coordinator.access.loadChecker.serverNum.threshold", 2);
+    coordinatorConf.setString("rss.coordinator.access.candidates.path", cfgFile.getAbsolutePath());
+    createCoordinatorServer(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createShuffleServer(shuffleServerConf);
+    startServers();
+
+    Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
+    String accessId = "111111";
+    RssAccessClusterRequest request = new RssAccessClusterRequest(
+        accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000);
+    RssAccessClusterResponse response = coordinatorClient.accessCluster(request);
+    assertEquals(ResponseStatusCode.ACCESS_DENIED, response.getStatusCode());
+    assertTrue(response.getMessage().startsWith("Denied by AccessCandidatesChecker"));
+
+    accessId = "135";
+    request = new RssAccessClusterRequest(
+        accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000);
+    response = coordinatorClient.accessCluster(request);
+    assertEquals(ResponseStatusCode.ACCESS_DENIED, response.getStatusCode());
+    assertTrue(response.getMessage().startsWith("Denied by AccessClusterLoadChecker"));
+
+    shuffleServerConf.setInteger("rss.rpc.server.port", SHUFFLE_SERVER_PORT + 2);
+    shuffleServerConf.setInteger("rss.jetty.http.port", 18082);
+    ShuffleServer shuffleServer = new ShuffleServer(shuffleServerConf);
+    shuffleServer.start();
+    Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
+
+    CoordinatorClient client = new CoordinatorClientFactory("GRPC")
+        .createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1 + 13);
+    request = new RssAccessClusterRequest(
+        accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000);
+    response = client.accessCluster(request);
+    assertEquals(ResponseStatusCode.INTERNAL_ERROR, response.getStatusCode());
+    assertTrue(response.getMessage().startsWith("UNAVAILABLE: io exception"));
+
+    request = new RssAccessClusterRequest(
+        accessId, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION), 2000);
+    response = coordinatorClient.accessCluster(request);
+    assertEquals(ResponseStatusCode.SUCCESS, response.getStatusCode());
+    assertTrue(response.getMessage().startsWith("SUCCESS"));
+    shuffleServer.stopServer();
+  }
+}
+

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
@@ -59,6 +59,9 @@ public class AccessClusterTest extends CoordinatorTestBase {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setInteger("rss.coordinator.access.loadChecker.serverNum.threshold", 2);
     coordinatorConf.setString("rss.coordinator.access.candidates.path", cfgFile.getAbsolutePath());
+    coordinatorConf.setString(
+        "rss.coordinator.access.checkers",
+        "com.tencent.rss.coordinator.AccessCandidatesChecker,com.tencent.rss.coordinator.AccessClusterLoadChecker");
     createCoordinatorServer(coordinatorConf);
 
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
@@ -38,6 +38,9 @@ public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
     final String candidates = Objects.requireNonNull(
         SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
     CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setString(
+        CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
+        "com.tencent.rss.coordinator.AccessCandidatesChecker,com.tencent.rss.coordinator.AccessClusterLoadChecker");
     coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidates);
     coordinatorConf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, 5000L);
     coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_SERVER_NUM_THRESHOLD, 1);

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
@@ -1,0 +1,74 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.io.File;
+
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.storage.util.StorageType;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssClientConfig;
+import org.junit.BeforeClass;
+
+public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
+
+  @BeforeClass
+  public static void setupServers() throws Exception {
+    final String candidates = Objects.requireNonNull(
+        SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidates);
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, 5000L);
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_SERVER_NUM_THRESHOLD, 1);
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    shuffleServerConf.set(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL, 1000L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 4000L);
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    File dataDir1 = new File(tmpDir, "data1");
+    File dataDir2 = new File(tmpDir, "data2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    shuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
+    createShuffleServer(shuffleServerConf);
+    startServers();
+    Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void updateRssStorage(SparkConf sparkConf) {
+    sparkConf.set(RssClientConfig.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE.name());
+    sparkConf.set(RssClientConfig.RSS_ACCESS_ID, "test_access_id");
+    sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.DelegationRssShuffleManager");
+
+  }
+
+  @Override
+  public void checkShuffleData() throws Exception {
+  }
+
+}
+

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
@@ -38,6 +38,9 @@ public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
     final String candidates = Objects.requireNonNull(
         SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
     CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setString(
+        CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
+        "com.tencent.rss.coordinator.AccessCandidatesChecker,com.tencent.rss.coordinator.AccessClusterLoadChecker");
     coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidates);
     coordinatorConf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, 5000L);
     coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_SERVER_NUM_THRESHOLD, 1);

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
@@ -1,0 +1,72 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.io.File;
+
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.storage.util.StorageType;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssClientConfig;
+import org.junit.BeforeClass;
+
+public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
+
+  @BeforeClass
+  public static void setupServers() throws Exception {
+    final String candidates = Objects.requireNonNull(
+        SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidates);
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, 5000L);
+    coordinatorConf.set(CoordinatorConf.COORDINATOR_ACCESS_LOADCHECKER_SERVER_NUM_THRESHOLD, 1);
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    shuffleServerConf.set(ShuffleServerConf.SERVER_HEARTBEAT_INTERVAL, 1000L);
+    shuffleServerConf.set(ShuffleServerConf.SERVER_APP_EXPIRED_WITHOUT_HEARTBEAT, 4000L);
+    File tmpDir = Files.createTempDir();
+    tmpDir.deleteOnExit();
+    File dataDir1 = new File(tmpDir, "data1");
+    File dataDir2 = new File(tmpDir, "data2");
+    String basePath = dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath();
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
+    shuffleServerConf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, basePath);
+    shuffleServerConf.setString(ShuffleServerConf.SERVER_BUFFER_CAPACITY.key(), "512mb");
+    createShuffleServer(shuffleServerConf);
+    startServers();
+    Uninterruptibles.sleepUninterruptibly(1L, TimeUnit.SECONDS);
+  }
+
+  @Override
+  public void updateRssStorage(SparkConf sparkConf) {
+    sparkConf.set(RssClientConfig.RSS_STORAGE_TYPE, StorageType.MEMORY_LOCALFILE.name());
+    sparkConf.set(RssClientConfig.RSS_ACCESS_ID, "wrong_id");
+    sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.DelegationRssShuffleManager");
+  }
+
+  @Override
+  public void checkShuffleData() throws Exception {
+  }
+
+}

--- a/integration-test/spark-common/src/test/resources/candidates
+++ b/integration-test/spark-common/src/test/resources/candidates
@@ -1,0 +1,19 @@
+#
+# Tencent is pleased to support the open source community by making
+# Firestorm-Spark remote shuffle server available.
+#
+# Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at
+#
+# https://opensource.org/licenses/Apache-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations under the License.
+#
+
+test_access_id

--- a/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
@@ -18,9 +18,11 @@
 
 package com.tencent.rss.client.api;
 
+import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
@@ -32,6 +34,8 @@ public interface CoordinatorClient {
   RssSendHeartBeatResponse sendHeartBeat(RssSendHeartBeatRequest request);
 
   RssGetShuffleAssignmentsResponse getShuffleAssignments(RssGetShuffleAssignmentsRequest request);
+
+  RssAccessClusterResponse accessCluster(RssAccessClusterRequest request);
 
   String getDesc();
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -246,9 +246,8 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
     try {
       rpcResponse = blockingStub
           .withDeadlineAfter(request.getTimeoutMs(), TimeUnit.MILLISECONDS).accessCluster(rpcRequest);
-
-    } catch (StatusRuntimeException e) {
-       return new RssAccessClusterResponse(ResponseStatusCode.ACCESS_DENIED, e.getMessage());
+    } catch (Exception e) {
+      return new RssAccessClusterResponse(ResponseStatusCode.INTERNAL_ERROR, e.getMessage());
     }
 
     RssAccessClusterResponse response;

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -35,10 +35,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.CoordinatorClient;
+import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
 import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
@@ -48,6 +50,8 @@ import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.proto.CoordinatorServerGrpc;
 import com.tencent.rss.proto.CoordinatorServerGrpc.CoordinatorServerBlockingStub;
 import com.tencent.rss.proto.RssProtos;
+import com.tencent.rss.proto.RssProtos.AccessClusterRequest;
+import com.tencent.rss.proto.RssProtos.AccessClusterResponse;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatRequest;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatResponse;
 import com.tencent.rss.proto.RssProtos.GetShuffleAssignmentsResponse;
@@ -188,7 +192,6 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
     AppHeartBeatRequest rpcRequest = AppHeartBeatRequest.newBuilder().setAppId(request.getAppId()).build();
     AppHeartBeatResponse rpcResponse = blockingStub
         .withDeadlineAfter(request.getTimeoutMs(), TimeUnit.MILLISECONDS).appHeartbeat(rpcRequest);
-
     RssAppHeartBeatResponse response;
     StatusCode statusCode = rpcResponse.getStatus();
     switch (statusCode) {
@@ -227,6 +230,35 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
         break;
       default:
         response = new RssGetShuffleAssignmentsResponse(ResponseStatusCode.INTERNAL_ERROR);
+    }
+
+    return response;
+  }
+
+  @Override
+  public RssAccessClusterResponse accessCluster(RssAccessClusterRequest request) {
+    AccessClusterRequest rpcRequest = AccessClusterRequest
+        .newBuilder()
+        .setAccessId(request.getAccessId())
+        .addAllTags(request.getTags())
+        .build();
+    AccessClusterResponse rpcResponse;
+    try {
+      rpcResponse = blockingStub
+          .withDeadlineAfter(request.getTimeoutMs(), TimeUnit.MILLISECONDS).accessCluster(rpcRequest);
+
+    } catch (StatusRuntimeException e) {
+       return new RssAccessClusterResponse(ResponseStatusCode.ACCESS_DENIED, e.getMessage());
+    }
+
+    RssAccessClusterResponse response;
+    StatusCode statusCode = rpcResponse.getStatus();
+    switch (statusCode) {
+      case SUCCESS:
+        response = new RssAccessClusterResponse(ResponseStatusCode.SUCCESS, rpcResponse.getRetMsg());
+        break;
+      default:
+        response = new RssAccessClusterResponse(ResponseStatusCode.ACCESS_DENIED, rpcResponse.getRetMsg());
     }
 
     return response;

--- a/internal-client/src/main/java/com/tencent/rss/client/request/RssAccessClusterRequest.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/request/RssAccessClusterRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.request;
+
+import java.util.Set;
+
+public class RssAccessClusterRequest {
+
+  private final String accessId;
+  private final Set<String> tags;
+  private final int timeoutMs;
+
+  public RssAccessClusterRequest(String accessId, Set<String> tags, int timeoutMs) {
+    this.accessId = accessId;
+    this.tags = tags;
+    this.timeoutMs = timeoutMs;
+  }
+
+  public String getAccessId() {
+    return accessId;
+  }
+
+  public Set<String> getTags() {
+    return tags;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+}

--- a/internal-client/src/main/java/com/tencent/rss/client/response/ResponseStatusCode.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/ResponseStatusCode.java
@@ -26,5 +26,6 @@ public enum ResponseStatusCode {
   NO_REGISTER,
   NO_PARTITION,
   INTERNAL_ERROR,
-  TIMEOUT
+  TIMEOUT,
+  ACCESS_DENIED
 }

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssAccessClusterResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssAccessClusterResponse.java
@@ -1,8 +1,8 @@
 /*
  * Tencent is pleased to support the open source community by making
- * Firestorm-Spark remote shuffle server available. 
+ * Firestorm-Spark remote shuffle server available.
  *
- * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved. 
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -18,26 +18,9 @@
 
 package com.tencent.rss.client.response;
 
-public class ClientResponse {
+public class RssAccessClusterResponse extends ClientResponse {
 
-  private final ResponseStatusCode statusCode;
-  private final String message;
-
-  public ClientResponse(ResponseStatusCode statusCode) {
-    this.statusCode = statusCode;
-    this.message = "";
-  }
-
-  public ClientResponse(ResponseStatusCode statusCode, String message) {
-    this.statusCode = statusCode;
-    this.message = message;
-  }
-
-  public ResponseStatusCode getStatusCode() {
-    return statusCode;
-  }
-
-  public String getMessage() {
-    return message;
+  public RssAccessClusterResponse(ResponseStatusCode statusCode, String messge) {
+    super(statusCode, messge);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Add a delegation shuffle manager
- choose the actual shuffle manager  (sort or rss)

### Why are the changes needed?
This pr is related to #61, which add access client.

### Does this PR introduce _any_ user-facing change?
Yes, client need to config `spark.shuffle.manager` explicitly and add the following config , `spark.rss.accessInfoKey` it specifies which is the config key of the accessInfo and then add the config duration submition.


### How was this patch tested?
UT and system test