### PR TITLE
[Bug] Support to read incomplete index data

### DIFF
--- a/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
@@ -120,5 +120,11 @@ public class RssUtilsTest {
     assertEquals(90, shuffleDataSegments.get(2).getOffset());
     assertEquals(6, shuffleDataSegments.get(2).getLength());
     assertEquals(1, shuffleDataSegments.get(2).getBufferSegments().size());
+
+    ByteBuffer incompleteByteBuffer = ByteBuffer.allocate(12);
+    incompleteByteBuffer.putLong(1L);
+    incompleteByteBuffer.putInt(2);
+    data = incompleteByteBuffer.array();
+    assertTrue(RssUtils.transIndexDataToSegments(new ShuffleIndexResult(data), readBufferSize).isEmpty());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we encounter the incomplete index, we just stop reading, not throw an exception.

### Why are the changes needed?
When we use the storageType MEMORY_HDFS, MEMORY_LOCALFILE_HDFS, after we read data from memory, the data may be flushed to HDFS. So we could read incomplete index data.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New ut
