### PR TITLE
[Bug] Replace parallelStream with stream except for the method `sendDataAsync`

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -213,7 +213,7 @@ public class RssShuffleManager implements ShuffleManager {
     LOG.info("Start to register shuffleId[" + shuffleId + "]");
     long start = System.currentTimeMillis();
     serverToPartitionRanges.entrySet()
-        .parallelStream()
+        .stream()
         .forEach(entry -> {
           shuffleWriteClient.registerShuffle(
               entry.getKey(), appId, shuffleId, entry.getValue());
@@ -336,7 +336,7 @@ public class RssShuffleManager implements ShuffleManager {
   private Roaring64NavigableMap getExpectedTasks(int shuffleId, int startPartition, int endPartition) {
     Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf();
     // In 2.3, getMapSizesByExecutorId returns Seq, while it returns Iterator in 2.4,
-    // so we use toIterator() to supoort Spark 2.3 & 2.4
+    // so we use toIterator() to support Spark 2.3 & 2.4
     Iterator<Tuple2<BlockManagerId, Seq<Tuple2<BlockId, Object>>>> mapStatusIter =
         SparkEnv.get().mapOutputTracker().getMapSizesByExecutorId(shuffleId, startPartition, endPartition)
             .toIterator();

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/writer/RssShuffleWriter.java
@@ -186,7 +186,7 @@ public class RssShuffleWriter<K, V, C> extends ShuffleWriter<K, V> {
    */
   private void processShuffleBlockInfos(List<ShuffleBlockInfo> shuffleBlockInfoList, Set<Long> blockIds) {
     if (shuffleBlockInfoList != null && !shuffleBlockInfoList.isEmpty()) {
-      shuffleBlockInfoList.parallelStream().forEach(sbi -> {
+      shuffleBlockInfoList.stream().forEach(sbi -> {
         long blockId = sbi.getBlockId();
         // add blockId to set, check if it is send later
         blockIds.add(blockId);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -503,7 +503,7 @@ public class RssShuffleManager implements ShuffleManager {
     LOG.info("Start to register shuffleId[" + shuffleId + "]");
     long start = System.currentTimeMillis();
     Set<Map.Entry<ShuffleServerInfo, List<PartitionRange>>> entries = serverToPartitionRanges.entrySet();
-    entries.parallelStream()
+    entries.stream()
         .forEach(entry -> {
           shuffleWriteClient.registerShuffle(
               entry.getKey(),

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -244,7 +244,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
       final int endPartition = partitionRangeAssignment.getEndPartition();
       final List<ShuffleServerInfo> shuffleServerInfos = partitionRangeAssignment
           .getServerList()
-          .parallelStream()
+          .stream()
           .map(ss -> new ShuffleServerInfo(ss.getId(), ss.getIp(), ss.getPort()))
           .collect(Collectors.toList());
       for (int i = startPartition; i <= endPartition; i++) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Replace parallelStream with stream except for the method `sendDataAsync`

### Why are the changes needed?
In our production environment, we found some heartbeats were blocked when we use parallelStream. Why don't replace `sendDataAsync`? Because we wanna release a new version, we don't wanna to involve changes that may influence the performance. Lately, we may replace `sendDataAsync`.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
GA passes.
