### PR TITLE
[Improvement] Add detailed logging for read client

### DIFF
--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -155,7 +155,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
         // mark block as processed
         processedBlockIds.addLong(bs.getBlockId());
         pendingBlockIds.removeLong(bs.getBlockId());
-        // only report the statistics of necessary blocks
+        // only update the statistics of necessary blocks
         clientReadHandler.updateConsumedBlockInfo(bs);
         break;
       }

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -156,7 +156,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
         processedBlockIds.addLong(bs.getBlockId());
         pendingBlockIds.removeLong(bs.getBlockId());
         // only report the statistics of necessary blocks
-        clientReadHandler.feedbackConsumedBlock(bs);
+        clientReadHandler.updateConsumedBlockInfo(bs);
         break;
       }
       // mark block as processed
@@ -235,6 +235,6 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     LOG.info("Metrics for shuffleId[" + shuffleId + "], partitionId[" + partitionId + "]"
         + ", read data cost " + readDataTime + " ms, copy data cost " + copyTime
         + " ms, crc check cost " + crcCheckTime + " ms");
-    clientReadHandler.reportConsumedBlockInfo();
+    clientReadHandler.logConsumedBlockInfo();
   }
 }

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -155,6 +155,8 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
         // mark block as processed
         processedBlockIds.addLong(bs.getBlockId());
         pendingBlockIds.removeLong(bs.getBlockId());
+        // only report the statistics of necessary blocks
+        clientReadHandler.feedbackConsumedBlock(bs);
         break;
       }
       // mark block as processed
@@ -233,5 +235,6 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
     LOG.info("Metrics for shuffleId[" + shuffleId + "], partitionId[" + partitionId + "]"
         + ", read data cost " + readDataTime + " ms, copy data cost " + copyTime
         + " ms, crc check cost " + crcCheckTime + " ms");
+    clientReadHandler.reportConsumedBlockInfo();
   }
 }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -39,7 +39,10 @@ import com.tencent.rss.storage.handler.impl.LocalFileQuorumClientReadHandler;
 import com.tencent.rss.storage.handler.impl.MemoryQuorumClientReadHandler;
 import com.tencent.rss.storage.util.StorageType;
 
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.io.File;

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -136,7 +136,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     processBlockIds.addLong(blocks.get(0).getBlockId());
     processBlockIds.addLong(blocks.get(1).getBlockId());
     processBlockIds.addLong(blocks.get(2).getBlockId());
-    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.feedbackConsumedBlock(bs));
+    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.updateConsumedBlockInfo(bs));
 
     // send data to shuffle server, and wait until flush to LocalFile
     List<ShuffleBlockInfo> blocks2 = createShuffleBlockList(
@@ -160,7 +160,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     validateResult(expectedData, sdr);
     processBlockIds.addLong(blocks2.get(0).getBlockId());
     processBlockIds.addLong(blocks2.get(1).getBlockId());
-    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.feedbackConsumedBlock(bs));
+    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.updateConsumedBlockInfo(bs));
 
     // read the 3-th segment from localFile
     sdr  = composedClientReadHandler.readShuffleData();
@@ -168,7 +168,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     expectedData.put(blocks2.get(2).getBlockId(), blocks2.get(2).getData());
     validateResult(expectedData, sdr);
     processBlockIds.addLong(blocks2.get(2).getBlockId());
-    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.feedbackConsumedBlock(bs));
+    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.updateConsumedBlockInfo(bs));
 
     // send data to shuffle server, and wait until flush to HDFS
     List<ShuffleBlockInfo> blocks3 = createShuffleBlockList(
@@ -191,7 +191,7 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     validateResult(expectedData, sdr);
     processBlockIds.addLong(blocks3.get(0).getBlockId());
     processBlockIds.addLong(blocks3.get(1).getBlockId());
-    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.feedbackConsumedBlock(bs));
+    sdr.getBufferSegments().forEach(bs -> composedClientReadHandler.updateConsumedBlockInfo(bs));
 
     // all segments are processed
     sdr  = composedClientReadHandler.readShuffleData();

--- a/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
@@ -29,12 +29,11 @@ public interface ClientReadHandler {
 
   // The handler only returns the segment,
   // but does not know the actually consumed blocks,
-  // so the consumer should feedback this information.
+  // so the consumer should let the handler update statistics.
   // Each type of handler can design their rules.
-  void feedbackConsumedBlock(BufferSegment bs);
+  void updateConsumedBlockInfo(BufferSegment bs);
 
-  // Display the debug information
-  void reportConsumedBlockInfo();
-
+  // Display the statistics of consumed blocks
+  void logConsumedBlockInfo();
 
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
@@ -27,7 +27,14 @@ public interface ClientReadHandler {
 
   void close();
 
+  // The handler only returns the segment,
+  // but does not know the actually consumed blocks,
+  // so the consumer should feedback this information.
+  // Each type of handler can design their rules.
   void feedbackConsumedBlock(BufferSegment bs);
 
+  // Display the debug information
   void reportConsumedBlockInfo();
+
+
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/api/ClientReadHandler.java
@@ -18,6 +18,7 @@
 
 package com.tencent.rss.storage.handler.api;
 
+import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 
 public interface ClientReadHandler {
@@ -25,4 +26,8 @@ public interface ClientReadHandler {
   ShuffleDataResult readShuffleData();
 
   void close();
+
+  void feedbackConsumedBlock(BufferSegment bs);
+
+  void reportConsumedBlockInfo();
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractClientReadHandler.java
@@ -18,6 +18,7 @@
 
 package com.tencent.rss.storage.handler.impl;
 
+import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
 
@@ -35,5 +36,13 @@ public abstract class AbstractClientReadHandler implements ClientReadHandler {
 
   @Override
   public void close() {
+  }
+
+  @Override
+  public void feedbackConsumedBlock(BufferSegment bs) {
+  }
+
+  @Override
+  public void reportConsumedBlockInfo() {
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/AbstractClientReadHandler.java
@@ -39,10 +39,10 @@ public abstract class AbstractClientReadHandler implements ClientReadHandler {
   }
 
   @Override
-  public void feedbackConsumedBlock(BufferSegment bs) {
+  public void updateConsumedBlockInfo(BufferSegment bs) {
   }
 
   @Override
-  public void reportConsumedBlockInfo() {
+  public void logConsumedBlockInfo() {
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
@@ -20,9 +20,11 @@ package com.tencent.rss.storage.handler.impl;
 
 import java.util.concurrent.Callable;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
 
@@ -45,6 +47,21 @@ public class ComposedClientReadHandler implements ClientReadHandler {
   private static final int FROZEN = 4;
   private int currentHandler = HOT;
   private final int topLevelOfHandler;
+
+  private long hotReadBlockNum = 0L;
+  private long warmReadBlockNum = 0L;
+  private long coldReadBlockNum = 0L;
+  private long frozenReadBlockNum = 0L;
+
+  private long hotReadLength = 0L;
+  private long warmReadLength = 0L;
+  private long coldReadLength = 0L;
+  private long frozenReadLength = 0L;
+
+  private long hotReadUncompressLength = 0L;
+  private long warmReadUncompressLength = 0L;
+  private long coldReadUncompressLength = 0L;
+  private long frozenReadUncompressLength = 0L;
 
   public ComposedClientReadHandler(ClientReadHandler... handlers) {
     topLevelOfHandler = handlers.length;
@@ -173,4 +190,72 @@ public class ComposedClientReadHandler implements ClientReadHandler {
       frozenDataReadHandler.close();
     }
   }
+
+  @Override
+  public void feedbackConsumedBlock(BufferSegment bs) {
+    if (bs == null) {
+      return;
+    }
+    switch (currentHandler) {
+      case HOT:
+        hotReadBlockNum++;
+        hotReadLength += bs.getLength();
+        hotReadUncompressLength += bs.getUncompressLength();
+        break;
+      case WARM:
+        warmReadBlockNum++;
+        warmReadLength += bs.getLength();
+        warmReadUncompressLength += bs.getUncompressLength();
+        break;
+      case COLD:
+        coldReadBlockNum++;
+        coldReadLength += bs.getLength();
+        coldReadUncompressLength += bs.getUncompressLength();
+        break;
+      case FROZEN:
+        frozenReadBlockNum++;
+        frozenReadLength += bs.getLength();
+        frozenReadUncompressLength += bs.getUncompressLength();
+        break;
+      default:
+        break;
+    }
+  }
+
+  @Override
+  public void reportConsumedBlockInfo() {
+    LOG.info(getReadBlokNumInfo());
+    LOG.info(getReadLengthInfo());
+    LOG.info(getReadUncompressLengthInfo());
+  }
+
+  @VisibleForTesting
+  public String getReadBlokNumInfo() {
+    long totalBlockNum = hotReadBlockNum + warmReadBlockNum
+      + coldReadBlockNum + frozenReadBlockNum;
+    return "Client read " + totalBlockNum + " blocks ["
+      + " hot:" + hotReadBlockNum + " warm:" + warmReadBlockNum
+      + " cold:" + coldReadBlockNum + " frozen:" + frozenReadBlockNum + " ]";
+  }
+
+  @VisibleForTesting
+  public String getReadLengthInfo() {
+    long totalReadLength = hotReadLength + warmReadLength
+      + coldReadLength + frozenReadLength;
+    return "Client read " + totalReadLength + " bytes ["
+      + " hot:" + hotReadLength + " warm:" + warmReadLength
+      + " cold:" + coldReadLength + " frozen:" + frozenReadLength + " ]";
+  }
+
+  @VisibleForTesting
+  public String getReadUncompressLengthInfo() {
+    long totalReadUncompressLength = hotReadUncompressLength + warmReadUncompressLength
+      + coldReadUncompressLength + frozenReadUncompressLength;
+    return "Client read " + totalReadUncompressLength + " uncompressed bytes ["
+      + " hot:" + hotReadUncompressLength
+      + " warm:" + warmReadUncompressLength
+      + " cold:" + coldReadUncompressLength
+      + " frozen:" + frozenReadUncompressLength + " ]";
+  }
+
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/ComposedClientReadHandler.java
@@ -192,7 +192,7 @@ public class ComposedClientReadHandler implements ClientReadHandler {
   }
 
   @Override
-  public void feedbackConsumedBlock(BufferSegment bs) {
+  public void updateConsumedBlockInfo(BufferSegment bs) {
     if (bs == null) {
       return;
     }
@@ -223,7 +223,7 @@ public class ComposedClientReadHandler implements ClientReadHandler {
   }
 
   @Override
-  public void reportConsumedBlockInfo() {
+  public void logConsumedBlockInfo() {
     LOG.info(getReadBlokNumInfo());
     LOG.info(getReadLengthInfo());
     LOG.info(getReadUncompressLengthInfo());

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -168,7 +168,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   }
 
   @Override
-  public void feedbackConsumedBlock(BufferSegment bs) {
+  public void updateConsumedBlockInfo(BufferSegment bs) {
     if (bs == null) {
       return;
     }
@@ -178,7 +178,7 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   }
 
   @Override
-  public void reportConsumedBlockInfo() {
+  public void logConsumedBlockInfo() {
     LOG.info("Client read " + readBlockNum + " blocks,"
         + " bytes:" +  readLength + "  uncompressed bytes:" + readUncompressLength);
   }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandler.java
@@ -31,6 +31,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
@@ -48,6 +49,10 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
   protected final Configuration hadoopConf;
   protected final List<HdfsShuffleReadHandler> readHandlers = Lists.newArrayList();
   private int readHandlerIndex;
+
+  private long readBlockNum = 0L;
+  private long readLength = 0L;
+  private long readUncompressLength = 0L;
 
   public HdfsClientReadHandler(
       String appId,
@@ -160,5 +165,21 @@ public class HdfsClientReadHandler extends AbstractClientReadHandler {
 
   protected int getReadHandlerIndex() {
     return readHandlerIndex;
+  }
+
+  @Override
+  public void feedbackConsumedBlock(BufferSegment bs) {
+    if (bs == null) {
+      return;
+    }
+    readBlockNum++;
+    readLength += bs.getLength();
+    readUncompressLength += bs.getUncompressLength();
+  }
+
+  @Override
+  public void reportConsumedBlockInfo() {
+    LOG.info("Client read " + readBlockNum + " blocks,"
+        + " bytes:" +  readLength + "  uncompressed bytes:" + readUncompressLength);
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileQuorumClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileQuorumClientReadHandler.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.ShuffleServerClient;
+import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.exception.RssException;
 
@@ -34,6 +35,10 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
   private static final Logger LOG = LoggerFactory.getLogger(LocalFileQuorumClientReadHandler.class);
 
   private List<LocalFileClientReadHandler> handlers = Lists.newLinkedList();
+
+  private long readBlockNum = 0L;
+  private long readLength = 0L;
+  private long readUncompressLength = 0L;
 
   public LocalFileQuorumClientReadHandler(
     String appId,
@@ -84,5 +89,21 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
         + shuffleId + "], partitionId[" + partitionId + "]");
     }
     return result;
+  }
+
+  @Override
+  public void feedbackConsumedBlock(BufferSegment bs) {
+    if (bs == null) {
+      return;
+    }
+    readBlockNum++;
+    readLength += bs.getLength();
+    readUncompressLength += bs.getUncompressLength();
+  }
+
+  @Override
+  public void reportConsumedBlockInfo() {
+    LOG.info("Client read " + readBlockNum + " blocks,"
+        + " bytes:" +  readLength + " uncompressed bytes:" + readUncompressLength);
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileQuorumClientReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileQuorumClientReadHandler.java
@@ -92,7 +92,7 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
   }
 
   @Override
-  public void feedbackConsumedBlock(BufferSegment bs) {
+  public void updateConsumedBlockInfo(BufferSegment bs) {
     if (bs == null) {
       return;
     }
@@ -102,7 +102,7 @@ public class LocalFileQuorumClientReadHandler extends AbstractClientReadHandler 
   }
 
   @Override
-  public void reportConsumedBlockInfo() {
+  public void logConsumedBlockInfo() {
     LOG.info("Client read " + readBlockNum + " blocks,"
         + " bytes:" +  readLength + " uncompressed bytes:" + readUncompressLength);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable to report how many blocks and bytes are read by the client.
1. Add two APIs in the interface of ClientReadHandler
   a. void feedbackConsumedBlock(BufferSegment bs);
   b. void reportConsumedBlockInfo();
2. Implements the two APIs in ComposedClientReadHandler.

###  Why are the changes needed?
Without this patch, the client side is difficult to debug.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Add a new UT.