### PR TITLE
[Bug] Exchange the position between `startHeartbeat` and `registerShuffleServers`

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -179,8 +179,8 @@ public class RssShuffleManager implements ShuffleManager {
         partitionNumPerRange, dataReplica, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = response.getPartitionToServers();
 
-    registerShuffleServers(appId, shuffleId, response.getServerToPartitionRanges());
     startHeartbeat();
+    registerShuffleServers(appId, shuffleId, response.getServerToPartitionRanges());
 
     LOG.info("RegisterShuffle with ShuffleId[" + shuffleId + "], partitionNum[" + partitionToServers.size() + "]");
     return new RssShuffleHandle(shuffleId, appId, numMaps, dependency, partitionToServers);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -216,8 +216,8 @@ public class RssShuffleManager implements ShuffleManager {
         Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = response.getPartitionToServers();
 
-    registerShuffleServers(id.get(), shuffleId, response.getServerToPartitionRanges());
     startHeartbeat();
+    registerShuffleServers(id.get(), shuffleId, response.getServerToPartitionRanges());
 
     LOG.info("RegisterShuffle with ShuffleId[" + shuffleId + "], partitionNum[" + partitionToServers.size()
         + "], shuffleServerForResult: " + partitionToServers);


### PR DESCRIPTION
### What changes were proposed in this pull request?
We exchange the position between `startHeartbeat` and `registerShuffleServers`

### Why are the changes needed?
Some register operation will be blocked for long time sometimes. Shuffle server will remove app because of heartbeat timeout.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
GA passed.
