### PR TITLE
[Feature] Enhance the DelegationRssShuffleManager to support hdfs conf file and reset the shuffle manager name

### DIFF
--- a/bin/start-coordinator.sh
+++ b/bin/start-coordinator.sh
@@ -28,13 +28,16 @@ COORDINATOR_HOME="$(
 CONF_FILE="./conf/coordinator.conf "
 MAIN_CLASS="com.tencent.rss.coordinator.CoordinatorServer"
 
+cd $COORDINATOR_HOME
+
 source "${COORDINATOR_HOME}/bin/rss-env.sh"
 source "${COORDINATOR_HOME}/bin/utils.sh"
 
+HADOOP_CONF_DIR=$HADOOP_HOME/etc/hadoop
+HADOOP_DEPENDENCY=$HADOOP_HOME/etc/hadoop:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*
+
 echo "Check process existence"
 is_jvm_process_running $JPS $MAIN_CLASS
-
-cd $COORDINATOR_HOME
 
 JAR_DIR="./jars"
 CLASSPATH=""
@@ -42,6 +45,21 @@ CLASSPATH=""
 for file in $(ls ${JAR_DIR}/coordinator/*.jar 2>/dev/null); do
   CLASSPATH=$CLASSPATH:$file
 done
+
+if [ -z "$HADOOP_HOME" ]; then
+  echo "No env HADOOP_HOME."
+  exit 1
+fi
+
+if [ -z "$HADOOP_CONF_DIR" ]; then
+  echo "No env HADOOP_CONF_DIR."
+  exit 1
+fi
+
+echo "Using Hadoop from $HADOOP_HOME"
+
+CLASSPATH=$CLASSPATH:$HADOOP_CONF_DIR:$HADOOP_DEPENDENCY
+JAVA_LIB_PATH="-Djava.library.path=$HADOOP_HOME/lib/native"
 
 echo "class path is $CLASSPATH"
 

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -71,16 +71,18 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       try {
         shuffleManager = new RssShuffleManager(sparkConf, true);
         sparkConf.set(RssClientConfig.RSS_ENABLED, "true");
+        sparkConf.set("spark.shuffle.manager", RssShuffleManager.class.getCanonicalName());
         LOG.info("Use RssShuffleManager");
         return shuffleManager;
       } catch (Exception exception) {
-        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager");
+        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager {}", exception.getMessage());
       }
     }
 
     try {
       shuffleManager = RssShuffleUtils.loadShuffleManager(Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, true);
       sparkConf.set(RssClientConfig.RSS_ENABLED, "false");
+      sparkConf.set("spark.shuffle.manager", "sort");
       LOG.info("Use SortShuffleManager");
     } catch (Exception e) {
       throw new RssException(e.getMessage());

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import com.google.common.collect.Lists;
+import com.tencent.rss.common.util.Constants;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.junit.AfterClass;
@@ -35,6 +36,7 @@ import com.tencent.rss.client.response.RssAccessClusterResponse;
 
 import static com.tencent.rss.client.response.ResponseStatusCode.ACCESS_DENIED;
 import static com.tencent.rss.client.response.ResponseStatusCode.SUCCESS;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +72,8 @@ public class DelegationRssShuffleManagerTest {
   @Test
   public void testCreateInDriver() throws Exception {
     CoordinatorClient mockCoordinatorClient = mock(CoordinatorClient.class);
-    when(mockCoordinatorClient.accessCluster(any())).thenReturn(new RssAccessClusterResponse(SUCCESS, ""));
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(
+        new RssAccessClusterResponse(SUCCESS, ""));
     List<CoordinatorClient> coordinatorClients = Lists.newArrayList();
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils.when(() ->
@@ -78,12 +81,16 @@ public class DelegationRssShuffleManagerTest {
 
     SparkConf conf = new SparkConf();
     assertCreateSortShuffleManager(conf);
-
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
     assertCreateSortShuffleManager(conf);
-
     conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
     assertCreateRssShuffleManager(conf);
+
+    conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    when(mockCoordinatorClient.accessCluster(any())).thenReturn(
+        new RssAccessClusterResponse(SUCCESS, ""));
+    assertCreateSortShuffleManager(conf);
   }
 
   @Test
@@ -129,7 +136,8 @@ public class DelegationRssShuffleManagerTest {
     DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(conf, true);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
-    assertFalse(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
+    assertFalse(conf.getBoolean(RssClientConfig.RSS_ENABLED, false));
+    assertEquals("sort", conf.get("spark.shuffle.manager"));
     return delegationRssShuffleManager;
   }
 
@@ -138,6 +146,7 @@ public class DelegationRssShuffleManagerTest {
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof SortShuffleManager);
     assertTrue(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
     assertTrue(Boolean.parseBoolean(conf.get(RssClientConfig.RSS_ENABLED)));
+    assertEquals(RssShuffleManager.class.getCanonicalName(), conf.get("spark.shuffle.manager"));
     return delegationRssShuffleManager;
   }
 }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/DelegationRssShuffleManager.java
@@ -71,16 +71,18 @@ public class DelegationRssShuffleManager implements ShuffleManager {
       try {
         shuffleManager = new RssShuffleManager(sparkConf, true);
         sparkConf.set(RssClientConfig.RSS_ENABLED, "true");
+        sparkConf.set("spark.shuffle.manager", RssShuffleManager.class.getCanonicalName());
         LOG.info("Use RssShuffleManager");
         return shuffleManager;
       } catch (Exception exception) {
-        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager");
+        LOG.warn("Fail to create RssShuffleManager, fallback to SortShuffleManager {}", exception.getMessage());
       }
     }
 
     try {
       shuffleManager = RssShuffleUtils.loadShuffleManager(Constants.SORT_SHUFFLE_MANAGER_NAME, sparkConf, true);
       sparkConf.set(RssClientConfig.RSS_ENABLED, "false");
+      sparkConf.set("spark.shuffle.manager", "sort");
       LOG.info("Use SortShuffleManager");
     } catch (Exception e) {
       throw new RssException(e.getMessage());

--- a/coordinator/pom.xml
+++ b/coordinator/pom.xml
@@ -71,6 +71,10 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
     </dependency>

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,19 +37,22 @@ public class AccessManager {
 
   private final CoordinatorConf coordinatorConf;
   private final ClusterManager clusterManager;
+  private final Configuration hadoopConf;
   private List<AccessChecker> accessCheckers = Lists.newArrayList();
 
-  public AccessManager(CoordinatorConf conf, ClusterManager clusterManager) throws RuntimeException {
+  public AccessManager(
+      CoordinatorConf conf, ClusterManager clusterManager, Configuration hadoopConf) throws RuntimeException {
     this.coordinatorConf = conf;
     this.clusterManager = clusterManager;
+    this.hadoopConf = hadoopConf;
     init();
   }
 
   private void init() throws RuntimeException {
     String checkers = coordinatorConf.get(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS);
     if (StringUtils.isEmpty(checkers)) {
-     LOG.warn("Access checkers is empty, will not init any checkers.");
-     return;
+      LOG.warn("Access checkers is empty, will not init any checkers.");
+      return;
     }
 
     String[] names = checkers.trim().split(",");
@@ -76,6 +80,10 @@ public class AccessManager {
 
   public List<AccessChecker> getAccessCheckers() {
     return accessCheckers;
+  }
+
+  public Configuration getHadoopConf() {
+    return hadoopConf;
   }
 
   public void close() throws IOException {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -69,10 +69,10 @@ public class CoordinatorConf extends RssBaseConf {
       .defaultValue("com.tencent.rss.coordinator.AccessClusterLoadChecker")
       .withDescription("Access checkers");
   public static final ConfigOption<Integer> COORDINATOR_ACCESS_CANDIDATES_UPDATE_INTERVAL_SEC = ConfigOptions
-      .key("rss.coordinator.access.candidates.update.interval.sec")
+      .key("rss.coordinator.access.candidates.updateIntervalSec")
       .intType()
       .checkValue(ConfigUtils.positiveIntegerValidator2, "access candidates update interval must be positive")
-      .defaultValue(60)
+      .defaultValue(120)
       .withDescription("Accessed candidates update interval in seconds");
   public static final ConfigOption<String> COORDINATOR_ACCESS_CANDIDATES_PATH = ConfigOptions
       .key("rss.coordinator.access.candidates.path")

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
@@ -21,6 +21,7 @@ package com.tencent.rss.coordinator;
 import java.io.FileNotFoundException;
 
 import io.prometheus.client.CollectorRegistry;
+import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -111,7 +112,7 @@ public class CoordinatorServer {
     AssignmentStrategyFactory assignmentStrategyFactory =
         new AssignmentStrategyFactory(coordinatorConf, clusterManager);
     this.assignmentStrategy = assignmentStrategyFactory.getAssignmentStrategy();
-    this.accessManager = new AccessManager(coordinatorConf, clusterManager);
+    this.accessManager = new AccessManager(coordinatorConf, clusterManager, new Configuration());
 
     jettyServer = new JettyServer(coordinatorConf);
     registerMetrics();

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessClusterLoadCheckerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessClusterLoadCheckerTest.java
@@ -18,17 +18,19 @@
 
 package com.tencent.rss.coordinator;
 
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import com.google.common.collect.Lists;
-import java.util.List;
-import java.util.Objects;
-import org.junit.Test;
 
 public class AccessClusterLoadCheckerTest {
 
@@ -52,7 +54,7 @@ public class AccessClusterLoadCheckerTest {
     CoordinatorConf conf = new CoordinatorConf(filePath);
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessClusterLoadChecker");
-    AccessManager accessManager = new AccessManager(conf, clusterManager);
+    AccessManager accessManager = new AccessManager(conf, clusterManager, new Configuration());
     AccessClusterLoadChecker accessClusterLoadChecker =
         (AccessClusterLoadChecker) accessManager.getAccessCheckers().get(0);
     when(clusterManager.getServerList(any())).thenReturn(serverNodeList);

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessManagerTest.java
@@ -21,6 +21,8 @@ package com.tencent.rss.coordinator;
 import com.google.common.collect.Sets;
 import com.tencent.rss.common.util.Constants;
 import java.util.Random;
+
+import org.apache.hadoop.conf.Configuration;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +42,7 @@ public class AccessManagerTest {
     CoordinatorConf conf = new CoordinatorConf();
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS, " , ");
     try {
-      new AccessManager(conf, null);
+      new AccessManager(conf, null, new Configuration());
     } catch (RuntimeException e) {
       String expectedMessage = "Empty classes";
       assertTrue(e.getMessage().startsWith(expectedMessage));
@@ -48,30 +50,30 @@ public class AccessManagerTest {
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.Dummy,com.tencent.rss.coordinator.AccessManagerTest$MockAccessChecker");
     try {
-      new AccessManager(conf, null);
+      new AccessManager(conf, null, new Configuration());
     } catch (RuntimeException e) {
       String expectedMessage = "java.lang.ClassNotFoundException: com.Dummy";
       assertTrue(e.getMessage().startsWith(expectedMessage));
     }
     // test empty checkers
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS, "");
-    AccessManager accessManager = new AccessManager(conf, null);
+    AccessManager accessManager = new AccessManager(conf, null, new Configuration());
     assertTrue(accessManager.handleAccessRequest(
-        new AccessInfo(String.valueOf(new Random().nextInt()),
-            Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION)))
+            new AccessInfo(String.valueOf(new Random().nextInt()),
+                Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION)))
         .isSuccess());
     accessManager.close();
     // test mock checkers
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessManagerTest$MockAccessCheckerAlwaysTrue,");
-    accessManager = new AccessManager(conf, null);
+    accessManager = new AccessManager(conf, null, new Configuration());
     assertEquals(1, accessManager.getAccessCheckers().size());
     assertTrue(accessManager.handleAccessRequest(new AccessInfo("mock1")).isSuccess());
     assertTrue(accessManager.handleAccessRequest(new AccessInfo("mock2")).isSuccess());
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessManagerTest$MockAccessCheckerAlwaysTrue,"
             + "com.tencent.rss.coordinator.AccessManagerTest$MockAccessCheckerAlwaysFalse");
-    accessManager = new AccessManager(conf, null);
+    accessManager = new AccessManager(conf, null, new Configuration());
     assertEquals(2, accessManager.getAccessCheckers().size());
     assertFalse(accessManager.handleAccessRequest(new AccessInfo("mock1")).isSuccess());
     accessManager.close();

--- a/coordinator/src/test/resources/coordinator.conf
+++ b/coordinator/src/test/resources/coordinator.conf
@@ -25,6 +25,6 @@ rss.jetty.http.port 9526
 rss.coordinator.exclude.nodes.file.path /a/b/c
 rss.coordinator.shuffle.nodes.max 37
 rss.coordinator.server.heartbeat.timeout 123
-rss.coordinator.access.candidates.update.interval.sec 1
+rss.coordinator.access.candidates.updateIntervalSec 1
 rss.coordinator.access.loadChecker.serverNum.threshold 2
 rss.coordinator.access.loadChecker.memory.percentage 20.0


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Enhance the candidates checker to support hdfs
2. Reset the shuffle manager name on the fly


### Why are the changes needed?
It is more feasible to support both local and hdfs and we need to reset shuffle manager name the adaptive ESS when fallback to SortShuffleManager, in which the only the sort shuffle manager is supported.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & system test
