### PR TITLE
[Improvement] Update spark.rss.client.read.buffer.size to avoid JVM humongous alloc…

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -57,8 +57,8 @@ public class RssClientConfig {
   public static String RSS_CLIENT_SEND_SIZE_LIMIT = "spark.rss.client.send.size.limit";
   public static String RSS_CLIENT_SEND_SIZE_LIMIT_DEFAULT_VALUE = "16m";
   public static String RSS_CLIENT_READ_BUFFER_SIZE = "spark.rss.client.read.buffer.size";
-  // When the size of read buffer reaches the half size of JVM region (i.e., 32m),
-  // it will incur  humongous allocation, so we set it to 14m.
+  // When the size of read buffer reaches the half of JVM region (i.e., 32m),
+  // it will incur humongous allocation, so we set it to 14m.
   public static String RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE = "14m";
   public static String RSS_HEARTBEAT_INTERVAL = "spark.rss.heartbeat.interval";
   public static long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -57,7 +57,9 @@ public class RssClientConfig {
   public static String RSS_CLIENT_SEND_SIZE_LIMIT = "spark.rss.client.send.size.limit";
   public static String RSS_CLIENT_SEND_SIZE_LIMIT_DEFAULT_VALUE = "16m";
   public static String RSS_CLIENT_READ_BUFFER_SIZE = "spark.rss.client.read.buffer.size";
-  public static String RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE = "32m";
+  // When the size of read buffer reaches the half size of JVM region (i.e., 32m),
+  // it will incur  humongous allocation, so we set it to 14m.
+  public static String RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE = "14m";
   public static String RSS_HEARTBEAT_INTERVAL = "spark.rss.heartbeat.interval";
   public static long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
   public static String RSS_HEARTBEAT_TIMEOUT = "spark.rss.heartbeat.timeout";


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update spark.rss.client.read.buffer.size  32M -> 14M

### Why are the changes needed?
When the size of read buffer reaches the half size of JVM region (i.e., 32m), it will incur  humongous allocation, so we set it to 14m.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Manually.