### PR TITLE
[Feature] add the dynamic client conf fetching and updating

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -1,8 +1,8 @@
 /*
  * Tencent is pleased to support the open source community by making
- * Firestorm-Spark remote shuffle server available. 
+ * Firestorm-Spark remote shuffle server available.
  *
- * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved. 
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -17,6 +17,10 @@
  */
 
 package org.apache.spark.shuffle;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
 
 public class RssClientConfig {
 
@@ -84,4 +88,8 @@ public class RssClientConfig {
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = 10000;
   public static String RSS_ENABLED = "spark.rss.enabled";
   public static boolean RSS_USE_RSS_SHUFFLE_MANAGER_DEFAULT_VALUE = false;
+  public static String RSS_DYNAMIC_CLIENT_CONF_ENABLED = "spark.rss.dynamicClientConf.enabled";
+  public static boolean RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE = true;
+
+  public static Set<String> RSS_MANDATORY_CLUSTER_CONF = Sets.newHashSet(RSS_STORAGE_TYPE, RSS_BASE_PATH);
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -24,8 +24,11 @@ import java.io.OutputStream;
 import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -40,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.factory.CoordinatorClientFactory;
+import com.tencent.rss.storage.util.StorageType;
 
 public class RssShuffleUtils {
 
@@ -174,5 +178,45 @@ public class RssShuffleUtils {
     String coordinators = sparkConf.get(RssClientConfig.RSS_COORDINATOR_QUORUM);
     CoordinatorClientFactory coordinatorClientFactory = new CoordinatorClientFactory(clientType);
     return coordinatorClientFactory.createCoordinatorClient(coordinators);
+  }
+
+  public static void applyDynamicClientConf(SparkConf sparkConf, Map<String, String> confItems) {
+    if (sparkConf == null) {
+      LOG.warn("Spark conf is null");
+      return;
+    }
+
+    if (confItems == null || confItems.isEmpty()) {
+      LOG.warn("Empty conf items");
+      return;
+    }
+
+    for (Map.Entry<String, String> kv : confItems.entrySet()) {
+      String confKey = kv.getKey();
+      String confVal = kv.getValue();
+      if (!sparkConf.contains(confKey) || RssClientConfig.RSS_MANDATORY_CLUSTER_CONF.contains(confKey)) {
+        LOG.warn("Use conf dynamic conf {} = {}", confKey, confVal);
+        sparkConf.set(confKey, confVal);
+      }
+    }
+  }
+
+  public static final Set<StorageType> STORAGE_TYPE_NEED_NO_PATH =
+      Sets.newHashSet(StorageType.LOCALFILE, StorageType.MEMORY_LOCALFILE);
+
+  public static void validateRssClientConf(SparkConf sparkConf) {
+    String msgFormat = "%s must be set by the client or fetched from coordinators.";
+    if (!sparkConf.contains(RssClientConfig.RSS_STORAGE_TYPE)) {
+      String msg = String.format(msgFormat, "Storage type");
+      LOG.error(msg);
+      throw new IllegalArgumentException(msg);
+    }
+
+    StorageType storageType = StorageType.valueOf(sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE));
+    if (!sparkConf.contains(RssClientConfig.RSS_BASE_PATH) && !STORAGE_TYPE_NEED_NO_PATH.contains(storageType)) {
+      String msg = String.format(msgFormat, "Storage path");
+      LOG.error(msg);
+      throw new IllegalArgumentException(msg);
+    }
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -201,8 +201,9 @@ public class RssShuffleUtils {
     }
   }
 
-  public static final Set<StorageType> STORAGE_TYPE_NEED_NO_PATH =
-      Sets.newHashSet(StorageType.LOCALFILE, StorageType.MEMORY_LOCALFILE);
+  public static final Set<StorageType> getStorageTypeWithoutPath() {
+    return Sets.newHashSet(StorageType.LOCALFILE, StorageType.MEMORY_LOCALFILE);
+  }
 
   public static void validateRssClientConf(SparkConf sparkConf) {
     String msgFormat = "%s must be set by the client or fetched from coordinators.";
@@ -213,7 +214,7 @@ public class RssShuffleUtils {
     }
 
     StorageType storageType = StorageType.valueOf(sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE));
-    if (!sparkConf.contains(RssClientConfig.RSS_BASE_PATH) && !STORAGE_TYPE_NEED_NO_PATH.contains(storageType)) {
+    if (!sparkConf.contains(RssClientConfig.RSS_BASE_PATH) && !getStorageTypeWithoutPath().contains(storageType)) {
       String msg = String.format(msgFormat, "Storage path");
       LOG.error(msg);
       throw new IllegalArgumentException(msg);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -150,6 +150,7 @@ public class RssShuffleManager implements ShuffleManager {
     RssShuffleUtils.validateRssClientConf(sparkConf);
     // External shuffle service is not supported when using remote shuffle service
     sparkConf.set("spark.shuffle.service.enabled", "false");
+    LOG.info("Disable external shuffle service in RssShuffleManager.");
     if (!sparkConf.getBoolean(RssClientConfig.RSS_TEST_FLAG, false)) {
       // for non-driver executor, start a thread for sending shuffle data to shuffle server
       LOG.info("RSS data send thread is starting");

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -138,6 +138,18 @@ public class RssShuffleManager implements ShuffleManager {
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
     registerCoordinator();
+    // fetch client conf and apply them if necessary and disable ESS
+    if (isDriver && sparkConf.getBoolean(
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE)) {
+      Map<String, String> clusterClientConf = shuffleWriteClient.fetchClientConf(
+          sparkConf.getInt(RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
+              RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
+      RssShuffleUtils.applyDynamicClientConf(sparkConf, clusterClientConf);
+    }
+    RssShuffleUtils.validateRssClientConf(sparkConf);
+    // External shuffle service is not supported when using remote shuffle service
+    sparkConf.set("spark.shuffle.service.enabled", "false");
     if (!sparkConf.getBoolean(RssClientConfig.RSS_TEST_FLAG, false)) {
       // for non-driver executor, start a thread for sending shuffle data to shuffle server
       LOG.info("RSS data send thread is starting");
@@ -394,5 +406,10 @@ public class RssShuffleManager implements ShuffleManager {
     taskToSuccessBlockIds.remove(taskId);
     taskToFailedBlockIds.remove(taskId);
     taskToBufferManager.remove(taskId);
+  }
+
+  @VisibleForTesting
+  public SparkConf getSparkConf() {
+    return sparkConf;
   }
 }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 
 import com.google.common.collect.Lists;
 import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.junit.AfterClass;
@@ -66,6 +67,7 @@ public class DelegationRssShuffleManagerTest {
     mockedStaticRssShuffleUtils.when(() ->
         RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
     SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     assertCreateSortShuffleManager(conf);
   }
 
@@ -81,7 +83,9 @@ public class DelegationRssShuffleManagerTest {
 
     SparkConf conf = new SparkConf();
     assertCreateSortShuffleManager(conf);
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     assertCreateSortShuffleManager(conf);
     conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
     assertCreateRssShuffleManager(conf);
@@ -111,9 +115,9 @@ public class DelegationRssShuffleManagerTest {
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils.when(() ->
         RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
-    DelegationRssShuffleManager delegationRssShuffleManager;
 
     SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
     conf.set(RssClientConfig.RSS_ENABLED, "true");
 

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -154,6 +154,7 @@ public class RssShuffleManager implements ShuffleManager {
     RssShuffleUtils.validateRssClientConf(sparkConf);
     // External shuffle service is not supported when using remote shuffle service
     sparkConf.set("spark.shuffle.service.enabled", "false");
+    LOG.info("Disable external shuffle service in RssShuffleManager.");
     taskToSuccessBlockIds = Maps.newConcurrentMap();
     taskToFailedBlockIds = Maps.newConcurrentMap();
     // for non-driver executor, start a thread for sending shuffle data to shuffle server

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -142,6 +142,18 @@ public class RssShuffleManager implements ShuffleManager {
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
     registerCoordinator();
+    // fetch client conf and apply them if necessary and disable ESS
+    if (isDriver && sparkConf.getBoolean(
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE)) {
+      Map<String, String> clusterClientConf = shuffleWriteClient.fetchClientConf(
+          sparkConf.getInt(RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
+              RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
+      RssShuffleUtils.applyDynamicClientConf(sparkConf, clusterClientConf);
+    }
+    RssShuffleUtils.validateRssClientConf(sparkConf);
+    // External shuffle service is not supported when using remote shuffle service
+    sparkConf.set("spark.shuffle.service.enabled", "false");
     taskToSuccessBlockIds = Maps.newConcurrentMap();
     taskToFailedBlockIds = Maps.newConcurrentMap();
     // for non-driver executor, start a thread for sending shuffle data to shuffle server
@@ -519,6 +531,11 @@ public class RssShuffleManager implements ShuffleManager {
     String coordinators = sparkConf.get(RssClientConfig.RSS_COORDINATOR_QUORUM);
     LOG.info("Start Registering coordinators {}", coordinators);
     shuffleWriteClient.registerCoordinators(coordinators);
+  }
+
+  @VisibleForTesting
+  public SparkConf getSparkConf() {
+    return sparkConf;
   }
 
   private synchronized void startHeartbeat() {

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 
 import com.google.common.collect.Lists;
 import com.tencent.rss.common.util.Constants;
+import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
 import org.junit.AfterClass;
@@ -66,6 +67,7 @@ public class DelegationRssShuffleManagerTest {
     mockedStaticRssShuffleUtils.when(() ->
         RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
     SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     assertCreateSortShuffleManager(conf);
   }
 
@@ -81,9 +83,11 @@ public class DelegationRssShuffleManagerTest {
 
     SparkConf conf = new SparkConf();
     assertCreateSortShuffleManager(conf);
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
     assertCreateSortShuffleManager(conf);
     conf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, "m1:8001,m2:8002");
+    conf.set("spark.rss.storage.type", StorageType.LOCALFILE.name());
     assertCreateRssShuffleManager(conf);
 
     conf = new SparkConf();
@@ -111,9 +115,9 @@ public class DelegationRssShuffleManagerTest {
     coordinatorClients.add(mockCoordinatorClient);
     mockedStaticRssShuffleUtils.when(() ->
         RssShuffleUtils.createCoordinatorClients(any())).thenReturn(coordinatorClients);
-    DelegationRssShuffleManager delegationRssShuffleManager;
 
     SparkConf conf = new SparkConf();
+    conf.set(RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED, "false");
     conf.set(RssClientConfig.RSS_ACCESS_ID, "mockId");
     conf.set(RssClientConfig.RSS_ENABLED, "true");
 
@@ -138,7 +142,6 @@ public class DelegationRssShuffleManagerTest {
     assertFalse(delegationRssShuffleManager.getDelegate() instanceof RssShuffleManager);
     assertFalse(conf.getBoolean(RssClientConfig.RSS_ENABLED, false));
     assertEquals("sort", conf.get("spark.shuffle.manager"));
-
     return delegationRssShuffleManager;
   }
 

--- a/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
@@ -43,6 +43,8 @@ public interface ShuffleWriteClient {
 
   void registerCoordinators(String coordinators);
 
+  Map<String, String> fetchClientConf(int timeoutMs);
+
   void reportShuffleResult(
       Map<Integer, List<ShuffleServerInfo>> partitionToServers,
       String appId,

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -229,10 +229,12 @@ public class RssUtils {
           constructor = klass.getConstructor(obj.getClass());
           instance = (T) constructor.newInstance(obj);
         } catch (Exception e) {
+          LOGGER.error("Fail to new instance.", e);
           instance = (T) klass.getConstructor().newInstance();
         }
         extensions.add(instance);
       } catch (Exception e) {
+        LOGGER.error("Fail to new instance using default constructor.", e);
         throw new RuntimeException(e);
       }
     }

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/AccessCandidatesChecker.java
@@ -61,6 +61,11 @@ public class AccessCandidatesChecker implements AccessChecker {
     Configuration hadoopConf = accessManager.getHadoopConf();
     this.fileSystem = CoordinatorUtils.getFileSystemForPath(path, hadoopConf);
 
+    if (!fileSystem.isFile(path)) {
+      String msg = String.format("Fail to init AccessCandidatesChecker, %s is not a file.", path.toUri());
+      LOG.error(msg);
+      throw new RuntimeException(msg);
+    }
     updateAccessCandidatesInternal();
     if (candidates.get() == null || candidates.get().isEmpty()) {
       String msg = "Candidates must be non-empty and can be loaded successfully at coordinator startup.";
@@ -101,6 +106,7 @@ public class AccessCandidatesChecker implements AccessChecker {
         if (lastCandidatesUpdateMS.get() != lastModifiedMS) {
           updateAccessCandidatesInternal();
           lastCandidatesUpdateMS.set(lastModifiedMS);
+          LOG.debug("Load candidates: {}", String.join(";", candidates.get()));
         }
       } else {
         LOG.warn("Candidates file not found.");

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
@@ -1,0 +1,145 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.coordinator;
+
+import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.collect.Maps;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ClientConfManager implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientConfManager.class);
+
+  private final AtomicReference<Map<String, String>> clientConf = new AtomicReference<>();
+  private final AtomicLong lastCandidatesUpdateMS = new AtomicLong(0L);
+  private Path path;
+  private ScheduledExecutorService updateClientConfSES = null;
+  private FileSystem fileSystem;
+  private static final String WHITESPACE_REGEX = "\\s+";
+
+  public ClientConfManager(CoordinatorConf conf, Configuration hadoopConf) throws Exception {
+    if (conf.getBoolean(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED)) {
+      init(conf, hadoopConf);
+    }
+  }
+
+  private void init(CoordinatorConf conf, Configuration hadoopConf) throws Exception {
+    String pathStr = conf.get(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH);
+    this.path = new Path(pathStr);
+
+    this.fileSystem = CoordinatorUtils.getFileSystemForPath(path, hadoopConf);
+    if (!fileSystem.isFile(path)) {
+      String msg = String.format("Fail to init ClientConfManager, %s is not a file", path.toUri());
+      LOG.error(msg);
+      throw new IllegalStateException(msg);
+    }
+
+    FileStatus[] fileStatus = fileSystem.listStatus(path);
+    if (ArrayUtils.isEmpty(fileStatus)) {
+      throw new IllegalStateException("Fail to list file " + path);
+    }
+
+    int updateIntervalS = conf.getInteger(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC);
+    updateClientConfSES = Executors.newSingleThreadScheduledExecutor(
+        new ThreadFactoryBuilder().setDaemon(true).setNameFormat("ClientConfManager-%d").build());
+    updateClientConfSES.scheduleAtFixedRate(
+        this::updateClientConf, 0, updateIntervalS, TimeUnit.SECONDS);
+  }
+
+  private void updateClientConf() {
+    try {
+      FileStatus[] fileStatus = fileSystem.listStatus(path);
+      if (!ArrayUtils.isEmpty(fileStatus)) {
+        long lastModifiedMS = fileStatus[0].getModificationTime();
+        if (lastCandidatesUpdateMS.get() != lastModifiedMS) {
+          updateClientConfInternal();
+          lastCandidatesUpdateMS.set(lastModifiedMS);
+        }
+      } else {
+        clientConf.set(Maps.newHashMap());
+      }
+    } catch (Exception e) {
+      LOG.warn("Error when update client conf, ignore this attempt.", e);
+    }
+  }
+
+  private void updateClientConfInternal() {
+    Map<String, String> newClientConf = Maps.newHashMap();
+    String content = loadClientConfContent();
+    if (StringUtils.isEmpty(content)) {
+      LOG.warn("Load empty content from {}", path.toUri().toString());
+      clientConf.set(newClientConf);
+      return;
+    }
+
+    for (String item : content.split(IOUtils.LINE_SEPARATOR_UNIX)) {
+      String confItem = item.trim();
+      if (!StringUtils.isEmpty(confItem)) {
+        String[] confKV = confItem.split(WHITESPACE_REGEX);
+        if (confKV.length == 2) {
+          newClientConf.put(confKV[0], confKV[1]);
+        }
+      }
+    }
+
+    if (newClientConf.isEmpty()) {
+      LOG.warn("Empty content in {}, client conf in coordinator will be empty", path.toUri().toString());
+    }
+
+    clientConf.set(newClientConf);
+  }
+
+  private String loadClientConfContent() {
+    String content = null;
+    try (FSDataInputStream in = fileSystem.open(path)) {
+      content = IOUtils.toString(in, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      LOG.error("Fail to load content from {}", path.toUri().toString());
+    }
+    return content;
+  }
+
+  public Map<String, String> getClientConf() {
+    return clientConf.get();
+  }
+
+  @Override
+  public void close() {
+    if (updateClientConfSES != null) {
+      updateClientConfSES.shutdownNow();
+    }
+  }
+}

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
@@ -63,6 +63,11 @@ public class ClientConfManager implements Closeable {
 
     this.fileSystem = CoordinatorUtils.getFileSystemForPath(path, hadoopConf);
 
+    if (!fileSystem.isFile(path)) {
+      String msg = String.format("Fail to init ClientConfManager, %s is not a file.", path.toUri());
+      LOG.error(msg);
+      throw new IllegalStateException(msg);
+    }
     updateClientConfInternal();
     if (clientConf.get() == null || clientConf.get().isEmpty()) {
       String msg = "Client conf file must be non-empty and can be loaded successfully at coordinator startup.";

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -92,6 +92,22 @@ public class CoordinatorConf extends RssBaseConf {
       .checkValue(ConfigUtils.positiveIntegerValidator2, "load checker serverNum threshold must be positive")
       .noDefaultValue()
       .withDescription("Accessed candidates file path");
+  public static final ConfigOption<Boolean> COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED = ConfigOptions
+      .key("rss.coordinator.dynamicClientConf.enabled")
+      .booleanType()
+      .defaultValue(false)
+      .withDescription("enable dynamic client conf");
+  public static final ConfigOption<String> COORDINATOR_DYNAMIC_CLIENT_CONF_PATH = ConfigOptions
+      .key("rss.coordinator.dynamicClientConf.path")
+      .stringType()
+      .noDefaultValue()
+      .withDescription("dynamic client conf of this cluster");
+  public static final ConfigOption<Integer> COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC = ConfigOptions
+      .key("rss.coordinator.dynamicClientConf.updateIntervalSec")
+      .intType()
+      .checkValue(ConfigUtils.positiveIntegerValidator2, "dynamic client conf update interval in seconds")
+      .defaultValue(120)
+      .withDescription("Accessed candidates update interval in seconds");
 
   public CoordinatorConf() {
   }

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
@@ -18,8 +18,6 @@
 
 package com.tencent.rss.coordinator;
 
-import java.io.FileNotFoundException;
-
 import io.prometheus.client.CollectorRegistry;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
@@ -45,11 +43,12 @@ public class CoordinatorServer {
   private ServerInterface server;
   private ClusterManager clusterManager;
   private AssignmentStrategy assignmentStrategy;
+  private ClientConfManager clientConfManager;
   private AccessManager accessManager;
   private ApplicationManager applicationManager;
   private GRPCMetrics grpcMetrics;
 
-  public CoordinatorServer(CoordinatorConf coordinatorConf) throws FileNotFoundException {
+  public CoordinatorServer(CoordinatorConf coordinatorConf) throws Exception {
     this.coordinatorConf = coordinatorConf;
     initialization();
 
@@ -100,15 +99,18 @@ public class CoordinatorServer {
     if (accessManager != null) {
       accessManager.close();
     }
+    if (clientConfManager != null) {
+      clientConfManager.close();
+    }
     server.stop();
   }
 
-  private void initialization() throws FileNotFoundException {
+  private void initialization() throws Exception {
     this.applicationManager = new ApplicationManager(coordinatorConf);
 
     ClusterManagerFactory clusterManagerFactory = new ClusterManagerFactory(coordinatorConf);
     this.clusterManager = clusterManagerFactory.getClusterManager();
-
+    this.clientConfManager = new ClientConfManager(coordinatorConf, new Configuration());
     AssignmentStrategyFactory assignmentStrategyFactory =
         new AssignmentStrategyFactory(coordinatorConf, clusterManager);
     this.assignmentStrategy = assignmentStrategyFactory.getAssignmentStrategy();
@@ -186,6 +188,10 @@ public class CoordinatorServer {
 
   public AccessManager getAccessManager() {
     return accessManager;
+  }
+
+  public ClientConfManager getClientConfManager() {
+    return clientConfManager;
   }
 
   public GRPCMetrics getGrpcMetrics() {

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessCandidatesCheckerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessCandidatesCheckerTest.java
@@ -53,12 +53,22 @@ public class AccessCandidatesCheckerTest {
     final String filePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("coordinator.conf")).getFile();
     CoordinatorConf conf = new CoordinatorConf(filePath);
-    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, cfgFile.toURI().toString());
+    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, tmpDir.getRoot().toURI().toString());
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessCandidatesChecker");
 
     // file load checking at startup
     Exception expectedException = null;
+    try {
+      new AccessManager(conf, null, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertTrue(expectedException.getMessage().contains(
+        "NoSuchMethodException: com.tencent.rss.coordinator.AccessCandidatesChecker.<init>()"));
+    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, cfgFile.toURI().toString());
+    expectedException = null;
     try {
       new AccessManager(conf, null, new Configuration());
     } catch (RuntimeException e) {

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
@@ -21,9 +21,9 @@ package com.tencent.rss.coordinator;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
+import java.util.Map;
 import java.util.Objects;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Before;
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class AccessCandidatesCheckerTest {
+public class ClientConfManagerTest {
   @ClassRule
   public static final TemporaryFolder tmpDir = new TemporaryFolder();
 
@@ -51,48 +51,48 @@ public class AccessCandidatesCheckerTest {
     String cfgFileName = cfgFile.getAbsolutePath();
     FileWriter fileWriter = new FileWriter(cfgFile);
     PrintWriter printWriter = new PrintWriter(fileWriter);
-    printWriter.println("9527");
-    printWriter.println(" 135 ");
-    printWriter.println("2 ");
+    printWriter.println("spark.mock.1 abc");
+    printWriter.println(" spark.mock.2   123 ");
+    printWriter.println("spark.mock.3 true  ");
     printWriter.flush();
     printWriter.close();
     final String filePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("coordinator.conf")).getFile();
     CoordinatorConf conf = new CoordinatorConf(filePath);
-    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, cfgFile.toURI().toString());
-    conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
-        "com.tencent.rss.coordinator.AccessCandidatesChecker");
-    AccessManager accessManager = new AccessManager(conf, null, new Configuration());
-    AccessCandidatesChecker checker = (AccessCandidatesChecker) accessManager.getAccessCheckers().get(0);
-    // load the config at the beginning
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile.toURI().toString());
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
+    ClientConfManager clientConfManager = new ClientConfManager(conf, new Configuration());
+    // load config at the beginning
     sleep(1200);
-    assertEquals(Sets.newHashSet("2", "9527", "135"), checker.getCandidates().get());
-    assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
-    assertTrue(checker.check(new AccessInfo("135")).isSuccess());
-    assertFalse(checker.check(new AccessInfo("1")).isSuccess());
-    assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
+    Map<String, String> clientConf = clientConfManager.getClientConf();
+    assertEquals("abc", clientConf.get("spark.mock.1"));
+    assertEquals("123", clientConf.get("spark.mock.2"));
+    assertEquals("true", clientConf.get("spark.mock.3"));
+    assertEquals(3, clientConf.size());
 
     // the config will not be changed when the conf file is deleted
     assertTrue(cfgFile.delete());
-    sleep(1200);
-    assertEquals(Sets.newHashSet("2", "9527", "135"), checker.getCandidates().get());
-    assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
-    assertTrue(checker.check(new AccessInfo("135")).isSuccess());
-    assertFalse(checker.check(new AccessInfo("1")).isSuccess());
-    assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
+    sleep(1300);
+    assertFalse(cfgFile.exists());
+    clientConf = clientConfManager.getClientConf();
+    assertEquals("abc", clientConf.get("spark.mock.1"));
+    assertEquals("123", clientConf.get("spark.mock.2"));
+    assertEquals("true", clientConf.get("spark.mock.3"));
+    assertEquals(3, clientConf.size());
 
     // the normal update config process, move the new conf file to the old one
     File cfgFileTmp = new File(cfgFileName + ".tmp");
     fileWriter = new FileWriter(cfgFileTmp);
     printWriter = new PrintWriter(fileWriter);
-    printWriter.println("13");
-    printWriter.println("57");
+    printWriter.println("spark.mock.4 deadbeaf");
+    printWriter.println("spark.mock.5 9527");
     printWriter.close();
     FileUtils.moveFile(cfgFileTmp, cfgFile);
     sleep(1200);
-    assertEquals(Sets.newHashSet("13", "57"), checker.getCandidates().get());
-    assertTrue(checker.check(new AccessInfo("13")).isSuccess());
-    assertTrue(checker.check(new AccessInfo("57")).isSuccess());
-    checker.close();
+    clientConf = clientConfManager.getClientConf();
+    assertEquals("deadbeaf", clientConf.get("spark.mock.4"));
+    assertEquals("9527", clientConf.get("spark.mock.5"));
+    assertEquals(2, clientConf.size());
+    clientConfManager.close();
   }
 }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
@@ -53,11 +53,21 @@ public class ClientConfManagerTest {
     final String filePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("coordinator.conf")).getFile();
     CoordinatorConf conf = new CoordinatorConf(filePath);
-    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile.toURI().toString());
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, tmpDir.getRoot().toURI().toString());
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
 
     // file load checking at startup
     Exception expectedException = null;
+    try {
+      new ClientConfManager(conf, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertTrue(expectedException.getMessage().endsWith("is not a file."));
+
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile.toURI().toString());
+    expectedException = null;
     try {
       new ClientConfManager(conf, new Configuration());
     } catch (RuntimeException e) {

--- a/coordinator/src/test/resources/coordinator.conf
+++ b/coordinator/src/test/resources/coordinator.conf
@@ -28,3 +28,4 @@ rss.coordinator.server.heartbeat.timeout 123
 rss.coordinator.access.candidates.updateIntervalSec 1
 rss.coordinator.access.loadChecker.serverNum.threshold 2
 rss.coordinator.access.loadChecker.memory.percentage 20.0
+rss.coordinator.dynamicClientConf.updateIntervalSec 1

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
@@ -47,12 +47,22 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
 
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_UPDATE_INTERVAL_SEC, 1);
-    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidatesFile);
+    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, HDFS_URI);
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessCandidatesChecker");
 
     // file load checking at startup
     Exception expectedException = null;
+    try {
+      new AccessManager(conf, null, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertTrue(expectedException.getMessage().contains(
+        "NoSuchMethodException: com.tencent.rss.coordinator.AccessCandidatesChecker.<init>()"));
+    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidatesFile);
+    expectedException = null;
     try {
       new AccessManager(conf, null, new Configuration());
     } catch (RuntimeException e) {
@@ -105,13 +115,13 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
     out = fs.create(tmpPath);
     printWriter = new PrintWriter(new OutputStreamWriter(out));
     printWriter.println("9527");
-    printWriter.println(" 135 ");
+    printWriter.println(" 1357 ");
     printWriter.flush();
     printWriter.close();
     fs.rename(tmpPath, path);
     sleep(1200);
-    assertEquals(Sets.newHashSet("135", "9527"), checker.getCandidates().get());
-    assertTrue(checker.check(new AccessInfo("135")).isSuccess());
+    assertEquals(Sets.newHashSet("1357", "9527"), checker.getCandidates().get());
+    assertTrue(checker.check(new AccessInfo("1357")).isSuccess());
     assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
     checker.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
@@ -27,6 +27,7 @@ import com.tencent.rss.coordinator.AccessInfo;
 import com.tencent.rss.coordinator.AccessManager;
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.storage.HdfsTestBase;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
@@ -42,20 +44,33 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
     String candidatesFile = HDFS_URI + "/test/access_checker_candidates";
     Path path = new Path(candidatesFile);
     FSDataOutputStream out = fs.create(path);
-    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
-    printWriter.println("9527");
-    printWriter.println(" 135 ");
-    printWriter.println("2 ");
-    printWriter.flush();
-    printWriter.close();
 
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_UPDATE_INTERVAL_SEC, 1);
     conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, candidatesFile);
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessCandidatesChecker");
+
+    // file load checking at startup
+    Exception expectedException = null;
+    try {
+      new AccessManager(conf, null, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertTrue(expectedException.getMessage().contains(
+        "NoSuchMethodException: com.tencent.rss.coordinator.AccessCandidatesChecker.<init>()"));
+
+    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("9527");
+    printWriter.println(" 135 ");
+    printWriter.println("2 ");
+    printWriter.flush();
+    printWriter.close();
     AccessManager accessManager = new AccessManager(conf, null, HdfsTestBase.conf);
     AccessCandidatesChecker checker = (AccessCandidatesChecker) accessManager.getAccessCheckers().get(0);
+    // load the config at the beginning
     sleep(1200);
     assertEquals(Sets.newHashSet("2", "9527", "135"), checker.getCandidates().get());
     assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
@@ -63,6 +78,19 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
     assertFalse(checker.check(new AccessInfo("1")).isSuccess());
     assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
 
+    // ignore empty or wrong content
+    printWriter.println("");
+    printWriter.flush();
+    printWriter.close();
+    sleep(1300);
+    assertTrue(fs.exists(path));
+    assertEquals(Sets.newHashSet("2", "9527", "135"), checker.getCandidates().get());
+    assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
+    assertTrue(checker.check(new AccessInfo("135")).isSuccess());
+    assertFalse(checker.check(new AccessInfo("1")).isSuccess());
+    assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
+
+    // the config will not be changed when the conf file is deleted
     fs.delete(path, true);
     assertFalse(fs.exists(path));
     sleep(1200);
@@ -72,6 +100,7 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
     assertFalse(checker.check(new AccessInfo("1")).isSuccess());
     assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
 
+    // the normal update config process, move the new conf file to the old one
     Path tmpPath = new Path(candidatesFile + ".tmp");
     out = fs.create(tmpPath);
     printWriter = new PrintWriter(new OutputStreamWriter(out));

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
@@ -62,15 +62,24 @@ public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
     assertTrue(checker.check(new AccessInfo("135")).isSuccess());
     assertFalse(checker.check(new AccessInfo("1")).isSuccess());
     assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
-    sleep(1100);
 
-    out = fs.create(path);
+    fs.delete(path, true);
+    assertFalse(fs.exists(path));
+    sleep(1200);
+    assertEquals(Sets.newHashSet("2", "9527", "135"), checker.getCandidates().get());
+    assertTrue(checker.check(new AccessInfo("9527")).isSuccess());
+    assertTrue(checker.check(new AccessInfo("135")).isSuccess());
+    assertFalse(checker.check(new AccessInfo("1")).isSuccess());
+    assertFalse(checker.check(new AccessInfo("1_2")).isSuccess());
+
+    Path tmpPath = new Path(candidatesFile + ".tmp");
+    out = fs.create(tmpPath);
     printWriter = new PrintWriter(new OutputStreamWriter(out));
     printWriter.println("9527");
     printWriter.println(" 135 ");
     printWriter.flush();
     printWriter.close();
-
+    fs.rename(tmpPath, path);
     sleep(1200);
     assertEquals(Sets.newHashSet("135", "9527"), checker.getCandidates().get());
     assertTrue(checker.check(new AccessInfo("135")).isSuccess());

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import com.tencent.rss.coordinator.ClientConfManager;
 import com.tencent.rss.coordinator.CoordinatorConf;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
@@ -33,6 +34,8 @@ import com.tencent.rss.storage.HdfsTestBase;
 import static java.lang.Thread.sleep;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class ClientConfManagerHdfsTest extends HdfsTestBase {
 
@@ -41,18 +44,30 @@ public class ClientConfManagerHdfsTest extends HdfsTestBase {
     String cfgFile = HDFS_URI + "/test/client_conf";
     Path path = new Path(cfgFile);
     FSDataOutputStream out = fs.create(path);
-    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
-    printWriter.println("spark.mock.1 abc");
-    printWriter.println(" spark.mock.2   123 ");
-    printWriter.println("spark.mock.3 true  ");
-    printWriter.flush();
-    printWriter.close();
 
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile);
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, 1);
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
 
+    // file load checking at startup
+    Exception expectedException = null;
+    try {
+      new ClientConfManager(conf, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertEquals(
+        "Client conf file must be non-empty and can be loaded successfully at coordinator startup.",
+        expectedException.getMessage());
+
+    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1 abc");
+    printWriter.println(" spark.mock.2   123 ");
+    printWriter.println("spark.mock.3 true  ");
+    printWriter.flush();
+    printWriter.close();
     ClientConfManager clientConfManager = new ClientConfManager(conf, HdfsTestBase.conf);
     sleep(1200);
     Map<String, String> clientConf = clientConfManager.getClientConf();
@@ -61,6 +76,19 @@ public class ClientConfManagerHdfsTest extends HdfsTestBase {
     assertEquals("true", clientConf.get("spark.mock.3"));
     assertEquals(3, clientConf.size());
 
+    // ignore empty or wrong content
+    printWriter.println("");
+    printWriter.flush();
+    printWriter.close();
+    sleep(1300);
+    assertTrue(fs.exists(path));
+    clientConf = clientConfManager.getClientConf();
+    assertEquals("abc", clientConf.get("spark.mock.1"));
+    assertEquals("123", clientConf.get("spark.mock.2"));
+    assertEquals("true", clientConf.get("spark.mock.3"));
+    assertEquals(3, clientConf.size());
+
+    // the config will not be changed when the conf file is deleted
     fs.delete(path, true);
     assertFalse(fs.exists(path));
     sleep(1200);
@@ -70,11 +98,14 @@ public class ClientConfManagerHdfsTest extends HdfsTestBase {
     assertEquals("true", clientConf.get("spark.mock.3"));
     assertEquals(3, clientConf.size());
 
+    // the normal update config process, move the new conf file to the old one
     Path tmpPath = new Path(cfgFile + ".tmp");
     out = fs.create(tmpPath);
     printWriter = new PrintWriter(new OutputStreamWriter(out));
     printWriter.println("spark.mock.4 deadbeaf");
     printWriter.println("spark.mock.5 9527");
+    printWriter.println("spark.mock.6 9527 3423");
+    printWriter.println("spark.mock.7");
     printWriter.close();
     fs.rename(tmpPath, path);
     sleep(1200);
@@ -82,6 +113,8 @@ public class ClientConfManagerHdfsTest extends HdfsTestBase {
     assertEquals("deadbeaf", clientConf.get("spark.mock.4"));
     assertEquals("9527", clientConf.get("spark.mock.5"));
     assertEquals(2, clientConf.size());
+    assertFalse(clientConf.containsKey("spark.mock.6"));
+    assertFalse(clientConf.containsKey("spark.mock.7"));
     clientConfManager.close();
   }
 }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.Map;
+
+import com.tencent.rss.coordinator.ClientConfManager;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+import com.tencent.rss.storage.HdfsTestBase;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ClientConfManagerHdfsTest extends HdfsTestBase {
+
+  @Test
+  public void test() throws Exception {
+    String cfgFile = HDFS_URI + "/test/client_conf";
+    Path path = new Path(cfgFile);
+    FSDataOutputStream out = fs.create(path);
+    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1 abc");
+    printWriter.println(" spark.mock.2   123 ");
+    printWriter.println("spark.mock.3 true  ");
+    printWriter.flush();
+    printWriter.close();
+
+    CoordinatorConf conf = new CoordinatorConf();
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile);
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, 1);
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
+
+    ClientConfManager clientConfManager = new ClientConfManager(conf, HdfsTestBase.conf);
+    sleep(1200);
+    Map<String, String> clientConf = clientConfManager.getClientConf();
+    assertEquals("abc", clientConf.get("spark.mock.1"));
+    assertEquals("123", clientConf.get("spark.mock.2"));
+    assertEquals("true", clientConf.get("spark.mock.3"));
+    assertEquals(3, clientConf.size());
+
+    fs.delete(path, true);
+    assertFalse(fs.exists(path));
+    sleep(1200);
+    clientConf = clientConfManager.getClientConf();
+    assertEquals("abc", clientConf.get("spark.mock.1"));
+    assertEquals("123", clientConf.get("spark.mock.2"));
+    assertEquals("true", clientConf.get("spark.mock.3"));
+    assertEquals(3, clientConf.size());
+
+    Path tmpPath = new Path(cfgFile + ".tmp");
+    out = fs.create(tmpPath);
+    printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.4 deadbeaf");
+    printWriter.println("spark.mock.5 9527");
+    printWriter.close();
+    fs.rename(tmpPath, path);
+    sleep(1200);
+    clientConf = clientConfManager.getClientConf();
+    assertEquals("deadbeaf", clientConf.get("spark.mock.4"));
+    assertEquals("9527", clientConf.get("spark.mock.5"));
+    assertEquals(2, clientConf.size());
+    clientConfManager.close();
+  }
+}

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
@@ -46,12 +46,22 @@ public class ClientConfManagerHdfsTest extends HdfsTestBase {
     FSDataOutputStream out = fs.create(path);
 
     CoordinatorConf conf = new CoordinatorConf();
-    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile);
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, HDFS_URI);
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, 1);
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
 
     // file load checking at startup
     Exception expectedException = null;
+    try {
+      new ClientConfManager(conf, new Configuration());
+    } catch (RuntimeException e) {
+      expectedException = e;
+    }
+    assertNotNull(expectedException);
+    assertTrue(expectedException.getMessage().endsWith("is not a file."));
+
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile);
+    expectedException = null;
     try {
       new ClientConfManager(conf, new Configuration());
     } catch (RuntimeException e) {

--- a/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
@@ -1,0 +1,89 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.tencent.rss.client.request.RssFetchClientConfRequest;
+import com.tencent.rss.client.response.ResponseStatusCode;
+import com.tencent.rss.client.response.RssFetchClientConfResponse;
+import com.tencent.rss.coordinator.CoordinatorConf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class FetchClientConfTest extends CoordinatorTestBase {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void test() throws Exception {
+    File clientConfFile = tmpFolder.newFile();
+    FileWriter fileWriter = new FileWriter(clientConfFile);
+    PrintWriter printWriter = new PrintWriter(fileWriter);
+    printWriter.println("spark.mock.1  1234");
+    printWriter.println(" spark.mock.2 true ");
+    printWriter.flush();
+    printWriter.close();
+
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setBoolean("rss.coordinator.dynamicClientConf.enabled", true);
+    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", clientConfFile.getAbsolutePath());
+    coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 10);
+    createCoordinatorServer(coordinatorConf);
+    startServers();
+
+    Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+    RssFetchClientConfRequest request = new RssFetchClientConfRequest(2000);
+    RssFetchClientConfResponse response = coordinatorClient.fetchClientConf(request);
+    assertEquals(ResponseStatusCode.SUCCESS, response.getStatusCode());
+    assertEquals(2, response.getClientConf().size());
+    assertEquals("1234", response.getClientConf().get("spark.mock.1"));
+    assertEquals("true", response.getClientConf().get("spark.mock.2"));
+    assertNull(response.getClientConf().get("spark.mock.3"));
+    shutdownServers();
+
+    // dynamic client conf is disabled by default
+    coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", clientConfFile.getAbsolutePath());
+    coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 10);
+    createCoordinatorServer(coordinatorConf);
+    startServers();
+    Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+    request = new RssFetchClientConfRequest(2000);
+    response = coordinatorClient.fetchClientConf(request);
+    assertEquals(ResponseStatusCode.SUCCESS, response.getStatusCode());
+    assertEquals(0, response.getClientConf().size());
+    shutdownServers();
+
+    // Fetch conf will not throw exception even if the request fails
+    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+    request = new RssFetchClientConfRequest(10);
+    response = coordinatorClient.fetchClientConf(request);
+    assertEquals(ResponseStatusCode.INTERNAL_ERROR, response.getStatusCode());
+    assertEquals(0, response.getClientConf().size());
+  }
+}

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/AutoAccessTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/AutoAccessTest.java
@@ -1,0 +1,188 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.DelegationRssShuffleManager;
+import org.apache.spark.shuffle.RssClientConfig;
+import org.apache.spark.shuffle.RssShuffleManager;
+import org.apache.spark.shuffle.ShuffleManager;
+import org.apache.spark.shuffle.sort.SortShuffleManager;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.storage.util.StorageType;
+
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class AutoAccessTest extends IntegrationTestBase {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void test() throws Exception {
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.DelegationRssShuffleManager");
+    sparkConf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, COORDINATOR_QUORUM);
+    sparkConf.set("spark.mock.2", "no-overwrite-conf");
+    sparkConf.set("spark.rss.base.path", "overwrite-path");
+    sparkConf.set("spark.shuffle.service.enabled", "true");
+
+    String cfgFile = HDFS_URI + "/test/client_conf";
+    Path path = new Path(cfgFile);
+    FSDataOutputStream out = fs.create(path);
+    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1  1234");
+    printWriter.println(" spark.mock.2 overwrite-conf ");
+    printWriter.println(" spark.mock.3 true ");
+    printWriter.println("spark.rss.storage.type " + StorageType.MEMORY_LOCALFILE_HDFS.name());
+    printWriter.println("spark.rss.base.path expectedPath");
+    printWriter.flush();
+    printWriter.close();
+
+    String candidatesFile = HDFS_URI + "/test/candidates";
+    Path candidatesPath = new Path(candidatesFile);
+    FSDataOutputStream out1 = fs.create(candidatesPath);
+    PrintWriter printWriter1 = new PrintWriter(new OutputStreamWriter(out1));
+    printWriter1.println(" test-id ");
+    printWriter1.println(" ");
+    printWriter1.flush();
+    printWriter1.close();
+
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setBoolean("rss.coordinator.dynamicClientConf.enabled", true);
+    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", cfgFile);
+    coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 1);
+    coordinatorConf.setInteger("rss.coordinator.access.candidates.updateIntervalSec", 1);
+    coordinatorConf.setInteger("rss.coordinator.access.loadChecker.serverNum.threshold", 1);
+    coordinatorConf.setString("rss.coordinator.access.candidates.path", candidatesFile);
+    coordinatorConf.setString(
+        "rss.coordinator.access.checkers",
+        "com.tencent.rss.coordinator.AccessCandidatesChecker,com.tencent.rss.coordinator.AccessClusterLoadChecker");
+    createCoordinatorServer(coordinatorConf);
+
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createShuffleServer(shuffleServerConf);
+    startServers();
+    Uninterruptibles.sleepUninterruptibly(2, TimeUnit.SECONDS);
+
+    assertFalse(sparkConf.contains("spark.mock.1"));
+    assertEquals("no-overwrite-conf", sparkConf.get("spark.mock.2"));
+    assertTrue(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+
+    // empty access id
+    DelegationRssShuffleManager delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    ShuffleManager shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof SortShuffleManager);
+    assertTrue(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+    assertEquals("overwrite-path", sparkConf.get("spark.rss.base.path"));
+    assertFalse(sparkConf.contains("spark.rss.storage.type"));
+
+    // wrong access id
+    sparkConf.set("spark.rss.access.id", "9527");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof SortShuffleManager);
+    assertEquals("overwrite-path", sparkConf.get("spark.rss.base.path"));
+    assertTrue(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+    assertFalse(sparkConf.contains("spark.rss.storage.type"));
+
+    // success to access and replace critical client conf
+    sparkConf.set("spark.rss.access.id", "test-id");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof RssShuffleManager);
+    assertSame(sparkConf, ((RssShuffleManager) shuffleManager).getSparkConf());
+    assertEquals(1234, sparkConf.getInt("spark.mock.1", 0));
+    assertEquals("no-overwrite-conf", sparkConf.get("spark.mock.2"));
+    assertTrue(sparkConf.getBoolean("spark.mock.3", false));
+    assertEquals(StorageType.MEMORY_LOCALFILE_HDFS.name(), sparkConf.get("spark.rss.storage.type"));
+    assertEquals("expectedPath", sparkConf.get("spark.rss.base.path"));
+    assertFalse(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+
+    // update candidates file
+    fs.delete(candidatesPath, true);
+    assertFalse(fs.exists(candidatesPath));
+    Path tmpPath1 = new Path(candidatesPath + ".tmp");
+    out1 = fs.create(tmpPath1);
+    printWriter1 = new PrintWriter(new OutputStreamWriter(out1));
+    printWriter1.println("9527");
+    printWriter1.flush();
+    printWriter1.close();
+    fs.rename(tmpPath1, candidatesPath);
+    sleep(1200);
+    sparkConf.set("spark.rss.access.id", "test-id");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof SortShuffleManager);
+    sparkConf.set("spark.rss.access.id", "9527");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof RssShuffleManager);
+    assertSame(sparkConf, ((RssShuffleManager) shuffleManager).getSparkConf());
+    assertEquals(1234, sparkConf.getInt("spark.mock.1", 0));
+    assertEquals("no-overwrite-conf", sparkConf.get("spark.mock.2"));
+    assertTrue(sparkConf.getBoolean("spark.mock.3", false));
+    assertEquals(StorageType.MEMORY_LOCALFILE_HDFS.name(), sparkConf.get("spark.rss.storage.type"));
+    assertEquals("expectedPath", sparkConf.get("spark.rss.base.path"));
+    assertFalse(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+
+    // update client conf file
+    fs.delete(path, true);
+    assertFalse(fs.exists(path));
+    Path tmpPath = new Path(path + ".tmp");
+    out = fs.create(tmpPath);
+    printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1  404");
+    printWriter.println(" spark.mock.2 overwrite-conf ");
+    printWriter.println(" spark.mock.3 false ");
+    printWriter.println("spark.rss.storage.type " + StorageType.MEMORY_LOCALFILE_HDFS.name());
+    printWriter.println("spark.rss.base.path expectedPathNew");
+    printWriter.flush();
+    printWriter.close();
+    fs.rename(tmpPath, path);
+    sleep(1200);
+    sparkConf.remove("spark.mock.1");
+    sparkConf.remove("spark.mock.2");
+    delegationRssShuffleManager = new DelegationRssShuffleManager(sparkConf, true);
+    shuffleManager = delegationRssShuffleManager.getDelegate();
+    assertTrue(shuffleManager instanceof RssShuffleManager);
+    assertSame(sparkConf, ((RssShuffleManager) shuffleManager).getSparkConf());
+    assertEquals(404, sparkConf.getInt("spark.mock.1", 0));
+    assertEquals("overwrite-conf", sparkConf.get("spark.mock.2"));
+    assertTrue(sparkConf.getBoolean("spark.mock.3", false));
+    assertEquals(StorageType.MEMORY_LOCALFILE_HDFS.name(), sparkConf.get("spark.rss.storage.type"));
+    assertEquals("expectedPathNew", sparkConf.get("spark.rss.base.path"));
+    assertFalse(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+  }
+}

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
@@ -126,7 +126,7 @@ public class DynamicFetchClientConfTest extends IntegrationTestBase {
         expectException.getMessage());
 
     for (StorageType storageType : StorageType.values()) {
-      if (RssShuffleUtils.STORAGE_TYPE_NEED_NO_PATH.contains(storageType)) {
+      if (RssShuffleUtils.getStorageTypeWithoutPath().contains(storageType)) {
         sparkConf.set("spark.rss.storage.type", storageType.name());
         RssShuffleManager rsm = new RssShuffleManager(sparkConf, true);
         assertFalse(rsm.getSparkConf().contains("spark.rss.base.path"));

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
@@ -1,0 +1,147 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.test;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.storage.util.StorageType;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.RssClientConfig;
+import org.apache.spark.shuffle.RssShuffleManager;
+import org.apache.spark.shuffle.RssShuffleUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DynamicFetchClientConfTest extends IntegrationTestBase {
+  @Rule
+  public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+  @Test
+  public void test() throws Exception {
+    SparkConf sparkConf = new SparkConf();
+    sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.RssShuffleManager");
+    sparkConf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, COORDINATOR_QUORUM);
+    sparkConf.set("spark.mock.2", "no-overwrite-conf");
+    sparkConf.set("spark.shuffle.service.enabled", "true");
+
+    String cfgFile = HDFS_URI + "/test/client_conf";
+    Path path = new Path(cfgFile);
+    FSDataOutputStream out = fs.create(path);
+    PrintWriter printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1  1234");
+    printWriter.println(" spark.mock.2 overwrite-conf ");
+    printWriter.println(" spark.mock.3 true ");
+    printWriter.println("spark.rss.storage.type " + StorageType.MEMORY_LOCALFILE_HDFS.name());
+    printWriter.println("spark.rss.base.path expectedPath");
+    printWriter.flush();
+    printWriter.close();
+    for (String k : RssClientConfig.RSS_MANDATORY_CLUSTER_CONF) {
+      sparkConf.set(k, "Dummy-" + k);
+    }
+    sparkConf.set("spark.mock.2", "no-overwrite-conf");
+
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setBoolean("rss.coordinator.dynamicClientConf.enabled", true);
+    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", cfgFile);
+    coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 10);
+    createCoordinatorServer(coordinatorConf);
+    startServers();
+
+    Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
+
+    assertFalse(sparkConf.contains("spark.mock.1"));
+    assertEquals("no-overwrite-conf", sparkConf.get("spark.mock.2"));
+    assertFalse(sparkConf.contains("spark.mock.3"));
+    assertEquals("Dummy-spark.rss.storage.type", sparkConf.get("spark.rss.storage.type"));
+    assertEquals("Dummy-spark.rss.base.path", sparkConf.get("spark.rss.base.path"));
+    assertTrue(sparkConf.getBoolean("spark.shuffle.service.enabled", true));
+
+    RssShuffleManager rssShuffleManager = new RssShuffleManager(sparkConf, true);
+
+    SparkConf sparkConf1 = rssShuffleManager.getSparkConf();
+    assertEquals(1234, sparkConf1.getInt("spark.mock.1", 0));
+    assertEquals("no-overwrite-conf", sparkConf1.get("spark.mock.2"));
+    assertEquals(StorageType.MEMORY_LOCALFILE_HDFS.name(), sparkConf.get("spark.rss.storage.type"));
+    assertEquals("expectedPath", sparkConf.get("spark.rss.base.path"));
+    assertFalse(sparkConf1.getBoolean("spark.shuffle.service.enabled", true));
+
+    fs.delete(path, true);
+    shutdownServers();
+    sparkConf = new SparkConf();
+    sparkConf.set("spark.shuffle.manager", "org.apache.spark.shuffle.RssShuffleManager");
+    sparkConf.set(RssClientConfig.RSS_COORDINATOR_QUORUM, COORDINATOR_QUORUM);
+    sparkConf.set("spark.mock.2", "no-overwrite-conf");
+    sparkConf.set("spark.shuffle.service.enabled", "true");
+
+    out = fs.create(path);
+    printWriter = new PrintWriter(new OutputStreamWriter(out));
+    printWriter.println("spark.mock.1  1234");
+    printWriter.println(" spark.mock.2 overwrite-conf ");
+    printWriter.println(" spark.mock.3 true ");
+    printWriter.flush();
+    printWriter.close();
+    coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setBoolean("rss.coordinator.dynamicClientConf.enabled", true);
+    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", cfgFile);
+    coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 10);
+    createCoordinatorServer(coordinatorConf);
+    startServers();
+    Uninterruptibles.sleepUninterruptibly(3, TimeUnit.SECONDS);
+
+    Exception expectException = null;
+    try {
+      new RssShuffleManager(sparkConf, true);
+    } catch (IllegalArgumentException e) {
+      expectException = e;
+    }
+    assertEquals(
+        "Storage type must be set by the client or fetched from coordinators.",
+        expectException.getMessage());
+
+    for (StorageType storageType : StorageType.values()) {
+      if (RssShuffleUtils.STORAGE_TYPE_NEED_NO_PATH.contains(storageType)) {
+        sparkConf.set("spark.rss.storage.type", storageType.name());
+        RssShuffleManager rsm = new RssShuffleManager(sparkConf, true);
+        assertFalse(rsm.getSparkConf().contains("spark.rss.base.path"));
+      } else {
+        sparkConf.set("spark.rss.storage.type", storageType.name());
+        expectException = null;
+        try {
+          new RssShuffleManager(sparkConf, true);
+        } catch (IllegalArgumentException e) {
+          expectException = e;
+        }
+        assertEquals(
+            "Storage path must be set by the client or fetched from coordinators.",
+            expectException.getMessage());
+      }
+    }
+  }
+}

--- a/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
@@ -1,8 +1,8 @@
 /*
  * Tencent is pleased to support the open source community by making
- * Firestorm-Spark remote shuffle server available. 
+ * Firestorm-Spark remote shuffle server available.
  *
- * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved. 
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -20,10 +20,12 @@ package com.tencent.rss.client.api;
 
 import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
+import com.tencent.rss.client.request.RssFetchClientConfRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
 import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
+import com.tencent.rss.client.response.RssFetchClientConfResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 
@@ -36,6 +38,8 @@ public interface CoordinatorClient {
   RssGetShuffleAssignmentsResponse getShuffleAssignments(RssGetShuffleAssignmentsRequest request);
 
   RssAccessClusterResponse accessCluster(RssAccessClusterRequest request);
+
+  RssFetchClientConfResponse fetchClientConf(RssFetchClientConfRequest request);
 
   String getDesc();
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -1,8 +1,8 @@
 /*
  * Tencent is pleased to support the open source community by making
- * Firestorm-Spark remote shuffle server available. 
+ * Firestorm-Spark remote shuffle server available.
  *
- * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved. 
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the
@@ -37,11 +37,13 @@ import org.slf4j.LoggerFactory;
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
+import com.tencent.rss.client.request.RssFetchClientConfRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
 import com.tencent.rss.client.response.ResponseStatusCode;
 import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
+import com.tencent.rss.client.response.RssFetchClientConfResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 import com.tencent.rss.common.PartitionRange;
@@ -54,6 +56,8 @@ import com.tencent.rss.proto.RssProtos.AccessClusterRequest;
 import com.tencent.rss.proto.RssProtos.AccessClusterResponse;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatRequest;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatResponse;
+import com.tencent.rss.proto.RssProtos.ClientConfItem;
+import com.tencent.rss.proto.RssProtos.FetchClientConfResponse;
 import com.tencent.rss.proto.RssProtos.GetShuffleAssignmentsResponse;
 import com.tencent.rss.proto.RssProtos.GetShuffleServerListResponse;
 import com.tencent.rss.proto.RssProtos.PartitionRangeAssignment;
@@ -254,13 +258,33 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
     StatusCode statusCode = rpcResponse.getStatus();
     switch (statusCode) {
       case SUCCESS:
-        response = new RssAccessClusterResponse(ResponseStatusCode.SUCCESS, rpcResponse.getRetMsg());
+        response = new RssAccessClusterResponse(
+            ResponseStatusCode.SUCCESS,
+            rpcResponse.getRetMsg());
         break;
       default:
         response = new RssAccessClusterResponse(ResponseStatusCode.ACCESS_DENIED, rpcResponse.getRetMsg());
     }
 
     return response;
+  }
+
+  @Override
+  public RssFetchClientConfResponse fetchClientConf(RssFetchClientConfRequest request) {
+    FetchClientConfResponse rpcResponse;
+    try {
+      rpcResponse = blockingStub
+          .withDeadlineAfter(request.getTimeoutMs(), TimeUnit.MILLISECONDS)
+          .fetchClientConf(Empty.getDefaultInstance());
+      Map<String, String> clientConf = rpcResponse
+          .getClientConfList().stream().collect(Collectors.toMap(ClientConfItem::getKey, ClientConfItem::getValue));
+      return new RssFetchClientConfResponse(
+          ResponseStatusCode.SUCCESS,
+          rpcResponse.getRetMsg(),
+          clientConf);
+    } catch (Exception e) {
+      return new RssFetchClientConfResponse(ResponseStatusCode.INTERNAL_ERROR, e.getMessage());
+    }
   }
 
   // transform [startPartition, endPartition] -> [server1, server2] to

--- a/internal-client/src/main/java/com/tencent/rss/client/request/RssFetchClientConfRequest.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/request/RssFetchClientConfRequest.java
@@ -1,0 +1,31 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.request;
+
+public class RssFetchClientConfRequest {
+  private final int timeoutMs;
+
+  public RssFetchClientConfRequest(int timeoutMs) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  public int getTimeoutMs() {
+    return timeoutMs;
+  }
+}

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssFetchClientConfResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssFetchClientConfResponse.java
@@ -1,0 +1,43 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.response;
+
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
+public class RssFetchClientConfResponse extends ClientResponse {
+  private final Map<String, String> clientConf;
+
+  public RssFetchClientConfResponse(ResponseStatusCode statusCode, String message) {
+    this(statusCode, message, Maps.newHashMap());
+  }
+
+  public RssFetchClientConfResponse(
+      ResponseStatusCode statusCode,
+      String message,
+      Map<String, String> clientConf) {
+    super(statusCode, message);
+    this.clientConf = clientConf;
+  }
+
+  public Map<String, String> getClientConf() {
+    return clientConf;
+  }
+}

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -260,6 +260,9 @@ service CoordinatorServer {
 
   // Access to the remote shuffle service cluster
   rpc accessCluster(AccessClusterRequest) returns (AccessClusterResponse);
+
+  // Get basic client conf from coordinator
+  rpc fetchClientConf(google.protobuf.Empty) returns (FetchClientConfResponse);
 }
 
 message AppHeartBeatRequest {
@@ -334,4 +337,15 @@ message AccessClusterRequest {
 message AccessClusterResponse {
   StatusCode status = 1;
   string retMsg = 2;
+}
+
+message FetchClientConfResponse {
+  StatusCode status = 1;
+  string retMsg = 2;
+  repeated ClientConfItem clientConf = 3;
+}
+
+message ClientConfItem {
+  string key = 1;
+  string value = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add api to fetch client conf from coordinator
2. Dynamic apply the client conf


### Why are the changes needed?
Support dynamic update client conf and avoid the requirement to add some client conf other than shuffle manager, client jar.
For now, we only read the conf from local file or hdfs, and we could support db and kv store or leverage a config center in the future.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
UT & System test
