### PR TITLE
[Feature] corrupted LocalStorage can be excluded

### DIFF
--- a/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
@@ -1,0 +1,28 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.tencent.rss.test;
+
+import org.junit.Test;
+
+public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
+
+  @Test
+  public void test() {
+
+  }
+}

--- a/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
@@ -15,14 +15,121 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.tencent.rss.test;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.client.impl.ShuffleReadClientImpl;
+import com.tencent.rss.client.impl.grpc.ShuffleServerGrpcClient;
+import com.tencent.rss.client.request.RssFinishShuffleRequest;
+import com.tencent.rss.client.request.RssRegisterShuffleRequest;
+import com.tencent.rss.client.request.RssReportShuffleResultRequest;
+import com.tencent.rss.client.request.RssSendCommitRequest;
+import com.tencent.rss.client.request.RssSendShuffleDataRequest;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.storage.util.StorageType;
+import org.apache.commons.io.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
+  private ShuffleServerGrpcClient shuffleServerClient;
+
+  private static File serverTmpDir = Files.createTempDir();
+  private static File data1 = new File(serverTmpDir, "data1");
+  private static File data2 = new File(serverTmpDir, "data2");
+
+  @BeforeClass
+  public static void setupServers() throws Exception {
+    serverTmpDir.deleteOnExit();
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
+    shuffleServerConf.setString(ShuffleServerConf.RSS_STORAGE_BASE_PATH,
+        data1.getAbsolutePath() + "," + data2.getAbsolutePath());
+    shuffleServerConf.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
+  @Before
+  public void createClient() {
+    shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
+  }
+
+  @After
+  public void closeClient() {
+    shuffleServerClient.close();
+  }
 
   @Test
-  public void test() {
+  public void diskErrorTest() throws Exception {
+
+    String appId = "ap_disk_error_data";
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Set<Long> expectedBlock1 = Sets.newHashSet();
+    Roaring64NavigableMap blockIdBitmap1 = Roaring64NavigableMap.bitmapOf();
+    List<ShuffleBlockInfo> blocks1 = createShuffleBlockList(
+        0, 0, 1,3, 25, blockIdBitmap1, expectedData);
+    RssRegisterShuffleRequest rr1 =  new RssRegisterShuffleRequest(appId, 0,
+        Lists.newArrayList(new PartitionRange(0, 0)));
+    shuffleServerClient.registerShuffle(rr1);
+    blocks1.forEach(b -> expectedBlock1.add(b.getBlockId()));
+    Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = Maps.newHashMap();
+    partitionToBlocks.put(0, blocks1);
+    Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleToBlocks = Maps.newHashMap();
+    shuffleToBlocks.put(0, partitionToBlocks);
+    RssSendShuffleDataRequest rs1 = new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rs1);
+    RssSendCommitRequest rc1 = new RssSendCommitRequest(appId, 0);
+    shuffleServerClient.sendCommit(rc1);
+    RssFinishShuffleRequest rf1 = new RssFinishShuffleRequest(appId, 0);
+    shuffleServerClient.finishShuffle(rf1);
+
+    FileUtils.deleteDirectory(data2);
+    assertFalse(data2.exists());
+    boolean suc = data2.createNewFile();
+    assertTrue(suc);
+    Uninterruptibles.sleepUninterruptibly(10, TimeUnit.SECONDS);
+
+    partitionToBlocks.clear();
+    shuffleToBlocks.clear();
+    Roaring64NavigableMap blockIdBitmap2 = Roaring64NavigableMap.bitmapOf();
+    Set<Long> expectedBlock2 = Sets.newHashSet();
+    List<ShuffleBlockInfo> blocks2 = createShuffleBlockList(
+        0, 0, 2, 5, 30, blockIdBitmap2, expectedData);
+    blocks2.forEach(b -> expectedBlock2.add(b.getBlockId()));
+    partitionToBlocks.put(0, blocks2);
+    shuffleToBlocks.put(0, partitionToBlocks);
+    rs1 = new RssSendShuffleDataRequest(appId, 3, 1000, shuffleToBlocks);
+    shuffleServerClient.sendShuffleData(rs1);
+    shuffleServerClient.sendCommit(rc1);
+    shuffleServerClient.finishShuffle(rf1);
+
+    ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
+        appId, 0, 0, 100, 1, 10, 1000, HDFS_URI + "xxxx",
+        blockIdBitmap2, Roaring64NavigableMap.bitmapOf(2), Lists.newArrayList(), conf);
+    validateResult(readClient, expectedData);
 
   }
 }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithLocalTest.java
@@ -131,12 +131,9 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
         10, 1000, 0);
     validateResult(sdr, expectedBlockIds4, expectedData, 3);
 
-    assertEquals(4, shuffleServers.get(0).getShuffleTaskManager()
-        .getServerReadHandlers().get(testAppId).size());
     assertNotNull(shuffleServers.get(0).getShuffleTaskManager()
         .getPartitionsToBlockIds().get(testAppId));
     Thread.sleep(8000);
-    assertNull(shuffleServers.get(0).getShuffleTaskManager().getServerReadHandlers().get(testAppId));
     assertNull(shuffleServers.get(0).getShuffleTaskManager().getPartitionsToBlockIds().get(testAppId));
   }
 

--- a/server/src/main/java/com/tencent/rss/server/LocalStorageChecker.java
+++ b/server/src/main/java/com/tencent/rss/server/LocalStorageChecker.java
@@ -20,10 +20,12 @@ package com.tencent.rss.server;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -183,9 +185,15 @@ public class LocalStorageChecker extends Checker {
           }
         }
       } catch (Exception e) {
+        LOG.error("Storage read and write error ", e);
         return false;
       } finally {
-        checkDir.delete();
+        try {
+          FileUtils.deleteDirectory(checkDir);
+        } catch (IOException ioe) {
+          LOG.error("delete directory fail", ioe);
+          return false;
+        }
       }
       return true;
     }

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServer.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServer.java
@@ -18,9 +18,11 @@
 
 package com.tencent.rss.server;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.prometheus.client.CollectorRegistry;
 import org.slf4j.Logger;
@@ -141,7 +143,9 @@ public class ShuffleServer {
 
     boolean healthCheckEnable = shuffleServerConf.getBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE);
     if (healthCheckEnable) {
-      healthCheck = new HealthCheck(isHealthy, shuffleServerConf);
+      List<Checker> buildInCheckers = Lists.newArrayList();
+      buildInCheckers.add(storageManager.getStorageChecker());
+      healthCheck = new HealthCheck(isHealthy, shuffleServerConf, buildInCheckers);
       healthCheck.start();
     }
 

--- a/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleServerConf.java
@@ -304,13 +304,13 @@ public class ShuffleServerConf extends RssBaseConf {
   public static final ConfigOption<Boolean> HEALTH_CHECK_ENABLE = ConfigOptions
       .key("rss.server.health.check.enable")
       .booleanType()
-      .defaultValue(true)
+      .defaultValue(false)
       .withDescription("The switch for the health check");
 
   public static final ConfigOption<String> HEALTH_CHECKER_CLASS_NAMES = ConfigOptions
       .key("rss.server.health.checker.class.names")
       .stringType()
-      .defaultValue("com.tencent.rss.server.LocalStorageChecker")
+      .noDefaultValue()
       .withDescription("The list of the Checker's name");
 
   public static final ConfigOption<Double> SERVER_MEMORY_SHUFFLE_LOWWATERMARK_PERCENTAGE = ConfigOptions

--- a/server/src/main/java/com/tencent/rss/server/ShuffleTaskManager.java
+++ b/server/src/main/java/com/tencent/rss/server/ShuffleTaskManager.java
@@ -53,7 +53,6 @@ import com.tencent.rss.server.buffer.ShuffleBufferManager;
 import com.tencent.rss.server.storage.StorageManager;
 import com.tencent.rss.storage.common.Storage;
 import com.tencent.rss.storage.common.StorageReadMetrics;
-import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 
 public class ShuffleTaskManager {
@@ -85,7 +84,6 @@ public class ShuffleTaskManager {
   private Runnable clearResourceThread;
   private BlockingQueue<String> expiredAppIdQueue = Queues.newLinkedBlockingQueue();
   // appId -> shuffleId -> serverReadHandler
-  private Map<String, Map<String, ServerReadHandler>> serverReadHandlers = Maps.newConcurrentMap();
 
   public ShuffleTaskManager(
       ShuffleServerConf conf,
@@ -386,7 +384,6 @@ public class ShuffleTaskManager {
     final long start = System.currentTimeMillis();
     final Map<Integer, Roaring64NavigableMap> shuffleToCachedBlockIds = cachedBlockIds.get(appId);
     appIds.remove(appId);
-    serverReadHandlers.remove(appId);
     partitionsToBlockIds.remove(appId);
     cachedBlockIds.remove(appId);
     commitCounts.remove(appId);
@@ -439,11 +436,6 @@ public class ShuffleTaskManager {
   @VisibleForTesting
   Map<Long, PreAllocatedBufferInfo> getRequireBufferIds() {
     return requireBufferIds;
-  }
-
-  @VisibleForTesting
-  public Map<String, Map<String, ServerReadHandler>> getServerReadHandlers() {
-    return serverReadHandlers;
   }
 
   @VisibleForTesting

--- a/server/src/main/java/com/tencent/rss/server/storage/LocalStorageManager.java
+++ b/server/src/main/java/com/tencent/rss/server/storage/LocalStorageManager.java
@@ -89,7 +89,7 @@ public class LocalStorageManager extends SingleStorageManager {
         event.getStartPartition()));
     if (storage.containsWriteHandler(event.getAppId(), event.getShuffleId(), event.getStartPartition())
         && storage.isCorrupted()) {
-      throw new RuntimeException("");
+      throw new RuntimeException("storage " + storage.getBasePath() + " is corrupted");
     }
     if (storage.isCorrupted()) {
       storage = getRepairedStorage(event.getAppId(), event.getShuffleId(), event.getStartPartition());
@@ -142,7 +142,7 @@ public class LocalStorageManager extends SingleStorageManager {
   void repair() {
     boolean hasNewCorruptedStorage = false;
     for (LocalStorage storage : localStorages) {
-      if (storage.isCorrupted() && corruptedStorages.contains(storage.getBasePath())) {
+      if (storage.isCorrupted() && !corruptedStorages.contains(storage.getBasePath())) {
         hasNewCorruptedStorage = true;
         corruptedStorages.add(storage.getBasePath());
       }

--- a/server/src/main/java/com/tencent/rss/server/storage/MultiStorageManager.java
+++ b/server/src/main/java/com/tencent/rss/server/storage/MultiStorageManager.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.tencent.rss.server.Checker;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
 import com.tencent.rss.server.ShuffleDataReadEvent;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -128,6 +129,11 @@ public class MultiStorageManager implements StorageManager {
         uploader.stop();
       }
     }
+  }
+
+  @Override
+  public Checker getStorageChecker() {
+    return warmStorageManager.getStorageChecker();
   }
 
   @Override

--- a/server/src/main/java/com/tencent/rss/server/storage/SingleStorageManager.java
+++ b/server/src/main/java/com/tencent/rss/server/storage/SingleStorageManager.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.util.RssUtils;
+import com.tencent.rss.server.Checker;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.server.ShuffleServerMetrics;
@@ -136,5 +137,10 @@ public abstract class SingleStorageManager implements StorageManager {
   @Override
   public void stop() {
     // do nothing
+  }
+
+  @Override
+  public Checker getStorageChecker() {
+    throw new RuntimeException("Not support storage checker");
   }
 }

--- a/server/src/main/java/com/tencent/rss/server/storage/StorageManager.java
+++ b/server/src/main/java/com/tencent/rss/server/storage/StorageManager.java
@@ -20,6 +20,7 @@ package com.tencent.rss.server.storage;
 
 import java.util.Set;
 
+import com.tencent.rss.server.Checker;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
 import com.tencent.rss.server.ShuffleDataReadEvent;
 import com.tencent.rss.storage.common.Storage;
@@ -43,6 +44,8 @@ public interface StorageManager {
   void start();
 
   void stop();
+
+  Checker getStorageChecker();
 
   // todo: add an interface that check storage isHealthy
 }

--- a/server/src/test/java/com/tencent/rss/server/HealthCheckTest.java
+++ b/server/src/test/java/com/tencent/rss/server/HealthCheckTest.java
@@ -17,10 +17,12 @@
 
 package com.tencent.rss.server;
 
-import com.tencent.rss.storage.util.StorageType;
+import com.google.common.collect.Lists;
 import org.junit.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.tencent.rss.storage.util.StorageType;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -28,7 +30,7 @@ import static org.junit.Assert.assertTrue;
 public class HealthCheckTest {
 
   @Test
-  public void constructorTest() {
+  public void buildInCheckerTest() {
     ShuffleServerConf conf = new ShuffleServerConf();
     assertConf(conf);
     conf.setString(ShuffleServerConf.HEALTH_CHECKER_CLASS_NAMES, "");
@@ -43,9 +45,6 @@ public class HealthCheckTest {
     conf.set(ShuffleServerConf.HEALTH_MIN_STORAGE_PERCENTAGE, 102.0);
     assertConf(conf);
     conf.set(ShuffleServerConf.HEALTH_MIN_STORAGE_PERCENTAGE, 1.0);
-    conf.set(ShuffleServerConf.HEALTH_CHECK_INTERVAL, -1L);
-    assertConf(conf);
-    conf.set(ShuffleServerConf.HEALTH_CHECK_INTERVAL, 1L);
     conf.set(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, -1.0);
     assertConf(conf);
     conf.set(ShuffleServerConf.HEALTH_STORAGE_MAX_USAGE_PERCENTAGE, 101.0);
@@ -56,7 +55,7 @@ public class HealthCheckTest {
     conf.set(ShuffleServerConf.HEALTH_STORAGE_RECOVERY_USAGE_PERCENTAGE, 101.0);
     assertConf(conf);
     conf.set(ShuffleServerConf.HEALTH_STORAGE_RECOVERY_USAGE_PERCENTAGE, 1.0);
-    new HealthCheck(new AtomicBoolean(), conf);
+    new LocalStorageChecker(conf, Lists.newArrayList());
   }
 
   @Test
@@ -64,16 +63,16 @@ public class HealthCheckTest {
     AtomicBoolean healthy = new AtomicBoolean(false);
     ShuffleServerConf conf = new ShuffleServerConf();
     conf.setString(ShuffleServerConf.HEALTH_CHECKER_CLASS_NAMES, HealthyMockChecker.class.getCanonicalName());
-    HealthCheck checker = new HealthCheck(healthy, conf);
+    HealthCheck checker = new HealthCheck(healthy, conf, Lists.newArrayList());
     checker.check();
     assertTrue(healthy.get());
     conf.setString(ShuffleServerConf.HEALTH_CHECKER_CLASS_NAMES, UnHealthyMockChecker.class.getCanonicalName());
-    checker = new HealthCheck(healthy, conf);
+    checker = new HealthCheck(healthy, conf, Lists.newArrayList());
     checker.check();
     assertFalse(healthy.get());
     conf.setString(ShuffleServerConf.HEALTH_CHECKER_CLASS_NAMES,
         UnHealthyMockChecker.class.getCanonicalName() + "," + HealthyMockChecker.class.getCanonicalName());
-    checker = new HealthCheck(healthy, conf);
+    checker = new HealthCheck(healthy, conf, Lists.newArrayList());
     checker.check();
     assertFalse(healthy.get());
   }
@@ -82,7 +81,7 @@ public class HealthCheckTest {
     boolean isThrown;
     isThrown = false;
     try {
-      new HealthCheck(new AtomicBoolean(), conf);
+      new LocalStorageChecker(conf, Lists.newArrayList());
     } catch (IllegalArgumentException e) {
       isThrown = true;
     }

--- a/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
@@ -17,10 +17,14 @@
 
 package com.tencent.rss.server;
 
+import com.google.common.collect.Lists;
+import com.tencent.rss.storage.common.LocalStorage;
 import com.tencent.rss.storage.util.StorageType;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.List;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -32,10 +36,15 @@ public class StorageCheckerTest {
   @Test
   public void checkTest() throws Exception {
     ShuffleServerConf conf = new ShuffleServerConf();
+    conf.setBoolean(ShuffleServerConf.HEALTH_CHECK_ENABLE, true);
     conf.setString(ShuffleServerConf.RSS_STORAGE_TYPE, StorageType.LOCALFILE.name());
     conf.set(ShuffleServerConf.RSS_STORAGE_BASE_PATH, "st1,st2,st3");
     conf.set(ShuffleServerConf.HEALTH_MIN_STORAGE_PERCENTAGE, 55.0);
-    LocalStorageChecker checker = new MockStorageChecker(conf);
+    List<LocalStorage> storages = Lists.newArrayList();
+    storages.add(LocalStorage.newBuilder().basePath("st1").build());
+    storages.add(LocalStorage.newBuilder().basePath("st2").build());
+    storages.add(LocalStorage.newBuilder().basePath("st3").build());
+    LocalStorageChecker checker = new MockStorageChecker(conf, storages);
 
     assertTrue(checker.checkIsHealthy());
 
@@ -48,7 +57,7 @@ public class StorageCheckerTest {
     callTimes++;
     assertTrue(checker.checkIsHealthy());
     conf.set(ShuffleServerConf.HEALTH_MIN_STORAGE_PERCENTAGE, 80.0);
-    checker = new MockStorageChecker(conf);
+    checker = new MockStorageChecker(conf, storages);
     assertFalse(checker.checkIsHealthy());
 
     callTimes++;
@@ -57,8 +66,8 @@ public class StorageCheckerTest {
   }
 
   private class MockStorageChecker extends LocalStorageChecker {
-    public MockStorageChecker(ShuffleServerConf conf) {
-      super(conf, null);
+    public MockStorageChecker(ShuffleServerConf conf, List<LocalStorage> storages) {
+      super(conf, storages);
     }
 
     @Override

--- a/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
@@ -58,7 +58,7 @@ public class StorageCheckerTest {
 
   private class MockStorageChecker extends LocalStorageChecker {
     public MockStorageChecker(ShuffleServerConf conf) {
-      super(conf);
+      super(conf, null);
     }
 
     @Override

--- a/storage/src/main/java/com/tencent/rss/storage/common/AbstractStorage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/AbstractStorage.java
@@ -24,22 +24,25 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 
 import com.tencent.rss.common.util.RssUtils;
+import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
+import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
+import com.tencent.rss.storage.util.ShuffleStorageUtils;
 
 public abstract class AbstractStorage implements Storage {
 
-  private Map<String, Map<String, ShuffleWriteHandler>> handlers = Maps.newConcurrentMap();
+  private Map<String, Map<String, ShuffleWriteHandler>> writerHandlers = Maps.newConcurrentMap();
   private Map<String, Map<String, CreateShuffleWriteHandlerRequest>> requests = Maps.newConcurrentMap();
+  private Map<String, Map<String, ServerReadHandler>> readerHandlers = Maps.newConcurrentMap();
 
   abstract ShuffleWriteHandler newWriteHandler(CreateShuffleWriteHandlerRequest request);
 
   @Override
   public ShuffleWriteHandler getOrCreateWriteHandler(CreateShuffleWriteHandlerRequest request) {
-
-    handlers.computeIfAbsent(request.getAppId(), key -> Maps.newConcurrentMap());
+    writerHandlers.computeIfAbsent(request.getAppId(), key -> Maps.newConcurrentMap());
     requests.computeIfAbsent(request.getAppId(), key -> Maps.newConcurrentMap());
-    Map<String, ShuffleWriteHandler> map = handlers.get(request.getAppId());
+    Map<String, ShuffleWriteHandler> map = writerHandlers.get(request.getAppId());
     String partitionKey = RssUtils.generatePartitionKey(
         request.getAppId(),
         request.getShuffleId(),
@@ -49,6 +52,30 @@ public abstract class AbstractStorage implements Storage {
     Map<String, CreateShuffleWriteHandlerRequest> requestMap = requests.get(request.getAppId());
     requestMap.putIfAbsent(partitionKey, request);
     return map.get(partitionKey);
+  }
+
+  @Override
+  public ServerReadHandler getOrCreateReadHandler(CreateShuffleReadHandlerRequest request) {
+    readerHandlers.computeIfAbsent(request.getAppId(), key -> Maps.newConcurrentMap());
+    Map<String, ServerReadHandler> map = readerHandlers.get(request.getAppId());
+    int[] range = ShuffleStorageUtils.getPartitionRange(
+        request.getPartitionId(),
+        request.getPartitionNumPerRange(),
+        request.getPartitionNum());
+    String partitionKey = RssUtils.generatePartitionKey(
+        request.getAppId(),
+        request.getShuffleId(),
+        range[0]
+    );
+    map.computeIfAbsent(partitionKey, key -> newReadHandler(request));
+    return null;
+  }
+
+  protected abstract ServerReadHandler newReadHandler(CreateShuffleReadHandlerRequest request);
+
+  public boolean containsWriteHandler(String appId, int shuffleId, int partition) {
+    String partitionKey = RssUtils.generatePartitionKey(appId, shuffleId, partition);
+    return writerHandlers.containsKey(partitionKey);
   }
 
   @Override
@@ -65,12 +92,13 @@ public abstract class AbstractStorage implements Storage {
 
   @Override
   public void removeHandlers(String appId) {
-    handlers.remove(appId);
+    writerHandlers.remove(appId);
+    readerHandlers.remove(appId);
     requests.remove(appId);
   }
 
   @VisibleForTesting
   public int getHandlerSize() {
-    return handlers.size();
+    return writerHandlers.size();
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/common/AbstractStorage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/AbstractStorage.java
@@ -68,7 +68,7 @@ public abstract class AbstractStorage implements Storage {
         range[0]
     );
     map.computeIfAbsent(partitionKey, key -> newReadHandler(request));
-    return null;
+    return map.get(partitionKey);
   }
 
   protected abstract ServerReadHandler newReadHandler(CreateShuffleReadHandlerRequest request);

--- a/storage/src/main/java/com/tencent/rss/storage/common/HdfsStorage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/HdfsStorage.java
@@ -20,8 +20,10 @@ package com.tencent.rss.storage.common;
 
 import org.apache.hadoop.conf.Configuration;
 
+import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
 import com.tencent.rss.storage.handler.impl.HdfsShuffleWriteHandler;
+import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
 
 public class HdfsStorage extends AbstractStorage {
@@ -84,6 +86,11 @@ public class HdfsStorage extends AbstractStorage {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  protected ServerReadHandler newReadHandler(CreateShuffleReadHandlerRequest request) {
+    throw new RuntimeException("Hdfs storage don't support to read from sever");
   }
 
   @Override

--- a/storage/src/main/java/com/tencent/rss/storage/common/LocalStorage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/LocalStorage.java
@@ -33,8 +33,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.common.util.RssUtils;
+import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
+import com.tencent.rss.storage.handler.impl.LocalFileServerReadHandler;
 import com.tencent.rss.storage.handler.impl.LocalFileWriteHandler;
+import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
 
 public class LocalStorage extends AbstractStorage {
@@ -51,7 +54,9 @@ public class LocalStorage extends AbstractStorage {
   private final Queue<String> expiredShuffleKeys = Queues.newLinkedBlockingQueue();
 
   private LocalStorageMeta metaData = new LocalStorageMeta();
-  private boolean canWrite = true;
+  private boolean isSpaceEnough = true;
+  private volatile boolean isCorrupted = false;
+
 
   private LocalStorage(Builder builder) {
     this.basePath = builder.basePath;
@@ -142,13 +147,24 @@ public class LocalStorage extends AbstractStorage {
   }
 
   @Override
+  protected ServerReadHandler newReadHandler(CreateShuffleReadHandlerRequest request) {
+    return new LocalFileServerReadHandler(
+        request.getAppId(),
+        request.getShuffleId(),
+        request.getPartitionId(),
+        request.getPartitionNumPerRange(),
+        request.getPartitionNum(),
+        request.getPath());
+  }
+
+  @Override
   public boolean canWrite() {
-    if (canWrite) {
-      canWrite = metaData.getDiskSize().doubleValue() * 100 / capacity < highWaterMarkOfWrite;
+    if (isSpaceEnough) {
+      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < highWaterMarkOfWrite;
     } else {
-      canWrite = metaData.getDiskSize().doubleValue() * 100 / capacity < lowWaterMarkOfWrite;
+      isSpaceEnough = metaData.getDiskSize().doubleValue() * 100 / capacity < lowWaterMarkOfWrite;
     }
-    return canWrite;
+    return isSpaceEnough && !isCorrupted;
   }
 
   public String getBasePath() {
@@ -272,6 +288,14 @@ public class LocalStorage extends AbstractStorage {
 
   public Queue<String> getExpiredShuffleKeys() {
     return expiredShuffleKeys;
+  }
+
+  public boolean isCorrupted() {
+    return isCorrupted;
+  }
+
+  public void markCorrupted() {
+    isCorrupted = true;
   }
 
   public static class Builder {

--- a/storage/src/main/java/com/tencent/rss/storage/common/LocalStorage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/LocalStorage.java
@@ -154,7 +154,7 @@ public class LocalStorage extends AbstractStorage {
         request.getPartitionId(),
         request.getPartitionNumPerRange(),
         request.getPartitionNum(),
-        request.getPath());
+        basePath);
   }
 
   @Override

--- a/storage/src/main/java/com/tencent/rss/storage/common/Storage.java
+++ b/storage/src/main/java/com/tencent/rss/storage/common/Storage.java
@@ -20,7 +20,9 @@ package com.tencent.rss.storage.common;
 
 import java.io.IOException;
 
+import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.handler.api.ShuffleWriteHandler;
+import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleWriteHandlerRequest;
 
 
@@ -41,6 +43,8 @@ public interface Storage {
   void updateReadMetrics(StorageReadMetrics metrics);
 
   ShuffleWriteHandler getOrCreateWriteHandler(CreateShuffleWriteHandlerRequest request) throws IOException;
+
+  ServerReadHandler getOrCreateReadHandler(CreateShuffleReadHandlerRequest request);
 
   CreateShuffleWriteHandlerRequest getCreateWriterHandlerRequest(String appId, int shuffleId, int partition);
 

--- a/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
+++ b/storage/src/main/java/com/tencent/rss/storage/factory/ShuffleHandlerFactory.java
@@ -26,19 +26,16 @@ import com.tencent.rss.client.factory.ShuffleServerClientFactory;
 import com.tencent.rss.client.util.ClientType;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
-import com.tencent.rss.storage.handler.api.ServerReadHandler;
 import com.tencent.rss.storage.handler.api.ShuffleDeleteHandler;
 import com.tencent.rss.storage.handler.impl.ComposedClientReadHandler;
 import com.tencent.rss.storage.handler.impl.HdfsClientReadHandler;
 import com.tencent.rss.storage.handler.impl.HdfsShuffleDeleteHandler;
 import com.tencent.rss.storage.handler.impl.LocalFileDeleteHandler;
 import com.tencent.rss.storage.handler.impl.LocalFileQuorumClientReadHandler;
-import com.tencent.rss.storage.handler.impl.LocalFileServerReadHandler;
 import com.tencent.rss.storage.handler.impl.MemoryQuorumClientReadHandler;
 import com.tencent.rss.storage.handler.impl.UploadedHdfsClientReadHandler;
 import com.tencent.rss.storage.request.CreateShuffleDeleteHandlerRequest;
 import com.tencent.rss.storage.request.CreateShuffleReadHandlerRequest;
-import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import com.tencent.rss.storage.util.StorageType;
 
 public class ShuffleHandlerFactory {
@@ -237,21 +234,6 @@ public class ShuffleHandlerFactory {
     } else {
       throw new UnsupportedOperationException(
           "Doesn't support storage type for client read handler:" + request.getStorageType());
-    }
-  }
-
-  public ServerReadHandler createServerReadHandler(CreateShuffleReadHandlerRequest request) {
-    if (ShuffleStorageUtils.containsLocalFile(request.getStorageType())) {
-      return new LocalFileServerReadHandler(
-          request.getAppId(),
-          request.getShuffleId(),
-          request.getPartitionId(),
-          request.getPartitionNumPerRange(),
-          request.getPartitionNum(),
-          request.getRssBaseConf());
-    } else {
-      throw new UnsupportedOperationException(
-          "Doesn't support storage type for server read handler:" + request.getStorageType());
     }
   }
 

--- a/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileServerReadHandler.java
+++ b/storage/src/main/java/com/tencent/rss/storage/handler/impl/LocalFileServerReadHandler.java
@@ -26,7 +26,6 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleIndexResult;
-import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import com.tencent.rss.storage.handler.api.ServerReadHandler;
@@ -47,11 +46,11 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
       int partitionId,
       int partitionNumPerRange,
       int partitionNum,
-      RssBaseConf rssBaseConf) {
+      String path) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
-    init(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, rssBaseConf);
+    init(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, path);
   }
 
   private void init(
@@ -60,18 +59,12 @@ public class LocalFileServerReadHandler implements ServerReadHandler {
       int partitionId,
       int partitionNumPerRange,
       int partitionNum,
-      RssBaseConf rssBaseConf) {
-    String allLocalPath = rssBaseConf.get(RssBaseConf.RSS_STORAGE_BASE_PATH);
-    String[] storageBasePaths = allLocalPath.split(",");
+      String path) {
 
     long start = System.currentTimeMillis();
-    if (storageBasePaths.length > 0) {
-      int[] range = ShuffleStorageUtils.getPartitionRange(partitionId, partitionNumPerRange, partitionNum);
-      int index = ShuffleStorageUtils.getStorageIndex(storageBasePaths.length, appId, shuffleId, range[0]);
-      prepareFilePath(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, storageBasePaths[index]);
-    } else {
-      throw new RuntimeException("Can't get base path, please check rss.storage.localFile.basePaths.");
-    }
+    // int[] range = ShuffleStorageUtils.getPartitionRange(partitionId, partitionNumPerRange, partitionNum);
+    // int index = ShuffleStorageUtils.getStorageIndex(storageBasePaths.length, appId, shuffleId, range[0]);
+    prepareFilePath(appId, shuffleId, partitionId, partitionNumPerRange, partitionNum, path);
     LOG.debug("Prepare for appId[" + appId + "], shuffleId[" + shuffleId + "], partitionId[" + partitionId
         + "] cost " + (System.currentTimeMillis() - start) + " ms");
   }

--- a/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
@@ -42,6 +42,7 @@ public class CreateShuffleReadHandlerRequest {
   private List<ShuffleServerInfo> shuffleServerInfoList;
   private Roaring64NavigableMap expectBlockIds;
   private Roaring64NavigableMap processBlockIds;
+  private String path;
 
   public CreateShuffleReadHandlerRequest() {
   }
@@ -156,5 +157,13 @@ public class CreateShuffleReadHandlerRequest {
 
   public Roaring64NavigableMap getProcessBlockIds() {
     return processBlockIds;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
   }
 }

--- a/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
+++ b/storage/src/main/java/com/tencent/rss/storage/request/CreateShuffleReadHandlerRequest.java
@@ -42,7 +42,6 @@ public class CreateShuffleReadHandlerRequest {
   private List<ShuffleServerInfo> shuffleServerInfoList;
   private Roaring64NavigableMap expectBlockIds;
   private Roaring64NavigableMap processBlockIds;
-  private String path;
 
   public CreateShuffleReadHandlerRequest() {
   }
@@ -157,13 +156,5 @@ public class CreateShuffleReadHandlerRequest {
 
   public Roaring64NavigableMap getProcessBlockIds() {
     return processBlockIds;
-  }
-
-  public String getPath() {
-    return path;
-  }
-
-  public void setPath(String path) {
-    this.path = path;
   }
 }

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
@@ -86,9 +86,9 @@ public class LocalFileHandlerTest {
     RssBaseConf conf = new RssBaseConf();
     conf.setString("rss.storage.basePath", dataDir1.getAbsolutePath() + "," + dataDir2.getAbsolutePath());
     LocalFileServerReadHandler readHandler1 = new LocalFileServerReadHandler(
-        "appId", 0, 1, 1, 10, conf);
+        "appId", 0, 1, 1, 10, dataDir1.getAbsolutePath());
     LocalFileServerReadHandler readHandler2 = new LocalFileServerReadHandler(
-        "appId", 0, 2, 1, 10, conf);
+        "appId", 0, 2, 1, 10, dataDir2.getAbsolutePath());
 
     validateResult(readHandler1, expectedBlockIds1, expectedData);
     validateResult(readHandler2, expectedBlockIds2, expectedData);

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
@@ -88,7 +88,7 @@ public class LocalFileHandlerTest {
     LocalFileServerReadHandler readHandler1 = new LocalFileServerReadHandler(
         "appId", 0, 1, 1, 10, dataDir1.getAbsolutePath());
     LocalFileServerReadHandler readHandler2 = new LocalFileServerReadHandler(
-        "appId", 0, 2, 1, 10, dataDir2.getAbsolutePath());
+        "appId", 0, 2, 1, 10, dataDir1.getAbsolutePath());
 
     validateResult(readHandler1, expectedBlockIds1, expectedData);
     validateResult(readHandler2, expectedBlockIds2, expectedData);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/Tencent/Firestorm/blob/master/CONTRIBUTING.md
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]XXXX Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
-->

### What changes were proposed in this pull request?
We check disk periodically, when a disk can't be read or write,  we think this disk is corrupted, and shuffle server won't use this disk again. 

### Why are the changes needed?
Sometimes the disk of server will be corrupted, we hope to reduce the influence.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New UT
