### PR TITLE
[Feature][WIP] Firestorm supports quorum write/read

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssClientConfig.java
@@ -73,6 +73,10 @@ public class RssClientConfig {
   public static int RSS_CLIENT_SEND_THREAD_POOL_KEEPALIVE_DEFAULT_VALUE = 60;
   public static String RSS_DATA_REPLICA = "spark.rss.data.replica";
   public static int RSS_DATA_REPLICA_DEFAULT_VALUE = 1;
+  public static String RSS_DATA_REPLICA_WRITE = "spark.rss.data.replica.write";
+  public static int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = 1;
+  public static String RSS_DATA_REPLICA_READ = "spark.rss.data.replica.read";
+  public static int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = 1;
   public static String RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE = "spark.rss.ozone.dfs.namenode.odfs.enable";
   public static boolean RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE_DEFAULT_VALUE = false;
   public static String RSS_OZONE_FS_HDFS_IMPL = "spark.rss.ozone.fs.hdfs.impl";

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -74,6 +74,9 @@ public class RssShuffleManager implements ShuffleManager {
   private Map<String, Set<Long>> taskToSuccessBlockIds = Maps.newConcurrentMap();
   private Map<String, Set<Long>> taskToFailedBlockIds = Maps.newConcurrentMap();
   private Map<String, WriteBufferManager> taskToBufferManager = Maps.newConcurrentMap();
+  private int dataReplica;
+  private int dataReplicaWrite;
+  private int dataReplicaRead;
   private boolean heartbeatStarted = false;
   private ThreadPoolExecutor threadPoolExecutor;
   private EventLoop eventLoop = new EventLoop<AddBlockEvent>("ShuffleDataQueue") {
@@ -122,6 +125,25 @@ public class RssShuffleManager implements ShuffleManager {
   };
 
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
+    // set & check replica config
+    dataReplica = sparkConf.getInt(RssClientConfig.RSS_DATA_REPLICA,
+      RssClientConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
+    dataReplicaWrite =  sparkConf.getInt(RssClientConfig.RSS_DATA_REPLICA_WRITE,
+      RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
+    dataReplicaRead =  sparkConf.getInt(RssClientConfig.RSS_DATA_REPLICA_READ,
+      RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+    LOG.info("Create RssShuffleManager with replica config ["
+      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + "]");
+    if (dataReplica == 1) {
+      if (dataReplicaWrite != 1 || dataReplicaRead != 1) {
+        throw new RuntimeException("Replica config is invalid");
+      }
+    } else if (1 < dataReplica) {
+      if (dataReplica <= dataReplicaWrite + dataReplicaRead) {
+        LOG.warn("Replica config is unsafe, recommend replica.write + replica.read > replica");
+      }
+    }
+
     this.sparkConf = sparkConf;
     this.clientType = sparkConf.get(RssClientConfig.RSS_CLIENT_TYPE,
         RssClientConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
@@ -136,7 +158,8 @@ public class RssShuffleManager implements ShuffleManager {
         RssClientConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE);
     shuffleWriteClient = ShuffleClientFactory
         .getInstance()
-        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
+        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
+          dataReplica, dataReplicaWrite, dataReplicaRead);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
     if (isDriver && sparkConf.getBoolean(
@@ -184,12 +207,11 @@ public class RssShuffleManager implements ShuffleManager {
 
     int partitionNumPerRange = sparkConf.getInt(RssClientConfig.RSS_PARTITION_NUM_PER_RANGE,
         RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
-    int dataReplica = sparkConf.getInt(RssClientConfig.RSS_DATA_REPLICA,
-        RssClientConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
+
     // get all register info according to coordinator's response
     ShuffleAssignmentsInfo response = shuffleWriteClient.getShuffleAssignments(
         appId, shuffleId, dependency.partitioner().numPartitions(),
-        partitionNumPerRange, dataReplica, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
+        partitionNumPerRange, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     Map<Integer, List<ShuffleServerInfo>> partitionToServers = response.getPartitionToServers();
 
     startHeartbeat();

--- a/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
@@ -54,7 +54,7 @@ public interface ShuffleWriteClient {
       int bitmapNum);
 
   ShuffleAssignmentsInfo getShuffleAssignments(String appId, int shuffleId, int partitionNum,
-      int partitionNumPerRange, int dataReplica, Set<String> requiredTags);
+      int partitionNumPerRange, Set<String> requiredTags);
 
   Roaring64NavigableMap getShuffleResult(String clientType, Set<ShuffleServerInfo> shuffleServerInfoSet,
       String appId, int shuffleId, int partitionId);

--- a/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
@@ -36,8 +36,10 @@ public class ShuffleClientFactory {
   }
 
   public ShuffleWriteClient createShuffleWriteClient(
-      String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum) {
-    return new ShuffleWriteClientImpl(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
+      String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
+      int replica, int replicaWrite, int replicaRead) {
+    return new ShuffleWriteClientImpl(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
+      replica, replicaWrite, replicaRead);
   }
 
   public ShuffleReadClient createShuffleReadClient(CreateShuffleReadClientRequest request) {

--- a/client/src/main/java/com/tencent/rss/client/response/SendShuffleDataResult.java
+++ b/client/src/main/java/com/tencent/rss/client/response/SendShuffleDataResult.java
@@ -18,12 +18,15 @@
 
 package com.tencent.rss.client.response;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class SendShuffleDataResult {
 
   private Set<Long> successBlockIds;
   private Set<Long> failedBlockIds;
+  private Map<Long, AtomicLong> blockIdsTracker;
 
   public SendShuffleDataResult(Set<Long> successBlockIds, Set<Long> failedBlockIds) {
     this.successBlockIds = successBlockIds;
@@ -36,5 +39,9 @@ public class SendShuffleDataResult {
 
   public Set<Long> getFailedBlockIds() {
     return failedBlockIds;
+  }
+
+  public Map<Long, AtomicLong> getBlockIdsTracker() {
+    return blockIdsTracker;
   }
 }

--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
@@ -42,7 +42,7 @@ public class ShuffleWriteClientImplTest {
   @Test
   public void testSendData() {
     ShuffleWriteClientImpl shuffleWriteClient =
-        new ShuffleWriteClientImpl("GRPC", 3, 2000, 4);
+        new ShuffleWriteClientImpl("GRPC", 3, 2000, 4, 1, 1, 1);
     ShuffleServerClient mockShuffleServerClient = mock(ShuffleServerClient.class);
     ShuffleWriteClientImpl spyClient = spy(shuffleWriteClient);
     doReturn(mockShuffleServerClient).when(spyClient).getShuffleServerClient(any());

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
@@ -96,7 +96,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
   public void clearResourceTest() throws Exception {
     final ShuffleWriteClient shuffleWriteClient =
         ShuffleClientFactory.getInstance().createShuffleWriteClient(
-            "GRPC", 2, 10000L, 4);
+            "GRPC", 2, 10000L, 4, 1, 1, 1);
     shuffleWriteClient.registerCoordinators("127.0.0.1:19999");
     shuffleWriteClient.registerShuffle(
         new ShuffleServerInfo("127.0.0.1-20001", "127.0.0.1", 20001),

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
@@ -85,7 +85,8 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
 
   @Before
   public void createClient() {
-    shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1);
+    shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
+      2, 1, 1);
   }
 
   @After
@@ -110,13 +111,11 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
     Roaring64NavigableMap failedBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap succBlockIdBitmap = Roaring64NavigableMap.bitmapOf();
-    for (Long blockId : result.getFailedBlockIds()) {
-      failedBlockIdBitmap.addLong(blockId);
-    }
     for (Long blockId : result.getSuccessBlockIds()) {
       succBlockIdBitmap.addLong(blockId);
     }
-    assertEquals(blockIdBitmap, failedBlockIdBitmap);
+    // There will no failed blocks when replica=2
+    assertEquals(failedBlockIdBitmap.getLongCardinality(), 0);
     assertEquals(blockIdBitmap, succBlockIdBitmap);
 
     boolean commitResult = shuffleWriteClientImpl.sendCommit(Sets.newHashSet(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor the client to support quorum write/read.

### Why are the changes needed?
 Without this patch, Firestorm cannot tolerate server failures before the shuffle is accomplished.

### Does this PR introduce _any_ user-facing change?
Yes.
The user is allowed to configure quorum with
spark.rss.data.replica=N
spark.rss.data.replica.write=W
spark.rss.data.replica.read=R

### How was this patch tested?
UTs
