### PR TITLE
[Bugfix] Exist memory leak when we use aqe

### DIFF
--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -303,7 +303,7 @@ public class RssShuffleManager implements ShuffleManager {
       endMapIndex);
     LOG.info("Get taskId cost " + (System.currentTimeMillis() - start) + " ms, and request expected blockIds from "
       + taskIdBitmap.getLongCardinality() + " tasks for shuffleId[" + handle.shuffleId() + "], partitionId["
-      + startPartition + "]");
+      + startPartition + ", " + endPartition +"]");
     return getReaderImpl(handle, startMapIndex, endMapIndex, startPartition, endPartition,
         context, metrics, taskIdBitmap);
   }
@@ -326,7 +326,7 @@ public class RssShuffleManager implements ShuffleManager {
       endMapIndex);
     LOG.info("Get taskId cost " + (System.currentTimeMillis() - start) + " ms, and request expected blockIds from "
       + taskIdBitmap.getLongCardinality() + " tasks for shuffleId[" + handle.shuffleId() + "], partitionId["
-      + startPartition + "]");
+      + startPartition + ", " + endPartition + "]");
     return getReaderImpl(handle, startMapIndex, endMapIndex, startPartition, endPartition,
         context, metrics, taskIdBitmap);
   }
@@ -366,7 +366,7 @@ public class RssShuffleManager implements ShuffleManager {
       partitionToExpectBlocks.put(partition, blockIdBitmap);
       LOG.info("Get shuffle blockId cost " + (System.currentTimeMillis() - start) + " ms, and get "
           + blockIdBitmap.getLongCardinality() + " blockIds for shuffleId[" + shuffleId + "], partitionId["
-          + startPartition + "]");
+          + partition + "]");
     }
 
     ShuffleReadMetrics readMetrics;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -303,7 +303,7 @@ public class RssShuffleManager implements ShuffleManager {
       endMapIndex);
     LOG.info("Get taskId cost " + (System.currentTimeMillis() - start) + " ms, and request expected blockIds from "
       + taskIdBitmap.getLongCardinality() + " tasks for shuffleId[" + handle.shuffleId() + "], partitionId["
-      + startPartition + ", " + endPartition +"]");
+      + startPartition + ", " + endPartition + "]");
     return getReaderImpl(handle, startMapIndex, endMapIndex, startPartition, endPartition,
         context, metrics, taskIdBitmap);
   }

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/reader/RssShuffleReader.java
@@ -201,6 +201,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
       iterator = iterators.iterator();
       if (iterator.hasNext()) {
         dataIterator = iterator.next();
+        iterator.remove();
       }
     }
 
@@ -214,6 +215,7 @@ public class RssShuffleReader<K, C> implements ShuffleReader<K, C> {
           return false;
         }
         dataIterator = iterator.next();
+        iterator.remove();
       }
       return dataIterator.hasNext();
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When we finish to use RssShuffleDataIterator, we release the RssShuffleDataIterator's memory.

### Why are the changes needed?
When we use aqe, if there too many partitions, RssShuffleIterator will occupy much memory, the executor will become out of memory.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually test. Run 10T's tpcds query1 with `spark.sql.adaptive.advisoryPartitionSizeInBytes 256000000` 
