### PR TITLE
[Bugfix] Add timestamp to avoid the conflicts of gc.log after server …

### DIFF
--- a/bin/start-shuffle-server.sh
+++ b/bin/start-shuffle-server.sh
@@ -83,7 +83,7 @@ JVM_ARGS=" -server \
           -XX:+PrintGCDateStamps \
           -XX:+PrintGCTimeStamps \
           -XX:+PrintGCDetails \
-          -Xloggc:./logs/gc.log"
+          -Xloggc:./logs/gc-%t.log"
 
 ARGS=""
 if [ -f ./conf/log4j.properties ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a timestamp as the suffix of gc log.

### Why are the changes needed?
JVM will rewrite gc.log after restart.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By hand.
