### PR TITLE
[Feature] Firestorm supports MapReduce (Part 1 - AppMaster)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,7 +57,7 @@ jobs:
         path: "**/target/surefire-reports/*.txt"
     - name: Build with Maven with Profile mr
       run: mvn -B package --file pom.xml -Pmr
-    - name: Upload spark3 test results to report
+    - name: Upload mr test results to report
       if: failure()
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,3 +55,11 @@ jobs:
       with:
         name: test-results-of-rss-spark3
         path: "**/target/surefire-reports/*.txt"
+    - name: Build with Maven with Profile mr
+      run: mvn -B package --file pom.xml -Pmr
+    - name: Upload spark3 test results to report
+      if: failure()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results-of-rss-mr
+        path: "**/target/surefire-reports/*.txt"

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -55,6 +55,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -26,7 +26,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>client-mr</artifactId>
+    <artifactId>rss-client-mr</artifactId>
     <dependencies>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Tencent is pleased to support the open source community by making
+  Firestorm-Spark remote shuffle server available.
+
+  Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of the
+  License at
+
+  https://opensource.org/licenses/Apache-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations under the License.
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -14,12 +31,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>2.8.5</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-app</artifactId>
-            <version>2.8.5</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -31,13 +48,112 @@
             <artifactId>rss-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.tencent.rss</groupId>
-            <artifactId>rss-client-spark-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>rss-client-mr-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/shaded</outputDirectory>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.tencent.rss:*</include>
+                                    <include>com.google.protobuf:*</include>
+                                    <include>com.google.code.gson:gson</include>
+                                    <include>io.grpc:*</include>
+                                    <include>com.google.android:annotations</include>
+                                    <include>io.perfmark:perfmark-api</include>
+                                    <include>io.netty:netty-all</include>
+                                    <include>com.google.api.grpc:proto-google-common-protos</include>
+                                    <include>org.codehaus.mojo:animal-sniffer-annotations</include>
+                                    <include>com.google.guava:*</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>org.roaringbitmap:RoaringBitmap</include>
+                                    <include>org.roaringbitmap:shims</include>
+                                </includes>
+                            </artifactSet>
+                            <finalName>${project.artifactId}-${project.version}</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>LICENSE</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.com.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>google.protobuf</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.core</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.jackson.core</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.databind</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.jackson.databind</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson.annotation</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.jackson.annotation</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.io.netty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.roaringbitmap</pattern>
+                                    <shadedPattern>${rss.shade.packageName}.org.roaringbitmap</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -78,6 +78,10 @@
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-client</artifactId>
         </dependency>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -58,6 +58,17 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>rss-main</artifactId>
         <groupId>com.tencent.rss</groupId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -71,6 +71,10 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client</artifactId>
         </dependency>
     </dependencies>
 

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -32,11 +32,23 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-app</artifactId>
             <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -61,12 +73,6 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
@@ -75,6 +81,11 @@
         <dependency>
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
         </dependency>
     </dependencies>
 

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -62,7 +62,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rss-main</artifactId>
+        <groupId>com.tencent.rss</groupId>
+        <version>0.3.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>client-mr</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-app</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce;
+
+public class RssMRConfig {
+
+  public static final String RSS_CLIENT_HEARTBEAT_THREAD_NUM = "mapreduce.rss.client.heartBeat.threadNum";
+  public static final int RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE = 4;
+  public static final String RSS_CLIENT_TYPE = "mapreduce.rss.client.type";
+  public static final String RSS_CLIENT_TYPE_DEFAULT_VALUE = "GRPC";
+  public static final String RSS_CLIENT_RETRY_MAX = "mapreduce.rss.client.retry.max";
+  public static final int RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE = 100;
+  public static final String RSS_CLIENT_RETRY_INTERVAL_MAX = "mapreduce.rss.client.retry.interval.max";
+  public static final long RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE = 10000;
+  public static final String RSS_COORDINATOR_QUORUM = "mapreduce.rss.coordinator.quorum";
+  public static final String RSS_DATA_REPLICA = "mapreduce.rss.data.replica";
+  public static final int RSS_DATA_REPLICA_DEFAULT_VALUE = 1;
+  public static final String RSS_DATA_REPLICA_WRITE = "mapreduce.rss.data.replica.write";
+  public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = 1;
+  public static final String RSS_DATA_REPLICA_READ = "mapreduce.rss.data.replica.read";
+  public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = 1;
+  public static final String RSS_HEARTBEAT_INTERVAL = "mapreduce.rss.heartbeat.interval";
+  public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
+  public static final String RSS_HEARTBEAT_TIMEOUT = "mapreduce.rss.heartbeat.timeout";
+  public static final String RSS_ASSIGNMENT_PREFIX = "mapreduce.rss.assignment.partition.";
+}

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -64,6 +64,10 @@ public class RssMRAppMaster {
   public static final String RSS_COORDINATOR_QUORUM = "mapreduce.rss.coordinator.quorum";
   public static final String RSS_DATA_REPLICA = "mapreduce.rss.data.replica";
   public static final int RSS_DATA_REPLICA_DEFAULT_VALUE = 1;
+  public static final String RSS_DATA_REPLICA_WRITE = "mapreduce.rss.data.replica.write";
+  public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = 1;
+  public static final String RSS_DATA_REPLICA_READ = "mapreduce.rss.data.replica.read";
+  public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = 1;
   public static final String RSS_HEARTBEAT_INTERVAL = "mapreduce.rss.heartbeat.interval";
   public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
   public static final String RSS_HEARTBEAT_TIMEOUT = "mapreduce.rss.heartbeat.timeout";
@@ -81,9 +85,13 @@ public class RssMRAppMaster {
     long retryIntervalMax = conf.getLong(RSS_CLIENT_RETRY_INTERVAL_MAX, RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE);
     String coordinators = conf.get(RSS_COORDINATOR_QUORUM);
 
+    int replica = conf.getInt(RSS_DATA_REPLICA, RSS_DATA_REPLICA_DEFAULT_VALUE);
+    int replicaWrite = conf.getInt(RSS_DATA_REPLICA_WRITE, RSS_DATA_REPLICA_WRITE);
+    int replicaRead = conf.getInt(RSS_DATA_REPLICA_READ, RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()
-        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum, 1, 1, 1);
+        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax,
+            heartBeatThreadNum, replica, replicaWrite, replicaRead);
 
     LOG.info("Registering coordinators {}", coordinators);
     client.registerCoordinators(coordinators);

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -87,8 +87,6 @@ public class RssMRAppMaster {
 
     LOG.info("Registering coordinators {}", coordinators);
     client.registerCoordinators(coordinators);
-    int dataReplica = conf.getInt(RSS_DATA_REPLICA, RSS_DATA_REPLICA_DEFAULT_VALUE);
-    // get all register info according to coordinator's response
 
     String containerIdStr =
         System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name());

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -163,6 +164,8 @@ public class RssMRAppMaster {
       LOG.error("Modify job conf exception", e);
       throw new RuntimeException("Modify job conf exception ", e);
     }
+    // remove org.apache.hadoop.mapreduce.v2.app.MRAppMaster
+    ArrayUtils.remove(args, 0);
     MRAppMaster.main(args);
     scheduledExecutorService.shutdown();
   }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -83,7 +83,7 @@ public class RssMRAppMaster {
 
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()
-        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
+        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum, 1, 1, 1);
 
     LOG.info("Registering coordinators {}", coordinators);
     client.registerCoordinators(coordinators);
@@ -97,7 +97,7 @@ public class RssMRAppMaster {
         containerId.getApplicationAttemptId();
     ShuffleAssignmentsInfo response = client.getShuffleAssignments(
         applicationAttemptId.toString(), 0, numReduceTasks,
-        1, dataReplica, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
+        1, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
     Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges = response.getServerToPartitionRanges();
     final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     if (serverToPartitionRanges == null || serverToPartitionRanges.isEmpty()) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -86,7 +86,7 @@ public class RssMRAppMaster {
     String coordinators = conf.get(RSS_COORDINATOR_QUORUM);
 
     int replica = conf.getInt(RSS_DATA_REPLICA, RSS_DATA_REPLICA_DEFAULT_VALUE);
-    int replicaWrite = conf.getInt(RSS_DATA_REPLICA_WRITE, RSS_DATA_REPLICA_WRITE);
+    int replicaWrite = conf.getInt(RSS_DATA_REPLICA_WRITE, RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     int replicaRead = conf.getInt(RSS_DATA_REPLICA_READ, RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -96,13 +96,7 @@ public class RssMRAppMaster {
     if (serverToPartitionRanges == null || serverToPartitionRanges.isEmpty()) {
       return;
     }
-    LOG.info("Start to register shuffle");
-    long start = System.currentTimeMillis();
-    serverToPartitionRanges.entrySet().forEach(entry -> {
-      client.registerShuffle(
-          entry.getKey(), applicationAttemptId.toString(), 0, entry.getValue());
-    });
-    LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
+
     long heartbeatInterval = conf.getLong(RssMRConfig.RSS_HEARTBEAT_INTERVAL,
         RssMRConfig.RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE);
     long heartbeatTimeout = conf.getLong(RssMRConfig.RSS_HEARTBEAT_TIMEOUT, heartbeatInterval / 2);
@@ -118,6 +112,14 @@ public class RssMRAppMaster {
         heartbeatInterval / 2,
         heartbeatInterval,
         TimeUnit.MILLISECONDS);
+
+    LOG.info("Start to register shuffle");
+    long start = System.currentTimeMillis();
+    serverToPartitionRanges.entrySet().forEach(entry -> {
+      client.registerShuffle(
+          entry.getKey(), applicationAttemptId.toString(), 0, entry.getValue());
+    });
+    LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
 
     // write shuffle worker assignments to submit work directory
     // format is as below:

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -1,0 +1,159 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.hadoop.mapreduce.v2.app;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.factory.ShuffleClientFactory;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleAssignmentsInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.util.Constants;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapreduce.Cluster;
+import org.apache.hadoop.mapreduce.JobSubmissionFiles;
+import org.apache.hadoop.mapreduce.MRJobConfig;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class RssMRAppMaster {
+  private static final Logger LOG = LoggerFactory.getLogger(RssMRAppMaster.class);
+
+  public static final String RSS_CLIENT_HEARTBEAT_THREAD_NUM = "mapreduce.rss.client.heartBeat.threadNum";
+  public static final int RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE = 4;
+  public static final String RSS_CLIENT_TYPE = "mapreduce.rss.client.type";
+  public static final String RSS_CLIENT_TYPE_DEFAULT_VALUE = "GRPC";
+  public static final String RSS_CLIENT_RETRY_MAX = "mapreduce.rss.client.retry.max";
+  public static final int RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE = 100;
+  public static final String RSS_CLIENT_RETRY_INTERVAL_MAX = "mapreduce.rss.client.retry.interval.max";
+  public static final long RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE = 10000;
+  public static final String RSS_COORDINATOR_QUORUM = "mapreduce.rss.coordinator.quorum";
+  public static final String RSS_DATA_REPLICA = "mapreduce.rss.data.replica";
+  public static final int RSS_DATA_REPLICA_DEFAULT_VALUE = 1;
+  public static final String RSS_HEARTBEAT_INTERVAL = "mapreduce.rss.heartbeat.interval";
+  public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
+  public static final String RSS_HEARTBEAT_TIMEOUT = "mapreduce.rss.heartbeat.timeout";
+  public static final String RSS_ASSIGNMENT_PREFIX = "mapreduce.rss.assignment.partition.";
+
+  public static void main(String[] args) {
+
+    String containerIdStr =
+        System.getenv(ApplicationConstants.Environment.CONTAINER_ID.name());
+    ContainerId containerId = ContainerId.fromString(containerIdStr);
+    ApplicationAttemptId applicationAttemptId =
+        containerId.getApplicationAttemptId();
+    JobConf conf = new JobConf(new YarnConfiguration());
+    conf.addResource(new Path(MRJobConfig.JOB_CONF_FILE));
+    int numReduceTasks = conf.getInt(MRJobConfig.NUM_REDUCES, 0);
+    String clientType = conf.get(RSS_CLIENT_TYPE, RSS_CLIENT_TYPE_DEFAULT_VALUE);
+    int heartBeatThreadNum = conf.getInt(RSS_CLIENT_HEARTBEAT_THREAD_NUM, RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE);
+    int retryMax = conf.getInt(RSS_CLIENT_RETRY_MAX, RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE);
+    long retryIntervalMax = conf.getLong(RSS_CLIENT_RETRY_INTERVAL_MAX, RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE);
+    String coordinators = conf.get(RSS_COORDINATOR_QUORUM);
+    long heartbeatInterval = conf.getLong(RSS_HEARTBEAT_INTERVAL, RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE);
+    long heartbeatTimeout = conf.getLong(RSS_HEARTBEAT_TIMEOUT, heartbeatInterval / 2);
+
+    ShuffleWriteClient client = ShuffleClientFactory
+        .getInstance()
+        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum);
+
+    LOG.info("Registering coordinators {}", coordinators);
+    client.registerCoordinators(coordinators);
+    int dataReplica = conf.getInt(RSS_DATA_REPLICA, RSS_DATA_REPLICA_DEFAULT_VALUE);
+    // get all register info according to coordinator's response
+    ShuffleAssignmentsInfo response = client.getShuffleAssignments(
+        applicationAttemptId.toString(), 0, numReduceTasks,
+        1, dataReplica, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
+    Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges = response.getServerToPartitionRanges();
+    final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    if (serverToPartitionRanges == null || serverToPartitionRanges.isEmpty()) {
+      return;
+    }
+    LOG.info("Start to register shuffle");
+    long start = System.currentTimeMillis();
+    serverToPartitionRanges.entrySet().forEach(entry -> {
+      client.registerShuffle(
+          entry.getKey(), applicationAttemptId.toString(), 0, entry.getValue());
+    });
+    LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
+    scheduledExecutorService.scheduleAtFixedRate(
+        () -> {
+          try {
+            client.sendAppHeartbeat(applicationAttemptId.toString(), heartbeatTimeout);
+            LOG.info("Finish send heartbeat to coordinator and servers");
+          } catch (Exception e) {
+            LOG.warn("Fail to send heartbeat to coordinator and servers", e);
+          }
+        },
+        heartbeatInterval / 2,
+        heartbeatInterval,
+        TimeUnit.MILLISECONDS);
+
+    // write shuffle worker assignments to submit work directory
+    // format is as below:
+    // mapreduce.rss.assignment.partition.1:server1,server2
+    // mapreduce.rss.assignment.partition.2:server3,server4
+    // ...
+
+    response.getPartitionToServers().entrySet().forEach(entry -> {
+      List<String> servers = Lists.newArrayList();
+      for (ShuffleServerInfo server : entry.getValue()) {
+        servers.add(server.getHost() + ":" + server.getPort());
+      }
+      conf.set(RSS_ASSIGNMENT_PREFIX + entry.getKey(), StringUtils.join(servers, ","));
+    });
+    String jobDirStr = conf.get(MRJobConfig.MAPREDUCE_JOB_DIR);
+    if (jobDirStr == null) {
+      throw new RuntimeException("");
+    }
+    Path newJobConfFile = new Path(jobDirStr, MRJobConfig.JOB_CONF_FILE + ".bak");
+    Path oldJobConfFile = new Path(jobDirStr, MRJobConfig.JOB_CONF_FILE);
+    try {
+      FileSystem fs = new Cluster(conf).getFileSystem();
+      try (FSDataOutputStream out =
+             FileSystem.create(fs, newJobConfFile,
+                 new FsPermission(JobSubmissionFiles.JOB_FILE_PERMISSION))) {
+          conf.writeXml(out);
+          fs.delete(oldJobConfFile, true);
+          fs.rename(newJobConfFile, oldJobConfFile);
+      }
+    } catch (Exception e) {
+      LOG.error("Modify job conf exception", e);
+      throw new RuntimeException("Modify job conf exception ", e);
+    }
+    MRAppMaster.main(args);
+    scheduledExecutorService.shutdown();
+  }
+}

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>rss-main</artifactId>
         <groupId>com.tencent.rss</groupId>
-        <version>0.3.0</version>
+        <version>0.4.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-app</artifactId>
-            <version>2.8.5</version>
+            <version>${hadoop.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Tencent is pleased to support the open source community by making
+  Firestorm-Spark remote shuffle server available.
+
+  Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of the
+  License at
+
+  https://opensource.org/licenses/Apache-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations under the License.
+ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -17,6 +34,7 @@
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-integration-common-test</artifactId>
             <type>test-jar</type>
+            <version>0.3.0</version>
         </dependency>
 
         <dependency>
@@ -30,6 +48,27 @@
             <version>2.8.5</version>
         </dependency>
         <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>shuffle-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>coordinator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>11.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>shuffle-storage</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-app</artifactId>
             <version>2.8.5</version>
@@ -39,14 +78,7 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.tencent.rss</groupId>
-            <artifactId>rss-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.tencent.rss</groupId>
-            <artifactId>rss-client-spark-common</artifactId>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rss-main</artifactId>
+        <groupId>com.tencent.rss</groupId>
+        <version>0.3.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rss-integration-mr-test</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-core</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-minicluster</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-app</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-client-spark-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -34,7 +34,7 @@
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-integration-common-test</artifactId>
             <type>test-jar</type>
-            <version>0.3.0</version>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -34,7 +34,7 @@
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-integration-common-test</artifactId>
             <type>test-jar</type>
-            <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -46,12 +46,14 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
-            <version>2.8.5</version>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-minicluster</artifactId>
-            <version>2.8.5</version>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tencent.rss</groupId>
@@ -67,6 +69,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>21.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.tencent.rss</groupId>
@@ -88,7 +91,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -38,6 +38,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>2.8.5</version>
@@ -60,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>11.0.2</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>com.tencent.rss</groupId>

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.filecache.DistributedCache;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LargeSorterTest extends MRIntegrationTestBase {
+
+  @Test
+  public void testAppMasterStart() throws Exception {
+    URL url = LargeSorterTest.class.getResource("/");
+    String parentPath = new Path(url.getPath()).getParent()
+        .getParent().getParent().getParent().toString();
+    Configuration conf = new Configuration(mrYarnCluster.getConfig());
+    if (System.getenv("JAVA_HOME") == null) {
+      throw new RuntimeException("We must set JAVA_HOME");
+    }
+    conf.set(MRJobConfig.MR_AM_COMMAND_OPTS, "org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster");
+    conf.setInt(MRJobConfig.MAP_MEMORY_MB, 2048);
+    conf.setInt(MRJobConfig.IO_SORT_MB, 128);
+    conf.setInt(LargeSorter.NUM_MAP_TASKS, 1);
+    conf.setInt(LargeSorter.MBS_PER_MAP, 128);
+    File file = new File(parentPath, "client-mr/target/shaded");
+    File[] jars = file.listFiles();
+    File localFile = null;
+    for (File jar : jars) {
+      if (jar.getName().startsWith("client-mr")) {
+        localFile = jar;
+        break;
+      }
+    }
+    assertNotNull(localFile);
+    Path newPath = new Path(HDFS_URI + "/rss.jar");
+    FileUtil.copy(file, fs, newPath, false, conf);
+    // DistributedCache.addArchiveToClassPath(new Path(newPath.toUri().getPath()), conf, fs);
+    DistributedCache.addFileToClassPath(
+        new Path(newPath.toUri().getPath()), conf, fs);
+    conf.set(MRJobConfig.MAPREDUCE_APPLICATION_CLASSPATH,
+        MRJobConfig.DEFAULT_MAPREDUCE_APPLICATION_CLASSPATH + ",$PWD/rss.jar/" + localFile.getName());
+    conf.set("mapreduce.rss.coordinator.quorum", COORDINATOR_QUORUM);
+    LargeSorter sorter = new LargeSorter();
+    sorter.setConf(conf);
+    assertEquals("Large sort failed", 0,
+        ToolRunner.run(conf, sorter, new String[0]));
+  }
+
+}

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.Test;
 

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
@@ -18,11 +18,14 @@
 
 package org.apache.hadoop.mapreduce;
 
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.filecache.DistributedCache;
 import org.apache.hadoop.util.ToolRunner;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -33,6 +36,15 @@ import static org.junit.Assert.assertNotNull;
 
 public class LargeSorterTest extends MRIntegrationTestBase {
 
+  @BeforeClass
+  public static void setupServers() throws Exception {
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    createCoordinatorServer(coordinatorConf);
+    ShuffleServerConf shuffleServerConf = getShuffleServerConf();
+    createShuffleServer(shuffleServerConf);
+    startServers();
+  }
+
   @Test
   public void testAppMasterStart() throws Exception {
     URL url = LargeSorterTest.class.getResource("/");
@@ -42,7 +54,7 @@ public class LargeSorterTest extends MRIntegrationTestBase {
     if (System.getenv("JAVA_HOME") == null) {
       throw new RuntimeException("We must set JAVA_HOME");
     }
-    conf.set(MRJobConfig.MR_AM_COMMAND_OPTS, "org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster");
+    conf.set(MRJobConfig.MR_AM_COMMAND_OPTS, "-XX:+TraceClassLoading org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster");
     conf.setInt(MRJobConfig.MAP_MEMORY_MB, 2048);
     conf.setInt(MRJobConfig.IO_SORT_MB, 128);
     conf.setInt(LargeSorter.NUM_MAP_TASKS, 1);
@@ -57,13 +69,21 @@ public class LargeSorterTest extends MRIntegrationTestBase {
       }
     }
     assertNotNull(localFile);
+    String props = System.getProperty("java.class.path");
+    String newProps = "";
+    String[] splittedProps = props.split(":");
+    for (String prop : splittedProps)  {
+      if (!prop.contains("classes") && !prop.contains("grpc")) {
+        newProps = newProps + ":" + prop;
+      }
+    }
+    System.setProperty("java.class.path", newProps);
     Path newPath = new Path(HDFS_URI + "/rss.jar");
     FileUtil.copy(file, fs, newPath, false, conf);
-    // DistributedCache.addArchiveToClassPath(new Path(newPath.toUri().getPath()), conf, fs);
     DistributedCache.addFileToClassPath(
         new Path(newPath.toUri().getPath()), conf, fs);
     conf.set(MRJobConfig.MAPREDUCE_APPLICATION_CLASSPATH,
-        MRJobConfig.DEFAULT_MAPREDUCE_APPLICATION_CLASSPATH + ",$PWD/rss.jar/" + localFile.getName());
+         "$PWD/rss.jar/" + localFile.getName() + "," + MRJobConfig.DEFAULT_MAPREDUCE_APPLICATION_CLASSPATH);
     conf.set("mapreduce.rss.coordinator.quorum", COORDINATOR_QUORUM);
     LargeSorter sorter = new LargeSorter();
     sorter.setConf(conf);

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
@@ -63,7 +63,7 @@ public class LargeSorterTest extends MRIntegrationTestBase {
     File[] jars = file.listFiles();
     File localFile = null;
     for (File jar : jars) {
-      if (jar.getName().startsWith("client-mr")) {
+      if (jar.getName().startsWith("rss-client-mr")) {
         localFile = jar;
         break;
       }

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/LargeSorterTest.java
@@ -73,7 +73,7 @@ public class LargeSorterTest extends MRIntegrationTestBase {
     String newProps = "";
     String[] splittedProps = props.split(":");
     for (String prop : splittedProps)  {
-      if (!prop.contains("classes") && !prop.contains("grpc")) {
+      if (!prop.contains("classes") && !prop.contains("grpc") && !prop.contains("rss-")) {
         newProps = newProps + ":" + prop;
       }
     }

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/MRIntegrationTestBase.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/MRIntegrationTestBase.java
@@ -1,0 +1,28 @@
+/*
+ *Tencent is pleased to support the open source community by making Firestorm-Spark remote shuffle server available.
+
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package org.apache.hadoop.mapreduce;
+
+import com.tencent.rss.test.IntegrationTestBase;
+import org.junit.Test;
+
+public class MRIntegrationTestBase extends IntegrationTestBase {
+  @Test
+  public void test(){
+
+  }
+}

--- a/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/MRIntegrationTestBase.java
+++ b/integration-test/mr/src/test/java/org/apache/hadoop/mapreduce/MRIntegrationTestBase.java
@@ -1,6 +1,7 @@
 /*
- *Tencent is pleased to support the open source community by making Firestorm-Spark remote shuffle server available.
-
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
  * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
@@ -18,11 +19,58 @@
 package org.apache.hadoop.mapreduce;
 
 import com.tencent.rss.test.IntegrationTestBase;
-import org.junit.Test;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.mapreduce.v2.MiniMRYarnCluster;
+import org.apache.hadoop.mapreduce.v2.TestMRJobs;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
 
 public class MRIntegrationTestBase extends IntegrationTestBase {
-  @Test
-  public void test(){
 
+  protected static MiniMRYarnCluster mrYarnCluster;
+  protected static FileSystem localFs;
+  static {
+    try {
+      localFs = FileSystem.getLocal(conf);
+    } catch (IOException io) {
+      throw new RuntimeException("problem getting local fs", io);
+    }
+  }
+
+  private static Path TEST_ROOT_DIR = localFs.makeQualified(
+      new Path("target", TestMRJobs.class.getName() + "-tmpDir"));
+  static Path APP_JAR = new Path(TEST_ROOT_DIR, "MRAppJar.jar");
+  private static final String OUTPUT_ROOT_DIR = "/tmp/" +
+      TestMRJobs.class.getSimpleName();
+  private static final Path TEST_RESOURCES_DIR = new Path(TEST_ROOT_DIR,
+      "localizedResources");
+
+  @BeforeClass
+  public static void setUpMRYarn() throws IOException {
+    mrYarnCluster = new MiniMRYarnCluster("test");
+    conf.set(MRJobConfig.MR_AM_STAGING_DIR, "/apps_staging_dir");
+    conf.setInt(YarnConfiguration.MAX_CLUSTER_LEVEL_APPLICATION_PRIORITY, 10);
+    mrYarnCluster.init(conf);
+    mrYarnCluster.start();
+    localFs.copyFromLocalFile(new Path(MiniMRYarnCluster.APPJAR), APP_JAR);
+    localFs.setPermission(APP_JAR, new FsPermission("700"));
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException {
+    if (mrYarnCluster != null) {
+      mrYarnCluster.stop();
+      mrYarnCluster = null;
+    }
+
+    if (localFs.exists(TEST_RESOURCES_DIR)) {
+      // clean up resource directory
+      localFs.delete(TEST_RESOURCES_DIR, true);
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,6 @@
     <module>server</module>
     <module>client</module>
     <module>integration-test/common</module>
-    <module>client-mr</module>
-    <module>integration-test/mr</module>
   </modules>
 
   <dependencies>
@@ -1306,7 +1304,24 @@
         </dependencies>
       </dependencyManagement>
     </profile>
-
+    <profile>
+      <id>mr</id>
+      <modules>
+        <module>client-mr</module>
+        <module>integration-test/mr</module>
+      </modules>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>com.tencent.rss</groupId>
+            <artifactId>rss-integration-common-test</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
   </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,8 @@
     <module>server</module>
     <module>client</module>
     <module>integration-test/common</module>
+    <module>client-mr</module>
+    <module>integration-test/mr</module>
   </modules>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.tencent.rss</groupId>
+        <artifactId>client-mr</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
@@ -1219,6 +1225,7 @@
             <type>test-jar</type>
             <scope>test</scope>
           </dependency>
+
           <dependency>
             <groupId>com.tencent.rss</groupId>
             <artifactId>rss-integration-spark-common-test</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
We add a new AppMaster to support the use of rss. New AppMaster will register shuffles,  get shuffle servers, and send heartbeats.

### Why are the changes needed?
In real production environments, there are too many MapReduce's jobs. The work is meaningful.


### Does this PR introduce _any_ user-facing change?
Yes, we bring some new configurations. In another pr, we will update the doc about the use of this feature.

### How was this patch tested?
new Uts.
