### PR TITLE
[Feature] Support multiple HDFS in Firestorm (Part1 for Coordinator &…

### DIFF
--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -18,15 +18,13 @@
 
 package org.apache.hadoop.mapred;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.response.SendShuffleDataResult;
-import com.tencent.rss.common.PartitionRange;
-import com.tencent.rss.common.ShuffleAssignmentsInfo;
-import com.tencent.rss.common.ShuffleBlockInfo;
-import com.tencent.rss.common.ShuffleServerInfo;
-import com.tencent.rss.common.exception.RssException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.WritableComparator;
@@ -34,10 +32,13 @@ import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.junit.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
-import java.util.Set;
+import com.tencent.rss.client.api.ShuffleWriteClient;
+import com.tencent.rss.client.response.SendShuffleDataResult;
+import com.tencent.rss.common.PartitionRange;
+import com.tencent.rss.common.ShuffleAssignmentsInfo;
+import com.tencent.rss.common.ShuffleBlockInfo;
+import com.tencent.rss.common.ShuffleServerInfo;
+import com.tencent.rss.common.exception.RssException;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -222,6 +223,11 @@ public class SortWriteBufferManagerTest {
 
     @Override
     public Map<String, String> fetchClientConf(int timeoutMs) {
+      return null;
+    }
+
+    @Override
+    public String fetchRemoteStorage(String appId) {
       return null;
     }
 

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleHandle.java
@@ -35,18 +35,22 @@ public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
   private Map<Integer, List<ShuffleServerInfo>> partitionToServers;
   // shuffle servers which is for store shuffle data
   private Set<ShuffleServerInfo> shuffleServersForData;
+  // remoteStorage used for this job
+  private String remoteStorage;
 
   public RssShuffleHandle(
       int shuffleId,
       String appId,
       int numMaps,
       ShuffleDependency<K, V, C> dependency,
-      Map<Integer, List<ShuffleServerInfo>> partitionToServers) {
+      Map<Integer, List<ShuffleServerInfo>> partitionToServers,
+      String remoteStorage) {
     super(shuffleId);
     this.appId = appId;
     this.numMaps = numMaps;
     this.dependency = dependency;
     this.partitionToServers = partitionToServers;
+    this.remoteStorage = remoteStorage;
     shuffleServersForData = Sets.newHashSet();
     for (List<ShuffleServerInfo> ssis : partitionToServers.values()) {
       shuffleServersForData.addAll(ssis);
@@ -75,5 +79,9 @@ public class RssShuffleHandle<K, V, C> extends ShuffleHandle {
 
   public Set<ShuffleServerInfo> getShuffleServersForData() {
     return shuffleServersForData;
+  }
+
+  public String getRemoteStorage() {
+    return remoteStorage;
   }
 }

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssShuffleUtils.java
@@ -25,10 +25,8 @@ import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
@@ -201,21 +199,18 @@ public class RssShuffleUtils {
     }
   }
 
-  public static final Set<StorageType> getStorageTypeWithoutPath() {
-    return Sets.newHashSet(StorageType.LOCALFILE, StorageType.MEMORY_LOCALFILE);
+  public static boolean requireRemoteStorage(String storageType) {
+    return StorageType.MEMORY_HDFS.name().equals(storageType)
+        || StorageType.MEMORY_LOCALFILE_HDFS.name().equals(storageType)
+        || StorageType.HDFS.name().equals(storageType)
+        || StorageType.LOCALFILE_HDFS.name().equals(storageType)
+        || StorageType.LOCALFILE_HDFS_2.name().equals(storageType);
   }
 
   public static void validateRssClientConf(SparkConf sparkConf) {
     String msgFormat = "%s must be set by the client or fetched from coordinators.";
     if (!sparkConf.contains(RssClientConfig.RSS_STORAGE_TYPE)) {
       String msg = String.format(msgFormat, "Storage type");
-      LOG.error(msg);
-      throw new IllegalArgumentException(msg);
-    }
-
-    StorageType storageType = StorageType.valueOf(sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE));
-    if (!sparkConf.contains(RssClientConfig.RSS_BASE_PATH) && !getStorageTypeWithoutPath().contains(storageType)) {
-      String msg = String.format(msgFormat, "Storage path");
       LOG.error(msg);
       throw new IllegalArgumentException(msg);
     }

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssShuffleUtilsTest.java
@@ -18,17 +18,20 @@
 
 package org.apache.spark.shuffle;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkConf;
+import org.junit.Test;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
-import com.google.common.collect.Lists;
-import java.util.List;
-import java.util.Random;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.spark.SparkConf;
-import org.junit.Test;
 
 public class RssShuffleUtilsTest {
 
@@ -59,6 +62,28 @@ public class RssShuffleUtilsTest {
     conf1 = RssShuffleUtils.newHadoopConfiguration(conf);
     assertEquals("expect_odfs_impl", conf1.get("fs.hdfs.impl"));
     assertEquals("expect_odfs_abstract_impl", conf1.get("fs.AbstractFileSystem.hdfs.impl"));
+  }
+
+  @Test
+  public void applyDynamicClientConfTest() {
+    SparkConf conf = new SparkConf();
+    Map<String, String> clientConf = Maps.newHashMap();
+    String remoteStoragePath = "hdfs://path1";
+    String mockKey = "spark.mockKey";
+    String mockValue = "v";
+    clientConf.put(RssClientConfig.RSS_BASE_PATH, remoteStoragePath);
+    clientConf.put(mockKey, mockValue);
+    RssShuffleUtils.applyDynamicClientConf(conf, clientConf);
+    assertEquals(remoteStoragePath, conf.get(RssClientConfig.RSS_BASE_PATH));
+    assertEquals(mockValue, conf.get(mockKey));
+
+    String remoteStoragePath2 = "hdfs://path2";
+    clientConf = Maps.newHashMap();
+    clientConf.put(RssClientConfig.RSS_BASE_PATH, remoteStoragePath2);
+    clientConf.put(mockKey, "won't be rewrite");
+    RssShuffleUtils.applyDynamicClientConf(conf, clientConf);
+    assertEquals(remoteStoragePath2, conf.get(RssClientConfig.RSS_BASE_PATH));
+    assertEquals(mockValue, conf.get(mockKey));
   }
 
   private void singleTest(int size) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
@@ -79,6 +80,8 @@ public class RssShuffleManager implements ShuffleManager {
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
   private boolean heartbeatStarted = false;
+  private boolean dynamicConfEnabled = false;
+  private String remoteStorage = "";
   private ThreadPoolExecutor threadPoolExecutor;
   private EventLoop eventLoop = new EventLoop<AddBlockEvent>("ShuffleDataQueue") {
 
@@ -147,6 +150,9 @@ public class RssShuffleManager implements ShuffleManager {
     this.heartbeatInterval = sparkConf.getLong(RssClientConfig.RSS_HEARTBEAT_INTERVAL,
         RssClientConfig.RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE);
     this.heartbeatTimeout = sparkConf.getLong(RssClientConfig.RSS_HEARTBEAT_TIMEOUT, heartbeatInterval / 2);
+    this.dynamicConfEnabled = sparkConf.getBoolean(
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE);
     int retryMax = sparkConf.getInt(RssClientConfig.RSS_CLIENT_RETRY_MAX,
         RssClientConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE);
     long retryIntervalMax = sparkConf.getLong(RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX,
@@ -159,9 +165,7 @@ public class RssShuffleManager implements ShuffleManager {
           dataReplica, dataReplicaWrite, dataReplicaRead);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
-    if (isDriver && sparkConf.getBoolean(
-        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
-        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE)) {
+    if (isDriver && dynamicConfEnabled) {
       Map<String, String> clusterClientConf = shuffleWriteClient.fetchClientConf(
           sparkConf.getInt(RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
               RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
@@ -202,6 +206,23 @@ public class RssShuffleManager implements ShuffleManager {
       LOG.info("Generate application id used in rss: " + appId);
     }
 
+    String storageType = sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE);
+    if (StringUtils.isEmpty(remoteStorage) && RssShuffleUtils.requireRemoteStorage(storageType)) {
+      if (dynamicConfEnabled) {
+        // get from coordinator first
+        remoteStorage = shuffleWriteClient.fetchRemoteStorage(appId);
+        if (StringUtils.isEmpty(remoteStorage)) {
+          // empty from coordinator, try local config
+          remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
+        }
+      } else {
+        remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
+      }
+      if (StringUtils.isEmpty(remoteStorage)) {
+        throw new RuntimeException("Can't find remoteStorage: with storageType[" + storageType + "]");
+      }
+    }
+
     int partitionNumPerRange = sparkConf.getInt(RssClientConfig.RSS_PARTITION_NUM_PER_RANGE,
         RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
 
@@ -215,7 +236,7 @@ public class RssShuffleManager implements ShuffleManager {
     registerShuffleServers(appId, shuffleId, response.getServerToPartitionRanges());
 
     LOG.info("RegisterShuffle with ShuffleId[" + shuffleId + "], partitionNum[" + partitionToServers.size() + "]");
-    return new RssShuffleHandle(shuffleId, appId, numMaps, dependency, partitionToServers);
+    return new RssShuffleHandle(shuffleId, appId, numMaps, dependency, partitionToServers, remoteStorage);
   }
 
   private void startHeartbeat() {
@@ -292,12 +313,11 @@ public class RssShuffleManager implements ShuffleManager {
   public <K, C> ShuffleReader<K, C> getReader(ShuffleHandle handle,
       int startPartition, int endPartition, TaskContext context) {
     if (handle instanceof RssShuffleHandle) {
-      // spark.rss.base.path is not necessary for every storage type, eg, hdfs need but localfile doesn't
-      final String shuffleDataBasePath = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
       final String storageType = sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE);
       final int indexReadLimit = sparkConf.getInt(RssClientConfig.RSS_INDEX_READ_LIMIT,
           RssClientConfig.RSS_INDEX_READ_LIMIT_DEFAULT_VALUE);
       RssShuffleHandle rssShuffleHandle = (RssShuffleHandle) handle;
+      final String shuffleRemoteStoragePath = rssShuffleHandle.getRemoteStorage();
       final int partitionNumPerRange = sparkConf.getInt(RssClientConfig.RSS_PARTITION_NUM_PER_RANGE,
           RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE);
       final int partitionNum = rssShuffleHandle.getDependency().partitioner().numPartitions();
@@ -323,7 +343,7 @@ public class RssShuffleManager implements ShuffleManager {
           + startPartition + "]");
 
       return new RssShuffleReader<K, C>(startPartition, endPartition, context,
-          rssShuffleHandle, shuffleDataBasePath, indexReadLimit,
+          rssShuffleHandle, shuffleRemoteStoragePath, indexReadLimit,
           RssShuffleUtils.newHadoopConfiguration(sparkConf),
           storageType, (int) readBufferSize, partitionNumPerRange, partitionNum,
           blockIdBitmap, taskIdBitmap);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -33,7 +33,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -252,22 +252,8 @@ public class RssShuffleManager implements ShuffleManager {
     }
     LOG.info("Generate application id used in rss: " + id.get());
 
-    String storageType = sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE);
-    if (StringUtils.isEmpty(remoteStorage) && RssShuffleUtils.requireRemoteStorage(storageType)) {
-      if (dynamicConfEnabled) {
-        // get from coordinator first
-        remoteStorage = shuffleWriteClient.fetchRemoteStorage(id.get());
-        if (StringUtils.isEmpty(remoteStorage)) {
-          // empty from coordinator, try local config
-          remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
-        }
-      } else {
-        remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
-      }
-      if (StringUtils.isEmpty(remoteStorage)) {
-        throw new RuntimeException("Can't find remoteStorage: with storageType[" + storageType + "]");
-      }
-    }
+    remoteStorage = RssShuffleUtils.fetchRemoteStorage(
+        id.get(), remoteStorage, dynamicConfEnabled, sparkConf, shuffleWriteClient);
 
     ShuffleAssignmentsInfo response = shuffleWriteClient.getShuffleAssignments(
         id.get(),

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -33,6 +33,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.ShuffleDependency;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkEnv;
@@ -83,6 +84,8 @@ public class RssShuffleManager implements ShuffleManager {
   private Map<String, WriteBufferManager> taskToBufferManager = Maps.newConcurrentMap();
   private final ScheduledExecutorService scheduledExecutorService;
   private boolean heartbeatStarted = false;
+  private boolean dynamicConfEnabled = false;
+  private String remoteStorage = "";
   private final EventLoop eventLoop;
   private final EventLoop defaultEventLoop = new EventLoop<AddBlockEvent>("ShuffleDataQueue") {
 
@@ -150,6 +153,9 @@ public class RssShuffleManager implements ShuffleManager {
         RssClientConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE);
     this.clientType = sparkConf.get(RssClientConfig.RSS_CLIENT_TYPE,
         RssClientConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
+    this.dynamicConfEnabled = sparkConf.getBoolean(
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
+        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE);
 
     long retryIntervalMax = sparkConf.getLong(RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX,
         RssClientConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE);
@@ -161,9 +167,7 @@ public class RssShuffleManager implements ShuffleManager {
           dataReplica, dataReplicaWrite, dataReplicaRead);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
-    if (isDriver && sparkConf.getBoolean(
-        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
-        RssClientConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE)) {
+    if (isDriver && dynamicConfEnabled) {
       Map<String, String> clusterClientConf = shuffleWriteClient.fetchClientConf(
           sparkConf.getInt(RssClientConfig.RSS_ACCESS_TIMEOUT_MS,
               RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
@@ -247,6 +251,24 @@ public class RssShuffleManager implements ShuffleManager {
       id.compareAndSet(null, SparkEnv.get().conf().getAppId() + System.currentTimeMillis());
     }
     LOG.info("Generate application id used in rss: " + id.get());
+
+    String storageType = sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE);
+    if (StringUtils.isEmpty(remoteStorage) && RssShuffleUtils.requireRemoteStorage(storageType)) {
+      if (dynamicConfEnabled) {
+        // get from coordinator first
+        remoteStorage = shuffleWriteClient.fetchRemoteStorage(id.get());
+        if (StringUtils.isEmpty(remoteStorage)) {
+          // empty from coordinator, try local config
+          remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
+        }
+      } else {
+        remoteStorage = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
+      }
+      if (StringUtils.isEmpty(remoteStorage)) {
+        throw new RuntimeException("Can't find remoteStorage: with storageType[" + storageType + "]");
+      }
+    }
+
     ShuffleAssignmentsInfo response = shuffleWriteClient.getShuffleAssignments(
         id.get(),
         shuffleId,
@@ -264,7 +286,8 @@ public class RssShuffleManager implements ShuffleManager {
         id.get(),
         dependency.rdd().getNumPartitions(),
         dependency,
-        partitionToServers);
+        partitionToServers,
+        remoteStorage);
   }
 
   @Override
@@ -369,11 +392,11 @@ public class RssShuffleManager implements ShuffleManager {
     if (!(handle instanceof RssShuffleHandle)) {
       throw new RuntimeException("Unexpected ShuffleHandle:" + handle.getClass().getName());
     }
-    final String shuffleDataBasePath = sparkConf.get(RssClientConfig.RSS_BASE_PATH, "");
     final String storageType = sparkConf.get(RssClientConfig.RSS_STORAGE_TYPE);
     final int indexReadLimit = sparkConf.getInt(RssClientConfig.RSS_INDEX_READ_LIMIT,
         RssClientConfig.RSS_INDEX_READ_LIMIT_DEFAULT_VALUE);
     RssShuffleHandle rssShuffleHandle = (RssShuffleHandle) handle;
+    final String shuffleRemoteStoragePath = rssShuffleHandle.getRemoteStorage();
     final int partitionNum = rssShuffleHandle.getDependency().partitioner().numPartitions();
     long readBufferSize = sparkConf.getSizeAsBytes(RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE,
         RssClientConfig.RSS_CLIENT_READ_BUFFER_SIZE_DEFAULT_VALUE);
@@ -408,7 +431,7 @@ public class RssShuffleManager implements ShuffleManager {
         endMapIndex,
         context,
         rssShuffleHandle,
-        shuffleDataBasePath,
+        shuffleRemoteStoragePath,
         indexReadLimit,
         RssShuffleUtils.newHadoopConfiguration(sparkConf),
         storageType,

--- a/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
+++ b/client/src/main/java/com/tencent/rss/client/api/ShuffleWriteClient.java
@@ -45,6 +45,8 @@ public interface ShuffleWriteClient {
 
   Map<String, String> fetchClientConf(int timeoutMs);
 
+  String fetchRemoteStorage(String appId);
+
   void reportShuffleResult(
       Map<Integer, List<ShuffleServerInfo>> partitionToServers,
       String appId,

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -44,6 +44,7 @@ import com.tencent.rss.client.factory.CoordinatorClientFactory;
 import com.tencent.rss.client.factory.ShuffleServerClientFactory;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssFetchClientConfRequest;
+import com.tencent.rss.client.request.RssFetchRemoteStorageRequest;
 import com.tencent.rss.client.request.RssFinishShuffleRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssGetShuffleResultRequest;
@@ -55,6 +56,7 @@ import com.tencent.rss.client.response.ClientResponse;
 import com.tencent.rss.client.response.ResponseStatusCode;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
 import com.tencent.rss.client.response.RssFetchClientConfResponse;
+import com.tencent.rss.client.response.RssFetchRemoteStorageResponse;
 import com.tencent.rss.client.response.RssFinishShuffleResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssGetShuffleResultResponse;
@@ -265,6 +267,23 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
       }
     }
     return response.getClientConf();
+  }
+
+  @Override
+  public String fetchRemoteStorage(String appId) {
+    String remoteStorage = "";
+    for (CoordinatorClient coordinatorClient : coordinatorClients) {
+      RssFetchRemoteStorageResponse response =
+          coordinatorClient.fetchRemoteStorage(new RssFetchRemoteStorageRequest(appId));
+      if (response.getStatusCode() == ResponseStatusCode.SUCCESS) {
+        remoteStorage = response.getRemoteStorage();
+        LOG.info("Success to get storage {} from {}", remoteStorage, coordinatorClient.getDesc());
+        break;
+      } else {
+        LOG.warn("Fail to get conf from {}", coordinatorClient.getDesc());
+      }
+    }
+    return remoteStorage;
   }
 
   @Override

--- a/common/src/main/java/com/tencent/rss/common/util/Constants.java
+++ b/common/src/main/java/com/tencent/rss/common/util/Constants.java
@@ -34,6 +34,12 @@ public class Constants {
   public static long MAX_TASK_ATTEMPT_ID = (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) - 1;
   public static long INVALID_BLOCK_ID = -1L;
   public static final String KEY_SPLIT_CHAR = "/";
+  public static final String COMMA_SPLIT_CHAR = ",";
   public static final String COMMON_SUCCESS_MESSAGE = "SUCCESS";
   public static final String SORT_SHUFFLE_MANAGER_NAME = "org.apache.spark.shuffle.sort.SortShuffleManager";
+
+  public static final String RSS_CLIENT_CONF_COMMON_PREFIX = "rss.client";
+  public static final String CONF_REMOTE_STORAGE_PATH = ".remote.storage.path";
+  public static final String RSS_CLIENT_CONF_REMOTE_STORAGE_PATH =
+          RSS_CLIENT_CONF_COMMON_PREFIX + CONF_REMOTE_STORAGE_PATH;
 }

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
@@ -18,23 +18,36 @@
 
 package com.tencent.rss.coordinator;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.tencent.rss.common.util.Constants;
 
 public class ApplicationManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(ApplicationManager.class);
   private long expired;
   private Map<String, Long> appIds = Maps.newConcurrentMap();
+  // store appId -> remote path to make sure all shuffle data of the same application
+  // will be written to the same remote storage
+  private Map<String, String> appIdToRemoteStoragePath = Maps.newConcurrentMap();
+  // store remote path -> application count for assignment strategy
+  private Map<String, AtomicInteger> remoteStoragePathCounter = Maps.newConcurrentMap();
+  private Set<String> availableRemoteStoragePath = Sets.newConcurrentHashSet();
   private ScheduledExecutorService scheduledExecutorService;
 
   public ApplicationManager(CoordinatorConf conf) {
@@ -53,8 +66,137 @@ public class ApplicationManager {
     appIds.put(appId, System.currentTimeMillis());
   }
 
+  public void refreshRemoteStorage(String remoteStoragePath) {
+    if (!StringUtils.isEmpty(remoteStoragePath)) {
+      LOG.info("Refresh remote storage with {}", remoteStoragePath);
+      Set<String> paths = Sets.newHashSet(remoteStoragePath.split(Constants.COMMA_SPLIT_CHAR));
+      // add remote path if not exist
+      for (String path : paths) {
+        if (!availableRemoteStoragePath.contains(path)) {
+          remoteStoragePathCounter.putIfAbsent(path, new AtomicInteger(0));
+          availableRemoteStoragePath.add(path);
+        }
+      }
+      // remove unused remote path if exist
+      List<String> unusedPath = Lists.newArrayList();
+      for (String existPath : availableRemoteStoragePath) {
+        if (!paths.contains(existPath)) {
+          unusedPath.add(existPath);
+        }
+      }
+      // remote unused path
+      for (String path : unusedPath) {
+        availableRemoteStoragePath.remove(path);
+        // try to remove if counter = 0, or it will be removed in decRemoteStorageCounter() later
+        removePathFromCounter(path);
+      }
+    } else {
+      LOG.info("Refresh remote storage with empty value {}", remoteStoragePath);
+      for (String path : availableRemoteStoragePath) {
+        removePathFromCounter(path);
+      }
+      availableRemoteStoragePath.clear();
+    }
+  }
+
+  // the strategy of pick remote storage is according to assignment count
+  // todo: better strategy with workload balance
+  public String pickRemoteStoragePath(String appId) {
+    if (appIdToRemoteStoragePath.containsKey(appId)) {
+      return appIdToRemoteStoragePath.get(appId);
+    }
+
+    // create list for sort
+    List<Map.Entry<String, AtomicInteger>> sizeList =
+            Lists.newArrayList(remoteStoragePathCounter.entrySet());
+
+    sizeList.sort((entry1, entry2) -> {
+      if (entry1 == null && entry2 == null) {
+        return 0;
+      }
+      if (entry1 == null) {
+        return -1;
+      }
+      if (entry2 == null) {
+        return 1;
+      }
+      if (entry1.getValue().get() > entry2.getValue().get()) {
+        return 1;
+      } else if (entry1.getValue().get() == entry2.getValue().get()) {
+        return 0;
+      }
+      return -1;
+    });
+
+    for (Map.Entry<String, AtomicInteger> entry : sizeList) {
+      String storagePath = entry.getKey();
+      if (availableRemoteStoragePath.contains(storagePath)) {
+        appIdToRemoteStoragePath.putIfAbsent(appId, storagePath);
+        incRemoteStorageCounter(storagePath);
+        break;
+      }
+    }
+    return appIdToRemoteStoragePath.get(appId);
+  }
+
+  @VisibleForTesting
+  protected synchronized void incRemoteStorageCounter(String remoteStoragePath) {
+    AtomicInteger counter = remoteStoragePathCounter.get(remoteStoragePath);
+    if (counter != null) {
+      counter.incrementAndGet();
+    } else {
+      // it may be happened when assignment remote storage
+      // and refresh remote storage at the same time
+      LOG.warn("Remote storage path lost during assignment: %s doesn't exist, reset it to 1",
+              remoteStoragePath);
+      remoteStoragePathCounter.put(remoteStoragePath, new AtomicInteger(1));
+    }
+  }
+
+  @VisibleForTesting
+  protected synchronized void decRemoteStorageCounter(String storagePath) {
+    AtomicInteger atomic = remoteStoragePathCounter.get(storagePath);
+    if (atomic != null) {
+      int count = atomic.decrementAndGet();
+      if (count < 0) {
+        LOG.warn("Unexpected counter for remote storage: %s, which is %i, reset to 0",
+                storagePath, count);
+        atomic.set(0);
+      }
+    } else {
+      LOG.warn("Can't find counter for remote storage: {}", storagePath);
+      remoteStoragePathCounter.putIfAbsent(storagePath, new AtomicInteger(0));
+    }
+    if (remoteStoragePathCounter.get(storagePath).get() == 0
+            && !availableRemoteStoragePath.contains(storagePath)) {
+      remoteStoragePathCounter.remove(storagePath);
+    }
+  }
+
+  private synchronized void removePathFromCounter(String storagePath) {
+    AtomicInteger atomic = remoteStoragePathCounter.get(storagePath);
+    if (atomic != null && atomic.get() == 0) {
+      remoteStoragePathCounter.remove(storagePath);
+    }
+  }
+
   public Set<String> getAppIds() {
     return appIds.keySet();
+  }
+
+  @VisibleForTesting
+  protected Map<String, String> getAppIdToRemoteStoragePath() {
+    return appIdToRemoteStoragePath;
+  }
+
+  @VisibleForTesting
+  protected Map<String, AtomicInteger> getRemoteStoragePathCounter() {
+    return remoteStoragePathCounter;
+  }
+
+  @VisibleForTesting
+  public Set<String> getAvailableRemoteStoragePath() {
+    return availableRemoteStoragePath;
   }
 
   private void statusCheck() {
@@ -71,6 +213,8 @@ public class ApplicationManager {
       for (String appId : expiredAppIds) {
         LOG.info("Remove expired application:" + appId);
         appIds.remove(appId);
+        decRemoteStorageCounter(appIdToRemoteStoragePath.get(appId));
+        appIdToRemoteStoragePath.remove(appId);
       }
       CoordinatorMetrics.gaugeRunningAppNum.set(appIds.size());
     } catch (Exception e) {

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
@@ -25,9 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.commons.io.IOUtils;
@@ -44,15 +42,18 @@ import org.slf4j.LoggerFactory;
 public class ClientConfManager implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(ClientConfManager.class);
 
-  private final AtomicReference<Map<String, String>> clientConf = new AtomicReference<>();
+  private Map<String, String> clientConf = Maps.newConcurrentMap();
   private final AtomicLong lastCandidatesUpdateMS = new AtomicLong(0L);
   private Path path;
   private ScheduledExecutorService updateClientConfSES = null;
   private FileSystem fileSystem;
   private static final String WHITESPACE_REGEX = "\\s+";
+  private ApplicationManager applicationManager;
 
-  public ClientConfManager(CoordinatorConf conf, Configuration hadoopConf) throws Exception {
+  public ClientConfManager(CoordinatorConf conf, Configuration hadoopConf,
+      ApplicationManager applicationManager) throws Exception {
     if (conf.getBoolean(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED)) {
+      this.applicationManager = applicationManager;
       init(conf, hadoopConf);
     }
   }
@@ -69,12 +70,7 @@ public class ClientConfManager implements Closeable {
       throw new IllegalStateException(msg);
     }
     updateClientConfInternal();
-    if (clientConf.get() == null || clientConf.get().isEmpty()) {
-      String msg = "Client conf file must be non-empty and can be loaded successfully at coordinator startup.";
-      LOG.error(msg);
-      throw new RuntimeException(msg);
-    }
-    LOG.info("Load client conf: {}", Joiner.on(";").withKeyValueSeparator("=").join(clientConf.get()));
+    LOG.info("Load client conf from " + pathStr + " successfully");
 
     int updateIntervalS = conf.getInteger(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC);
     updateClientConfSES = Executors.newSingleThreadScheduledExecutor(
@@ -87,25 +83,25 @@ public class ClientConfManager implements Closeable {
     try {
       FileStatus[] fileStatus = fileSystem.listStatus(path);
       if (!ArrayUtils.isEmpty(fileStatus)) {
-        long lastModifiedMS = fileStatus[0].getModificationTime();
-        if (lastCandidatesUpdateMS.get() != lastModifiedMS) {
+        long modifiedMS = fileStatus[0].getModificationTime();
+        if (lastCandidatesUpdateMS.get() != modifiedMS) {
           updateClientConfInternal();
-          lastCandidatesUpdateMS.set(lastModifiedMS);
-          LOG.info("Update client conf to: {}",
-              Joiner.on(";").withKeyValueSeparator("=").join(clientConf.get()));
+          lastCandidatesUpdateMS.set(modifiedMS);
+          LOG.info("Update client conf from " + path + " successfully.");
         }
       } else {
-        LOG.warn("Client conf file not found.");
+        LOG.warn("Client conf file not found with " + path);
       }
     } catch (Exception e) {
-      LOG.warn("Error when update client conf, ignore this updating.", e);
+      LOG.warn("Error when update client conf with " + path, e);
     }
   }
 
   private void updateClientConfInternal() {
-    Map<String, String> newClientConf = Maps.newHashMap();
+    Map<String, String> newClientConf = Maps.newConcurrentMap();
     String content = loadClientConfContent();
     if (StringUtils.isEmpty(content)) {
+      clientConf = newClientConf;
       LOG.warn("Load empty content from {}, ignore this updating.", path.toUri().toString());
       return;
     }
@@ -115,17 +111,16 @@ public class ClientConfManager implements Closeable {
       if (!StringUtils.isEmpty(confItem)) {
         String[] confKV = confItem.split(WHITESPACE_REGEX);
         if (confKV.length == 2) {
-          newClientConf.put(confKV[0], confKV[1]);
+          if (CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key().equals(confKV[0])) {
+            applicationManager.refreshRemoteStorage(confKV[1]);
+          } else {
+            newClientConf.put(confKV[0], confKV[1]);
+          }
         }
       }
     }
 
-    if (newClientConf.isEmpty()) {
-      LOG.warn("Empty or wrong content in {}, ignore this updating.", path.toUri().toString());
-      return;
-    }
-
-    clientConf.set(newClientConf);
+    clientConf = newClientConf;
   }
 
   private String loadClientConfContent() {
@@ -139,7 +134,7 @@ public class ClientConfManager implements Closeable {
   }
 
   public Map<String, String> getClientConf() {
-    return clientConf.get();
+    return clientConf;
   }
 
   @Override

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ClientConfManager.java
@@ -87,10 +87,10 @@ public class ClientConfManager implements Closeable {
         if (lastCandidatesUpdateMS.get() != modifiedMS) {
           updateClientConfInternal();
           lastCandidatesUpdateMS.set(modifiedMS);
-          LOG.info("Update client conf from " + path + " successfully.");
+          LOG.info("Update client conf from {} successfully.", path);
         }
       } else {
-        LOG.warn("Client conf file not found with " + path);
+        LOG.warn("Client conf file not found with {}", path);
       }
     } catch (Exception e) {
       LOG.warn("Error when update client conf with " + path, e);

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorConf.java
@@ -102,6 +102,11 @@ public class CoordinatorConf extends RssBaseConf {
       .stringType()
       .noDefaultValue()
       .withDescription("dynamic client conf of this cluster");
+  public static final ConfigOption<String> COORDINATOR_REMOTE_STORAGE_PATH = ConfigOptions
+          .key("rss.coordinator.remote.storage.path")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("all supported remote paths for RSS cluster, seperated by ','");
   public static final ConfigOption<Integer> COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC = ConfigOptions
       .key("rss.coordinator.dynamicClientConf.updateIntervalSec")
       .intType()

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/CoordinatorServer.java
@@ -110,7 +110,7 @@ public class CoordinatorServer {
 
     ClusterManagerFactory clusterManagerFactory = new ClusterManagerFactory(coordinatorConf);
     this.clusterManager = clusterManagerFactory.getClusterManager();
-    this.clientConfManager = new ClientConfManager(coordinatorConf, new Configuration());
+    this.clientConfManager = new ClientConfManager(coordinatorConf, new Configuration(), applicationManager);
     AssignmentStrategyFactory assignmentStrategyFactory =
         new AssignmentStrategyFactory(coordinatorConf, clusterManager);
     this.assignmentStrategy = assignmentStrategyFactory.getAssignmentStrategy();

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ApplicationManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ApplicationManagerTest.java
@@ -1,0 +1,166 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.coordinator;
+
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.tencent.rss.common.util.Constants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ApplicationManagerTest {
+
+  static {
+    CoordinatorMetrics.register();
+  }
+
+  private ApplicationManager applicationManager;
+  private long appExpiredTime = 2000L;
+  private String remotePath1 = "hdfs://path1";
+  private String remotePath2 = "hdfs://path2";
+  private String remotePath3 = "hdfs://path3";
+
+  @Before
+  public void setUp() {
+    CoordinatorConf conf = new CoordinatorConf();
+    conf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, appExpiredTime);
+    applicationManager = new ApplicationManager(conf);
+  }
+
+  @Test
+  public void refreshTest() {
+    String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
+    Set<String> expectedAvailablePath = Sets.newHashSet(remotePath1, remotePath2);
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStoragePath());
+    assertEquals(expectedAvailablePath, applicationManager.getRemoteStoragePathCounter().keySet());
+
+    remoteStoragePath = remotePath3;
+    expectedAvailablePath = Sets.newHashSet(remotePath3);
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStoragePath());
+    assertEquals(expectedAvailablePath, applicationManager.getRemoteStoragePathCounter().keySet());
+
+    remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath3;
+    expectedAvailablePath = Sets.newHashSet(remotePath1, remotePath3);
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStoragePath());
+    assertEquals(expectedAvailablePath, applicationManager.getRemoteStoragePathCounter().keySet());
+
+    remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
+    expectedAvailablePath = Sets.newHashSet(remotePath1, remotePath2);
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStoragePath());
+    assertEquals(expectedAvailablePath, applicationManager.getRemoteStoragePathCounter().keySet());
+  }
+
+  @Test
+  public void storageCounterTest() throws Exception {
+    String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2;
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(0, applicationManager.getRemoteStoragePathCounter().get(remotePath1).get());
+    assertEquals(0, applicationManager.getRemoteStoragePathCounter().get(remotePath2).get());
+
+    // do inc for remotePath1 to make sure pick storage will be remotePath2 in next call
+    applicationManager.incRemoteStorageCounter(remotePath1);
+    applicationManager.incRemoteStorageCounter(remotePath1);
+    String testApp1 = "testApp1";
+    applicationManager.refreshAppId(testApp1);
+    assertEquals(remotePath2, applicationManager.pickRemoteStoragePath(testApp1));
+    assertEquals(remotePath2, applicationManager.getAppIdToRemoteStoragePath().get(testApp1));
+    assertEquals(1, applicationManager.getRemoteStoragePathCounter().get(remotePath2).get());
+    // return the same value if did the assignment already
+    assertEquals(remotePath2, applicationManager.pickRemoteStoragePath(testApp1));
+    assertEquals(1, applicationManager.getRemoteStoragePathCounter().get(remotePath2).get());
+
+    Thread.sleep(appExpiredTime + 2000);
+    assertNull(applicationManager.getAppIdToRemoteStoragePath().get(testApp1));
+    assertEquals(0, applicationManager.getRemoteStoragePathCounter().get(remotePath2).get());
+
+    // refresh app1, got remotePath2, then remove remotePath2,
+    // it should be existed in counter until it expired
+    applicationManager.refreshAppId(testApp1);
+    assertEquals(remotePath2, applicationManager.pickRemoteStoragePath(testApp1));
+    remoteStoragePath = remotePath1;
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    assertEquals(Sets.newConcurrentHashSet(Sets.newHashSet(remotePath1, remotePath2)),
+        applicationManager.getRemoteStoragePathCounter().keySet());
+    assertEquals(1, applicationManager.getRemoteStoragePathCounter().get(remotePath2).get());
+    // app1 is expired, remotePath2 is removed because of counter = 0
+    Thread.sleep(appExpiredTime + 2000);
+    assertEquals(Sets.newConcurrentHashSet(Sets.newHashSet(remotePath1)),
+        applicationManager.getRemoteStoragePathCounter().keySet());
+
+    // restore previous manually inc for next test case
+    applicationManager.decRemoteStorageCounter(remotePath1);
+    applicationManager.decRemoteStorageCounter(remotePath1);
+    // remove all remote storage
+    applicationManager.refreshRemoteStorage("");
+    assertEquals(0, applicationManager.getAvailableRemoteStoragePath().size());
+    assertEquals(0, applicationManager.getRemoteStoragePathCounter().size());
+  }
+
+  @Test
+  public void storageCounterMulThreadTest() throws Exception {
+    String remoteStoragePath = remotePath1 + Constants.COMMA_SPLIT_CHAR + remotePath2
+        + Constants.COMMA_SPLIT_CHAR + remotePath3;
+    applicationManager.refreshRemoteStorage(remoteStoragePath);
+    String appPrefix = "testAppId";
+
+    Thread pickThread1 = new Thread(() -> {
+      for (int i = 0; i < 1000; i++) {
+        String appId = appPrefix + i;
+        applicationManager.refreshAppId(appId);
+        applicationManager.pickRemoteStoragePath(appId);
+      }
+    });
+
+    Thread pickThread2 = new Thread(() -> {
+      for (int i = 1000; i < 2000; i++) {
+        String appId = appPrefix + i;
+        applicationManager.refreshAppId(appId);
+        applicationManager.pickRemoteStoragePath(appId);
+      }
+    });
+
+    Thread pickThread3 = new Thread(() -> {
+      for (int i = 2000; i < 3000; i++) {
+        String appId = appPrefix + i;
+        applicationManager.refreshAppId(appId);
+        applicationManager.pickRemoteStoragePath(appId);
+      }
+    });
+    pickThread1.start();
+    pickThread2.start();
+    pickThread3.start();
+    pickThread1.join();
+    pickThread2.join();
+    pickThread3.join();
+    Thread.sleep(appExpiredTime + 2000);
+
+    applicationManager.refreshRemoteStorage("");
+    assertEquals(0, applicationManager.getAvailableRemoteStoragePath().size());
+    assertEquals(0, applicationManager.getRemoteStoragePathCounter().size());
+  }
+}

--- a/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
@@ -17,25 +17,35 @@
 
 package com.tencent.rss.test;
 
+import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
-import java.io.File;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.request.RssFetchClientConfRequest;
+import com.tencent.rss.client.request.RssFetchRemoteStorageRequest;
 import com.tencent.rss.client.response.ResponseStatusCode;
 import com.tencent.rss.client.response.RssFetchClientConfResponse;
+import com.tencent.rss.client.response.RssFetchRemoteStorageResponse;
+import com.tencent.rss.coordinator.ApplicationManager;
 import com.tencent.rss.coordinator.CoordinatorConf;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class FetchClientConfTest extends CoordinatorTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FetchClientConfTest.class);
+
   @Rule
   public TemporaryFolder tmpFolder = new TemporaryFolder();
 
@@ -50,8 +60,9 @@ public class FetchClientConfTest extends CoordinatorTestBase {
     printWriter.close();
 
     CoordinatorConf coordinatorConf = getCoordinatorConf();
-    coordinatorConf.setBoolean("rss.coordinator.dynamicClientConf.enabled", true);
-    coordinatorConf.setString("rss.coordinator.dynamicClientConf.path", clientConfFile.getAbsolutePath());
+    coordinatorConf.setBoolean(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
+    coordinatorConf.setString(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH,
+        clientConfFile.getAbsolutePath());
     coordinatorConf.setInteger("rss.coordinator.dynamicClientConf.updateIntervalSec", 10);
     createCoordinatorServer(coordinatorConf);
     startServers();
@@ -85,5 +96,69 @@ public class FetchClientConfTest extends CoordinatorTestBase {
     response = coordinatorClient.fetchClientConf(request);
     assertEquals(ResponseStatusCode.INTERNAL_ERROR, response.getStatusCode());
     assertEquals(0, response.getClientConf().size());
+  }
+
+  @Test
+  public void testFetchRemoteStorage() throws Exception {
+    String remotePath1 = "hdfs://path1";
+    String remotePath2 = "hdfs://path2";
+    File cfgFile = tmpFolder.newFile();
+    writeRemoteStorageConf(cfgFile, remotePath1);
+
+    CoordinatorConf coordinatorConf = getCoordinatorConf();
+    coordinatorConf.setBoolean(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
+    coordinatorConf.setString(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, cfgFile.toURI().toString());
+    coordinatorConf.setInteger(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_UPDATE_INTERVAL_SEC, 3);
+    createCoordinatorServer(coordinatorConf);
+    startServers();
+
+    waitForUpdate(Sets.newHashSet(remotePath1), coordinators.get(0).getApplicationManager());
+    String appId = "testFetchRemoteStorageApp";
+    RssFetchRemoteStorageRequest request = new RssFetchRemoteStorageRequest(appId);
+    RssFetchRemoteStorageResponse response = coordinatorClient.fetchRemoteStorage(request);
+    assertEquals(remotePath1, response.getRemoteStorage());
+
+    // update remote storage info
+    writeRemoteStorageConf(cfgFile, remotePath2);
+    waitForUpdate(Sets.newHashSet(remotePath2), coordinators.get(0).getApplicationManager());
+    request = new RssFetchRemoteStorageRequest(appId);
+    response = coordinatorClient.fetchRemoteStorage(request);
+    // remotePath1 will be return because (appId -> remote storage path) is in cache
+    assertEquals(remotePath1, response.getRemoteStorage());
+
+    request = new RssFetchRemoteStorageRequest(appId + "another");
+    response = coordinatorClient.fetchRemoteStorage(request);
+    // got the remotePath2 for new appId
+    assertEquals(remotePath2, response.getRemoteStorage());
+  }
+
+  private void waitForUpdate(
+      Set<String> expectedAvailablePath,
+      ApplicationManager applicationManager) throws Exception {
+    int maxAttempt = 10;
+    int attempt = 0;
+    while (true) {
+      if (attempt > maxAttempt) {
+        throw new RuntimeException("Timeout when update configuration");
+      }
+      Thread.sleep(1000);
+      try {
+        assertEquals(expectedAvailablePath, applicationManager.getAvailableRemoteStoragePath());
+        break;
+      } catch (Throwable e) {
+        // ignore
+      }
+      attempt++;
+    }
+  }
+
+  private void writeRemoteStorageConf(File cfgFile, String value) throws Exception {
+    // sleep 2 secs to make sure the modified time will be updated
+    Thread.sleep(2000);
+    FileWriter fileWriter = new FileWriter(cfgFile);
+    PrintWriter printWriter = new PrintWriter(fileWriter);
+    printWriter.println(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key() + " " + value);
+    printWriter.flush();
+    printWriter.close();
   }
 }

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
@@ -18,22 +18,22 @@
 
 package com.tencent.rss.test;
 
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.util.concurrent.Uninterruptibles;
-import com.tencent.rss.coordinator.CoordinatorConf;
-import com.tencent.rss.storage.util.StorageType;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssClientConfig;
 import org.apache.spark.shuffle.RssShuffleManager;
-import org.apache.spark.shuffle.RssShuffleUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.OutputStreamWriter;
-import java.io.PrintWriter;
-import java.util.concurrent.TimeUnit;
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.storage.util.StorageType;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -124,24 +124,5 @@ public class DynamicFetchClientConfTest extends IntegrationTestBase {
     assertEquals(
         "Storage type must be set by the client or fetched from coordinators.",
         expectException.getMessage());
-
-    for (StorageType storageType : StorageType.values()) {
-      if (RssShuffleUtils.getStorageTypeWithoutPath().contains(storageType)) {
-        sparkConf.set("spark.rss.storage.type", storageType.name());
-        RssShuffleManager rsm = new RssShuffleManager(sparkConf, true);
-        assertFalse(rsm.getSparkConf().contains("spark.rss.base.path"));
-      } else {
-        sparkConf.set("spark.rss.storage.type", storageType.name());
-        expectException = null;
-        try {
-          new RssShuffleManager(sparkConf, true);
-        } catch (IllegalArgumentException e) {
-          expectException = e;
-        }
-        assertEquals(
-            "Storage path must be set by the client or fetched from coordinators.",
-            expectException.getMessage());
-      }
-    }
   }
 }

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionTest.java
@@ -44,19 +44,6 @@ public abstract class RepartitionTest extends SparkIntegrationTestBase {
     run();
   }
 
-  @Test
-  public void testMemoryRelease() throws Exception {
-    String fileName = generateTextFile(10000, 10000);
-    SparkConf sparkConf = createSparkConf();
-    updateSparkConfWithRss(sparkConf);
-    sparkConf.set("spark.executor.memory", "500m");
-    sparkConf.set("spark.unsafe.exceptionOnMemoryLeak", "true");
-    updateRssStorage(sparkConf);
-
-    // oom if there has no memory release
-    runSparkApp(sparkConf, fileName);
-  }
-
   @Override
   public Map runTest(SparkSession spark, String fileName) {
     return repartitionApp(spark, fileName);
@@ -74,7 +61,7 @@ public abstract class RepartitionTest extends SparkIntegrationTestBase {
 
   public abstract void updateRssStorage(SparkConf sparkConf);
 
-  private String generateTextFile(int wordsPerRow, int rows) throws Exception {
+  protected String generateTextFile(int wordsPerRow, int rows) throws Exception {
     String tempDir = Files.createTempDirectory("rss").toString();
     File file = new File(tempDir, "wordcount.txt");
     file.createNewFile();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithLocalFileRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithLocalFileRssTest.java
@@ -18,14 +18,16 @@
 
 package com.tencent.rss.test;
 
-import com.google.common.io.Files;
-import com.tencent.rss.coordinator.CoordinatorConf;
-import com.tencent.rss.server.ShuffleServerConf;
-import com.tencent.rss.storage.util.StorageType;
 import java.io.File;
+
+import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssClientConfig;
 import org.junit.BeforeClass;
+
+import com.tencent.rss.coordinator.CoordinatorConf;
+import com.tencent.rss.server.ShuffleServerConf;
+import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithLocalFileRssTest extends RepartitionTest {
 

--- a/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/api/CoordinatorClient.java
@@ -21,11 +21,13 @@ package com.tencent.rss.client.api;
 import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssFetchClientConfRequest;
+import com.tencent.rss.client.request.RssFetchRemoteStorageRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
 import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
 import com.tencent.rss.client.response.RssFetchClientConfResponse;
+import com.tencent.rss.client.response.RssFetchRemoteStorageResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 
@@ -40,6 +42,8 @@ public interface CoordinatorClient {
   RssAccessClusterResponse accessCluster(RssAccessClusterRequest request);
 
   RssFetchClientConfResponse fetchClientConf(RssFetchClientConfRequest request);
+
+  RssFetchRemoteStorageResponse fetchRemoteStorage(RssFetchRemoteStorageRequest request);
 
   String getDesc();
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -38,12 +38,14 @@ import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.request.RssAccessClusterRequest;
 import com.tencent.rss.client.request.RssAppHeartBeatRequest;
 import com.tencent.rss.client.request.RssFetchClientConfRequest;
+import com.tencent.rss.client.request.RssFetchRemoteStorageRequest;
 import com.tencent.rss.client.request.RssGetShuffleAssignmentsRequest;
 import com.tencent.rss.client.request.RssSendHeartBeatRequest;
 import com.tencent.rss.client.response.ResponseStatusCode;
 import com.tencent.rss.client.response.RssAccessClusterResponse;
 import com.tencent.rss.client.response.RssAppHeartBeatResponse;
 import com.tencent.rss.client.response.RssFetchClientConfResponse;
+import com.tencent.rss.client.response.RssFetchRemoteStorageResponse;
 import com.tencent.rss.client.response.RssGetShuffleAssignmentsResponse;
 import com.tencent.rss.client.response.RssSendHeartBeatResponse;
 import com.tencent.rss.common.PartitionRange;
@@ -58,6 +60,8 @@ import com.tencent.rss.proto.RssProtos.AppHeartBeatRequest;
 import com.tencent.rss.proto.RssProtos.AppHeartBeatResponse;
 import com.tencent.rss.proto.RssProtos.ClientConfItem;
 import com.tencent.rss.proto.RssProtos.FetchClientConfResponse;
+import com.tencent.rss.proto.RssProtos.FetchRemoteStorageRequest;
+import com.tencent.rss.proto.RssProtos.FetchRemoteStorageResponse;
 import com.tencent.rss.proto.RssProtos.GetShuffleAssignmentsResponse;
 import com.tencent.rss.proto.RssProtos.GetShuffleServerListResponse;
 import com.tencent.rss.proto.RssProtos.PartitionRangeAssignment;
@@ -283,7 +287,25 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
           rpcResponse.getRetMsg(),
           clientConf);
     } catch (Exception e) {
+      LOG.info(e.getMessage(), e);
       return new RssFetchClientConfResponse(ResponseStatusCode.INTERNAL_ERROR, e.getMessage());
+    }
+  }
+
+  @Override
+  public RssFetchRemoteStorageResponse fetchRemoteStorage(RssFetchRemoteStorageRequest request) {
+    FetchRemoteStorageResponse rpcResponse;
+    FetchRemoteStorageRequest rpcRequest =
+        FetchRemoteStorageRequest.newBuilder().setAppId(request.getAppId()).build();
+    try {
+      rpcResponse = blockingStub.fetchRemoteStorage(rpcRequest);
+      RssFetchRemoteStorageResponse tt = new RssFetchRemoteStorageResponse(
+          ResponseStatusCode.SUCCESS,
+          rpcResponse.getRemoteStorage());
+      return tt;
+    } catch (Exception e) {
+      LOG.info(e.getMessage(), e);
+      return new RssFetchRemoteStorageResponse(ResponseStatusCode.INTERNAL_ERROR, "");
     }
   }
 

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/CoordinatorGrpcClient.java
@@ -304,7 +304,7 @@ public class CoordinatorGrpcClient extends GrpcClient implements CoordinatorClie
           rpcResponse.getRemoteStorage());
       return tt;
     } catch (Exception e) {
-      LOG.info(e.getMessage(), e);
+      LOG.info("Failed to fetch remote storage from coordinator, " + e.getMessage(), e);
       return new RssFetchRemoteStorageResponse(ResponseStatusCode.INTERNAL_ERROR, "");
     }
   }

--- a/internal-client/src/main/java/com/tencent/rss/client/request/RssFetchRemoteStorageRequest.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/request/RssFetchRemoteStorageRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.request;
+
+public class RssFetchRemoteStorageRequest {
+
+  private String appId;
+
+  public RssFetchRemoteStorageRequest(String appId) {
+    this.appId = appId;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+}

--- a/internal-client/src/main/java/com/tencent/rss/client/response/RssFetchRemoteStorageResponse.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/response/RssFetchRemoteStorageResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.response;
+
+public class RssFetchRemoteStorageResponse extends ClientResponse {
+
+  private String remoteStorage;
+
+  public RssFetchRemoteStorageResponse(ResponseStatusCode statusCode, String remoteStorage) {
+    super(statusCode);
+    this.remoteStorage = remoteStorage;
+  }
+
+  public String getRemoteStorage() {
+    return remoteStorage;
+  }
+}

--- a/proto/src/main/proto/Rss.proto
+++ b/proto/src/main/proto/Rss.proto
@@ -263,6 +263,9 @@ service CoordinatorServer {
 
   // Get basic client conf from coordinator
   rpc fetchClientConf(google.protobuf.Empty) returns (FetchClientConfResponse);
+
+  // Get remote storage from coordinator
+  rpc fetchRemoteStorage(FetchRemoteStorageRequest) returns (FetchRemoteStorageResponse);
 }
 
 message AppHeartBeatRequest {
@@ -348,4 +351,13 @@ message FetchClientConfResponse {
 message ClientConfItem {
   string key = 1;
   string value = 2;
+}
+
+message FetchRemoteStorageRequest {
+  string appId = 1;
+}
+
+message FetchRemoteStorageResponse {
+  StatusCode status = 1;
+  string remoteStorage = 2;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, Firestorm cluster can work with only one HDFS, and it will be the bottleneck if HDFS has some problem.
This PR is target to support multiple HDFS with Firestorm to avoid above problem. 

### Why are the changes needed?
To improve stability of Firestorm


### Does this PR introduce _any_ user-facing change?
Yes, spark.rss.bath.path is updated as spark.rss.remote.storage.path


### How was this patch tested?
new UT & integration test added
