### PR TITLE
[Improvement] Optimize quorum write by skipping unnecessary blocks

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -50,6 +50,10 @@ public class RssMRConfig {
       MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE =
       RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
+  public static final String RSS_DATA_REPLICA_SKIP =
+      MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP;
+  public static boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE =
+      RssClientConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE;
   public static final String RSS_HEARTBEAT_INTERVAL =
       MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_HEARTBEAT_INTERVAL;
   public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE =

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -50,10 +50,10 @@ public class RssMRConfig {
       MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE =
       RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_SKIP =
-      MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP;
-  public static boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE =
-      RssClientConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE;
+  public static final String RSS_DATA_REPLICA_SKIP_ENABLED =
+      MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
+  public static boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE =
+      RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
   public static final String RSS_HEARTBEAT_INTERVAL =
       MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_HEARTBEAT_INTERVAL;
   public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE =

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -68,12 +68,12 @@ public class RssMRUtils {
         RssMRConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
     int replica = jobConf.getInt(RssMRConfig.RSS_DATA_REPLICA,
         RssMRConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
-    boolean replicaSkip = jobConf.getBoolean(RssMRConfig.RSS_DATA_REPLICA_SKIP,
-        RssMRConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
+    boolean replicaSkipEnabled = jobConf.getBoolean(RssMRConfig.RSS_DATA_REPLICA_SKIP_ENABLED,
+        RssMRConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax,
-            heartBeatThreadNum, replica, replicaWrite, replicaRead, replicaSkip);
+            heartBeatThreadNum, replica, replicaWrite, replicaRead, replicaSkipEnabled);
     return client;
   }
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -68,10 +68,12 @@ public class RssMRUtils {
         RssMRConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
     int replica = jobConf.getInt(RssMRConfig.RSS_DATA_REPLICA,
         RssMRConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
+    boolean replicaSkip = jobConf.getBoolean(RssMRConfig.RSS_DATA_REPLICA_SKIP,
+        RssMRConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
     ShuffleWriteClient client = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax,
-            heartBeatThreadNum, replica, replicaWrite, replicaRead);
+            heartBeatThreadNum, replica, replicaWrite, replicaRead, replicaSkip);
     return client;
   }
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -45,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.ShuffleWriteClient;
-import com.tencent.rss.client.factory.ShuffleClientFactory;
 import com.tencent.rss.client.util.ClientUtils;
 import com.tencent.rss.common.PartitionRange;
 import com.tencent.rss.common.ShuffleAssignmentsInfo;
@@ -61,23 +60,9 @@ public class RssMRAppMaster {
     JobConf conf = new JobConf(new YarnConfiguration());
     conf.addResource(new Path(MRJobConfig.JOB_CONF_FILE));
     int numReduceTasks = conf.getInt(MRJobConfig.NUM_REDUCES, 0);
-    String clientType = conf.get(RssMRConfig.RSS_CLIENT_TYPE, RssMRConfig.RSS_CLIENT_TYPE_DEFAULT_VALUE);
-    int heartBeatThreadNum = conf.getInt(RssMRConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM,
-        RssMRConfig.RSS_CLIENT_HEARTBEAT_THREAD_NUM_DEFAULT_VALUE);
-    int retryMax = conf.getInt(RssMRConfig.RSS_CLIENT_RETRY_MAX, RssMRConfig.RSS_CLIENT_RETRY_MAX_DEFAULT_VALUE);
-    long retryIntervalMax = conf.getLong(RssMRConfig.RSS_CLIENT_RETRY_INTERVAL_MAX,
-        RssMRConfig.RSS_CLIENT_RETRY_INTERVAL_MAX_DEFAULT_VALUE);
     String coordinators = conf.get(RssMRConfig.RSS_COORDINATOR_QUORUM);
 
-    int replica = conf.getInt(RssMRConfig.RSS_DATA_REPLICA, RssMRConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
-    int replicaWrite = conf.getInt(RssMRConfig.RSS_DATA_REPLICA_WRITE,
-        RssMRConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
-    int replicaRead = conf.getInt(RssMRConfig.RSS_DATA_REPLICA_READ,
-        RssMRConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    ShuffleWriteClient client = ShuffleClientFactory
-        .getInstance()
-        .createShuffleWriteClient(clientType, retryMax, retryIntervalMax,
-            heartBeatThreadNum, replica, replicaWrite, replicaRead);
+    ShuffleWriteClient client = RssMRUtils.createShuffleClient(conf);
 
     LOG.info("Registering coordinators {}", coordinators);
     client.registerCoordinators(coordinators);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -103,8 +103,8 @@ public class RssSparkConfig {
   public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE;
   public static final String RSS_DATA_REPLICA_READ = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_SKIP = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP;
-  public static final boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE;
+  public static final String RSS_DATA_REPLICA_SKIP_ENABLED = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
+  public static final boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
   public static final String RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE =
       SPARK_RSS_CONFIG_PREFIX + "rss.ozone.dfs.namenode.odfs.enable";
   public static final boolean RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE_DEFAULT_VALUE = false;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -103,8 +103,10 @@ public class RssSparkConfig {
   public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE;
   public static final String RSS_DATA_REPLICA_READ = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
-  public static final String RSS_DATA_REPLICA_SKIP_ENABLED = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
-  public static final boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
+  public static final String RSS_DATA_REPLICA_SKIP_ENABLED =
+      SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
+  public static final boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE =
+      RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
   public static final String RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE =
       SPARK_RSS_CONFIG_PREFIX + "rss.ozone.dfs.namenode.odfs.enable";
   public static final boolean RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE_DEFAULT_VALUE = false;

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -103,6 +103,8 @@ public class RssSparkConfig {
   public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE;
   public static final String RSS_DATA_REPLICA_READ = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_READ;
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
+  public static final String RSS_DATA_REPLICA_SKIP = SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP;
+  public static final boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE = RssClientConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE;
   public static final String RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE =
       SPARK_RSS_CONFIG_PREFIX + "rss.ozone.dfs.namenode.odfs.enable";
   public static final boolean RSS_OZONE_DFS_NAMENODE_ODFS_ENABLE_DEFAULT_VALUE = false;

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -79,7 +79,7 @@ public class RssShuffleManager implements ShuffleManager {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
-  private final boolean dataReplicaSkip;
+  private final boolean dataReplicaSkipEnabled;
   private boolean heartbeatStarted = false;
   private boolean dynamicConfEnabled = false;
   private String remoteStorage = "";
@@ -142,10 +142,10 @@ public class RssShuffleManager implements ShuffleManager {
         RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
         RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
-        RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
+    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED,
+        RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-        + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
+        + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE,
@@ -165,7 +165,7 @@ public class RssShuffleManager implements ShuffleManager {
     shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkipEnabled);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
     if (isDriver && dynamicConfEnabled) {

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -79,6 +79,7 @@ public class RssShuffleManager implements ShuffleManager {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
+  private final boolean dataReplicaSkip;
   private boolean heartbeatStarted = false;
   private boolean dynamicConfEnabled = false;
   private String remoteStorage = "";
@@ -136,13 +137,15 @@ public class RssShuffleManager implements ShuffleManager {
 
     // set & check replica config
     this.dataReplica = sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA,
-      RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
     this.dataReplicaWrite =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_WRITE,
-      RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
-      RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
+        RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + "]");
+        + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     this.clientType = sparkConf.get(RssSparkConfig.RSS_CLIENT_TYPE,
@@ -162,7 +165,7 @@ public class RssShuffleManager implements ShuffleManager {
     shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
     if (isDriver && dynamicConfEnabled) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -78,6 +78,7 @@ public class RssShuffleManager implements ShuffleManager {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
+  private final boolean dataReplicaSkip;
   private ShuffleWriteClient shuffleWriteClient;
   private final Map<String, Set<Long>> taskToSuccessBlockIds;
   private final Map<String, Set<Long>> taskToFailedBlockIds;
@@ -142,8 +143,10 @@ public class RssShuffleManager implements ShuffleManager {
       RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
       RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA,
+      RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + "]");
+      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     this.heartbeatInterval = sparkConf.getLong(RssSparkConfig.RSS_HEARTBEAT_INTERVAL,
@@ -164,7 +167,7 @@ public class RssShuffleManager implements ShuffleManager {
     shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
     if (isDriver && dynamicConfEnabled) {
@@ -212,8 +215,10 @@ public class RssShuffleManager implements ShuffleManager {
       RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
       RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
+      RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + "]");
+      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     int retryMax = sparkConf.getInt(RssSparkConfig.RSS_CLIENT_RETRY_MAX,
@@ -225,7 +230,7 @@ public class RssShuffleManager implements ShuffleManager {
      shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
     this.taskToSuccessBlockIds = taskToSuccessBlockIds;
     this.taskToFailedBlockIds = taskToFailedBlockIds;
     if (loop != null) {

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -143,7 +143,7 @@ public class RssShuffleManager implements ShuffleManager {
         RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
         RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_ENABLED,
+    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED,
         RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
         + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
@@ -215,8 +215,8 @@ public class RssShuffleManager implements ShuffleManager {
       RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
       RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
-      RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
+    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED,
+      RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
       + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);

--- a/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark3/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -78,7 +78,7 @@ public class RssShuffleManager implements ShuffleManager {
   private final int dataReplica;
   private final int dataReplicaWrite;
   private final int dataReplicaRead;
-  private final boolean dataReplicaSkip;
+  private final boolean dataReplicaSkipEnabled;
   private ShuffleWriteClient shuffleWriteClient;
   private final Map<String, Set<Long>> taskToSuccessBlockIds;
   private final Map<String, Set<Long>> taskToFailedBlockIds;
@@ -138,15 +138,15 @@ public class RssShuffleManager implements ShuffleManager {
 
     // set & check replica config
     this.dataReplica = sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA,
-      RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);
     this.dataReplicaWrite =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_WRITE,
-      RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
-      RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA,
-      RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
+        RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
+    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_ENABLED,
+        RssSparkConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
+        + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     this.heartbeatInterval = sparkConf.getLong(RssSparkConfig.RSS_HEARTBEAT_INTERVAL,
@@ -167,7 +167,7 @@ public class RssShuffleManager implements ShuffleManager {
     shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkipEnabled);
     registerCoordinator();
     // fetch client conf and apply them if necessary and disable ESS
     if (isDriver && dynamicConfEnabled) {
@@ -215,10 +215,10 @@ public class RssShuffleManager implements ShuffleManager {
       RssSparkConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
     this.dataReplicaRead =  sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA_READ,
       RssSparkConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE);
-    this.dataReplicaSkip = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
+    this.dataReplicaSkipEnabled = sparkConf.getBoolean(RssSparkConfig.RSS_DATA_REPLICA_SKIP,
       RssSparkConfig.RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE);
     LOG.info("Check quorum config ["
-      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkip + "]");
+      + dataReplica + ":" + dataReplicaWrite + ":" + dataReplicaRead + ":" + dataReplicaSkipEnabled + "]");
     RssUtils.checkQuorumSetting(dataReplica, dataReplicaWrite, dataReplicaRead);
 
     int retryMax = sparkConf.getInt(RssSparkConfig.RSS_CLIENT_RETRY_MAX,
@@ -230,7 +230,7 @@ public class RssShuffleManager implements ShuffleManager {
      shuffleWriteClient = ShuffleClientFactory
         .getInstance()
         .createShuffleWriteClient(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkip);
+          dataReplica, dataReplicaWrite, dataReplicaRead, dataReplicaSkipEnabled);
     this.taskToSuccessBlockIds = taskToSuccessBlockIds;
     this.taskToFailedBlockIds = taskToFailedBlockIds;
     if (loop != null) {

--- a/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
@@ -37,9 +37,9 @@ public class ShuffleClientFactory {
 
   public ShuffleWriteClient createShuffleWriteClient(
       String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
-      int replica, int replicaWrite, int replicaRead, boolean replicaSkip) {
+      int replica, int replicaWrite, int replicaRead, boolean replicaSkipEnabled) {
     return new ShuffleWriteClientImpl(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-      replica, replicaWrite, replicaRead, replicaSkip);
+      replica, replicaWrite, replicaRead, replicaSkipEnabled);
   }
 
   public ShuffleReadClient createShuffleReadClient(CreateShuffleReadClientRequest request) {

--- a/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
@@ -37,9 +37,9 @@ public class ShuffleClientFactory {
 
   public ShuffleWriteClient createShuffleWriteClient(
       String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
-      int replica, int replicaWrite, int replicaRead) {
+      int replica, int replicaWrite, int replicaRead, boolean replicaSkip) {
     return new ShuffleWriteClientImpl(clientType, retryMax, retryIntervalMax, heartBeatThreadNum,
-      replica, replicaWrite, replicaRead);
+      replica, replicaWrite, replicaRead, replicaSkip);
   }
 
   public ShuffleReadClient createShuffleReadClient(CreateShuffleReadClientRequest request) {

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -85,10 +85,10 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
   private int replica;
   private int replicaWrite;
   private int replicaRead;
-  private boolean replicaSkip;
+  private boolean replicaSkipEnabled;
 
   public ShuffleWriteClientImpl(String clientType, int retryMax, long retryIntervalMax, int heartBeatThreadNum,
-                                int replica, int replicaWrite, int replicaRead, boolean replicaSkip) {
+                                int replica, int replicaWrite, int replicaRead, boolean replicaSkipEnabled) {
     this.clientType = clientType;
     this.retryMax = retryMax;
     this.retryIntervalMax = retryIntervalMax;
@@ -98,7 +98,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.replica = replica;
     this.replicaWrite = replicaWrite;
     this.replicaRead = replicaRead;
-    this.replicaSkip = replicaSkip;
+    this.replicaSkipEnabled = replicaSkipEnabled;
   }
 
   private boolean sendShuffleDataAsync(
@@ -190,7 +190,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     // which is minimum number when there is at most *replicaWrite - replica* sending server failures.
     for (ShuffleBlockInfo sbi : shuffleBlockInfoList) {
       List<ShuffleServerInfo> allServers = sbi.getShuffleServerInfos();
-      if (replicaSkip) {
+      if (replicaSkipEnabled) {
         genServerToBlocks(sbi, allServers.subList(0, replicaWrite),
           primaryServerToBlocks, primaryServerToBlockIds);
         genServerToBlocks(sbi, allServers.subList(replicaWrite, replica),
@@ -222,7 +222,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
     // The secondary round of blocks is sent only when the primary group issues failed sending.
     // This should be infrequent.
-    if (!isAllSuccess && replicaSkip) {
+    if (!isAllSuccess && !secondaryServerToBlocks.isEmpty()) {
       LOG.info("The sending of primary round is failed partially, so start the secondary round");
       sendShuffleDataAsync(appId, secondaryServerToBlocks, secondaryServerToBlockIds, blockIdsTracker);
     }

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -98,19 +99,13 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
     this.replicaRead = replicaRead;
   }
 
-  private void sendShuffleDataAsync(
+  private boolean sendShuffleDataAsync(
       String appId,
       Map<ShuffleServerInfo, Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
       Map<ShuffleServerInfo, List<Long>> serverToBlockIds,
-      Set<Long> successBlockIds,
-      Set<Long> tempFailedBlockIds) {
-
-    // maintain the count of blocks that have been sent to the server
-    Map<Long, AtomicInteger> blockIdsTracker = Maps.newConcurrentMap();
-    serverToBlockIds.values().forEach(
-      blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
-    );
-
+      Map<Long, AtomicInteger> blockIdsTracker) {
+    // If one or more servers is failed, the sending is not totally successful.
+    AtomicBoolean isAllServersSuccess = new AtomicBoolean(true);
     if (serverToBlocks != null) {
       serverToBlocks.entrySet().parallelStream().forEach(entry -> {
         ShuffleServerInfo ssi = entry.getKey();
@@ -118,7 +113,7 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
           Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks = entry.getValue();
           // todo: compact unnecessary blocks that reach replicaWrite
           RssSendShuffleDataRequest request = new RssSendShuffleDataRequest(
-              appId, retryMax, retryIntervalMax, shuffleIdToBlocks);
+            appId, retryMax, retryIntervalMax, shuffleIdToBlocks);
           long s = System.currentTimeMillis();
           RssSendShuffleDataResponse response = getShuffleServerClient(ssi).sendShuffleData(request);
           LOG.info("ShuffleWriteClientImpl sendShuffleData cost:" + (System.currentTimeMillis() - s));
@@ -127,27 +122,46 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
             // mark a replica of block that has been sent
             serverToBlockIds.get(ssi).forEach(block -> blockIdsTracker.get(block).incrementAndGet());
             LOG.info("Send: " + serverToBlockIds.get(ssi).size()
-                + " blocks to [" + ssi.getId() + "] successfully");
+              + " blocks to [" + ssi.getId() + "] successfully");
           } else {
+            isAllServersSuccess.set(false);
             LOG.warn("Send: " + serverToBlockIds.get(ssi).size() + " blocks to [" + ssi.getId()
-                + "] failed with statusCode[" + response.getStatusCode() + "], ");
+              + "] failed with statusCode[" + response.getStatusCode() + "], ");
           }
         } catch (Exception e) {
+          isAllServersSuccess.set(false);
           LOG.warn("Send: " + serverToBlockIds.get(ssi).size() + " blocks to [" + ssi.getId() + "] failed.", e);
         }
       });
+    }
+    return isAllServersSuccess.get();
+  }
 
-      // check success and failed blocks according to the replicaWrite
-      blockIdsTracker.entrySet().forEach(blockCt -> {
-          long blockId = blockCt.getKey();
-          int count = blockCt.getValue().get();
-          if (count >= replicaWrite) {
-            successBlockIds.add(blockId);
-          } else {
-            tempFailedBlockIds.add(blockId);
-          }
-        }
-      );
+  private void genServerToBlocks(ShuffleBlockInfo sbi, List<ShuffleServerInfo> serverList,
+                                 Map<ShuffleServerInfo,
+                                  Map<Integer, Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks,
+                                 Map<ShuffleServerInfo, List<Long>> serverToBlockIds) {
+    int partitionId = sbi.getPartitionId();
+    int shuffleId = sbi.getShuffleId();
+    for (ShuffleServerInfo ssi : serverList) {
+      if (!serverToBlockIds.containsKey(ssi)) {
+        serverToBlockIds.put(ssi, Lists.newArrayList());
+      }
+      serverToBlockIds.get(ssi).add(sbi.getBlockId());
+
+      if (!serverToBlocks.containsKey(ssi)) {
+        serverToBlocks.put(ssi, Maps.newHashMap());
+      }
+      Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks = serverToBlocks.get(ssi);
+      if (!shuffleIdToBlocks.containsKey(shuffleId)) {
+        shuffleIdToBlocks.put(shuffleId, Maps.newHashMap());
+      }
+
+      Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = shuffleIdToBlocks.get(shuffleId);
+      if (!partitionToBlocks.containsKey(partitionId)) {
+        partitionToBlocks.put(partitionId, Lists.newArrayList());
+      }
+      partitionToBlocks.get(partitionId).add(sbi);
     }
   }
 
@@ -156,41 +170,66 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
     // shuffleServer -> shuffleId -> partitionId -> blocks
     Map<ShuffleServerInfo, Map<Integer,
-        Map<Integer, List<ShuffleBlockInfo>>>> serverToBlocks = Maps.newHashMap();
-    Map<ShuffleServerInfo, List<Long>> serverToBlockIds = Maps.newHashMap();
+        Map<Integer, List<ShuffleBlockInfo>>>> primaryServerToBlocks = Maps.newHashMap();
+    Map<ShuffleServerInfo, Map<Integer,
+      Map<Integer, List<ShuffleBlockInfo>>>> secondaryServerToBlocks = Maps.newHashMap();
+    Map<ShuffleServerInfo, List<Long>> primaryServerToBlockIds = Maps.newHashMap();
+    Map<ShuffleServerInfo, List<Long>> secondaryServerToBlockIds = Maps.newHashMap();
+
     // send shuffle block to shuffle server
     // for all ShuffleBlockInfo, create the data structure as shuffleServer -> shuffleId -> partitionId -> blocks
     // it will be helpful to send rpc request to shuffleServer
+
+    // In order to reduce the data to send in quorum protocol,
+    // we split these blocks into two rounds: primary and secondary.
+    // The primary round contains [0, replicaWrite) replicas,
+    // which is minimum number when there is no sending server failures.
+    // The secondary round contains [replicaWrite, replica) replicas,
+    // which is minimum number when there is at most *replicaWrite - replica* sending server failures.
     for (ShuffleBlockInfo sbi : shuffleBlockInfoList) {
-      int partitionId = sbi.getPartitionId();
-      int shuffleId = sbi.getShuffleId();
-      for (ShuffleServerInfo ssi : sbi.getShuffleServerInfos()) {
-        if (!serverToBlockIds.containsKey(ssi)) {
-          serverToBlockIds.put(ssi, Lists.newArrayList());
-        }
-        serverToBlockIds.get(ssi).add(sbi.getBlockId());
-
-        if (!serverToBlocks.containsKey(ssi)) {
-          serverToBlocks.put(ssi, Maps.newHashMap());
-        }
-        Map<Integer, Map<Integer, List<ShuffleBlockInfo>>> shuffleIdToBlocks = serverToBlocks.get(ssi);
-        if (!shuffleIdToBlocks.containsKey(shuffleId)) {
-          shuffleIdToBlocks.put(shuffleId, Maps.newHashMap());
-        }
-
-        Map<Integer, List<ShuffleBlockInfo>> partitionToBlocks = shuffleIdToBlocks.get(shuffleId);
-        if (!partitionToBlocks.containsKey(partitionId)) {
-          partitionToBlocks.put(partitionId, Lists.newArrayList());
-        }
-        partitionToBlocks.get(partitionId).add(sbi);
-      }
+      List<ShuffleServerInfo> allServers = sbi.getShuffleServerInfos();
+      genServerToBlocks(sbi, allServers.subList(0, replicaWrite),
+        primaryServerToBlocks, primaryServerToBlockIds);
+      genServerToBlocks(sbi, allServers.subList(replicaWrite, replica),
+        secondaryServerToBlocks, secondaryServerToBlockIds);
     }
+
+    // maintain the count of blocks that have been sent to the server
+    Map<Long, AtomicInteger> blockIdsTracker = Maps.newConcurrentMap();
+    primaryServerToBlockIds.values().forEach(
+      blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
+    );
+    secondaryServerToBlockIds.values().forEach(
+      blockList -> blockList.forEach(block -> blockIdsTracker.put(block, new AtomicInteger(0)))
+    );
 
     Set<Long> failedBlockIds = Sets.newConcurrentHashSet();
     Set<Long> successBlockIds = Sets.newConcurrentHashSet();
     // if send block failed, the task will fail
     // todo: better to have fallback solution when send to multiple servers
-    sendShuffleDataAsync(appId, serverToBlocks, serverToBlockIds, successBlockIds, failedBlockIds);
+
+    // sent the primary round of blocks.
+    boolean isAllSuccess = sendShuffleDataAsync(
+        appId, primaryServerToBlocks, primaryServerToBlockIds, blockIdsTracker);
+
+    // The secondary round of blocks is sent only when the primary group issues failed sending.
+    // This should be infrequent.
+    if (!isAllSuccess) {
+      LOG.info("The sending of primary round is failed partially, so start the secondary round");
+      sendShuffleDataAsync(appId, secondaryServerToBlocks, secondaryServerToBlockIds, blockIdsTracker);
+    }
+
+    // check success and failed blocks according to the replicaWrite
+    blockIdsTracker.entrySet().forEach(blockCt -> {
+        long blockId = blockCt.getKey();
+        int count = blockCt.getValue().get();
+        if (count >= replicaWrite) {
+          successBlockIds.add(blockId);
+        } else {
+          failedBlockIds.add(blockId);
+        }
+      }
+    );
     return new SendShuffleDataResult(successBlockIds, failedBlockIds);
   }
 

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleWriteClientImpl.java
@@ -222,6 +222,8 @@ public class ShuffleWriteClientImpl implements ShuffleWriteClient {
 
     // The secondary round of blocks is sent only when the primary group issues failed sending.
     // This should be infrequent.
+    // Even though the secondary round may send blocks more than replicaWrite replicas,
+    // we do not apply complicated skipping logic, because server crash is rare in production environment.
     if (!isAllSuccess && !secondaryServerToBlocks.isEmpty()) {
       LOG.info("The sending of primary round is failed partially, so start the secondary round");
       sendShuffleDataAsync(appId, secondaryServerToBlocks, secondaryServerToBlockIds, blockIdsTracker);

--- a/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
+++ b/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
@@ -33,8 +33,8 @@ public class RssClientConfig {
   public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = 1;
   public static final String RSS_DATA_REPLICA_READ = "rss.data.replica.read";
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = 1;
-  public static final String RSS_DATA_REPLICA_SKIP = "rss.data.replica.skip";
-  public static final boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE = true;
+  public static final String RSS_DATA_REPLICA_SKIP_ENABLED = "rss.data.replica.skip.enabled";
+  public static final boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE = true;
   public static final String RSS_HEARTBEAT_INTERVAL = "rss.heartbeat.interval";
   public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
   public static final String RSS_HEARTBEAT_TIMEOUT = "rss.heartbeat.timeout";

--- a/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
+++ b/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
@@ -33,6 +33,8 @@ public class RssClientConfig {
   public static final int RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE = 1;
   public static final String RSS_DATA_REPLICA_READ = "rss.data.replica.read";
   public static final int RSS_DATA_REPLICA_READ_DEFAULT_VALUE = 1;
+  public static final String RSS_DATA_REPLICA_SKIP = "rss.data.replica.skip";
+  public static final boolean RSS_DATA_REPLICA_SKIP_DEFAULT_VALUE = true;
   public static final String RSS_HEARTBEAT_INTERVAL = "rss.heartbeat.interval";
   public static final long RSS_HEARTBEAT_INTERVAL_DEFAULT_VALUE = 10 * 1000L;
   public static final String RSS_HEARTBEAT_TIMEOUT = "rss.heartbeat.timeout";

--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
@@ -42,7 +42,7 @@ public class ShuffleWriteClientImplTest {
   @Test
   public void testSendData() {
     ShuffleWriteClientImpl shuffleWriteClient =
-        new ShuffleWriteClientImpl("GRPC", 3, 2000, 4, 1, 1, 1);
+        new ShuffleWriteClientImpl("GRPC", 3, 2000, 4, 1, 1, 1, true);
     ShuffleServerClient mockShuffleServerClient = mock(ShuffleServerClient.class);
     ShuffleWriteClientImpl spyClient = spy(shuffleWriteClient);
     doReturn(mockShuffleServerClient).when(spyClient).getShuffleServerClient(any());

--- a/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
@@ -66,6 +66,8 @@ public class QuorumTest extends ShuffleReadWriteBase {
   private static ShuffleServerInfo fakedShuffleServerInfo0;
   private static ShuffleServerInfo fakedShuffleServerInfo1;
   private static ShuffleServerInfo fakedShuffleServerInfo2;
+  private static ShuffleServerInfo fakedShuffleServerInfo3;
+  private static ShuffleServerInfo fakedShuffleServerInfo4;
   private ShuffleWriteClientImpl shuffleWriteClientImpl;
 
   public static MockedShuffleServer createServer(int id) throws Exception {
@@ -125,6 +127,10 @@ public class QuorumTest extends ShuffleReadWriteBase {
       new ShuffleServerInfo("127.0.0.1-20002", shuffleServers.get(1).getIp(), SHUFFLE_SERVER_PORT + 200);
     fakedShuffleServerInfo2 =
       new ShuffleServerInfo("127.0.0.1-20003", shuffleServers.get(2).getIp(), SHUFFLE_SERVER_PORT + 300);
+    fakedShuffleServerInfo3 =
+      new ShuffleServerInfo("127.0.0.1-20004", shuffleServers.get(2).getIp(), SHUFFLE_SERVER_PORT + 400);
+    fakedShuffleServerInfo4 =
+      new ShuffleServerInfo("127.0.0.1-20005", shuffleServers.get(2).getIp(), SHUFFLE_SERVER_PORT + 500);
     Thread.sleep(2000);
   }
 
@@ -187,7 +193,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void rpcFailedTest() throws Exception {
     String testAppId = "rpcFailedTest";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
 
@@ -247,22 +253,25 @@ public class QuorumTest extends ShuffleReadWriteBase {
       .disableMockedTimeout();
   }
 
-  private void registerShuffleServer(String testAppId){
+  private void registerShuffleServer(String testAppId,
+      int replica, int replicaWrite, int replicaRead, boolean replicaSkip) {
 
     shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
-      3, 2, 2);
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo0,
-      testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), "");
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo1,
-      testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), "");
-    shuffleWriteClientImpl.registerShuffle(shuffleServerInfo2,
-      testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), "");
+      replica, replicaWrite, replicaRead, replicaSkip);
+
+    List<ShuffleServerInfo> allServers = Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1,
+        shuffleServerInfo2, shuffleServerInfo3, shuffleServerInfo4);
+
+    for (int i = 0; i < replica; i ++) {
+      shuffleWriteClientImpl.registerShuffle(allServers.get(i),
+          testAppId, 0, Lists.newArrayList(new PartitionRange(0, 0)), "");
+    }
   }
 
   @Test
   public void case1() throws Exception {
     String testAppId = "case1";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
 
@@ -305,7 +314,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case2() throws Exception {
     String testAppId = "case2";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2,true);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
@@ -351,7 +360,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case3() throws Exception {
     String testAppId = "case3";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId,3, 2, 2, true);
     disableTimeout((MockedShuffleServer)shuffleServers.get(0));
     disableTimeout((MockedShuffleServer)shuffleServers.get(1));
     disableTimeout((MockedShuffleServer)shuffleServers.get(2));
@@ -410,7 +419,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case4() throws Exception {
     String testAppId = "case4";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
     // when 1 server is timeout, the sending multiple blocks should success
     enableTimeout((MockedShuffleServer)shuffleServers.get(2), 500);
 
@@ -437,7 +446,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   public void case5() throws Exception {
     // this case is to simulate server restarting.
     String testAppId = "case5";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
@@ -493,7 +502,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case6() throws Exception {
     String testAppId = "case6";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap0 = Roaring64NavigableMap.bitmapOf();
     Roaring64NavigableMap blockIdBitmap1 = Roaring64NavigableMap.bitmapOf();
@@ -536,7 +545,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case7() throws Exception {
     String testAppId = "case7";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
@@ -577,7 +586,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
   @Test
   public void case8() throws Exception {
     String testAppId = "case8";
-    registerShuffleServer(testAppId);
+    registerShuffleServer(testAppId, 3, 2, 2, true);
 
     Map<Long, byte[]> expectedData = Maps.newHashMap();
     Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
@@ -588,7 +597,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     // secondary round: server 2
     for (int i = 0; i < 5; i++) {
       List<ShuffleBlockInfo> blocks = createShuffleBlockList(
-        0, 0, 0, 3, 10 * (i + 1), blockIdBitmap,
+        0, 0, 0, 3, 25, blockIdBitmap,
         expectedData, Lists.newArrayList(shuffleServerInfo0, fakedShuffleServerInfo1, shuffleServerInfo2));
       SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
       assertTrue(result.getSuccessBlockIds().size() == 3);
@@ -614,6 +623,156 @@ public class QuorumTest extends ShuffleReadWriteBase {
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
       Lists.newArrayList(shuffleServerInfo0, fakedShuffleServerInfo1, shuffleServerInfo2), null);
+    validateResult(readClient, expectedData);
+  }
+
+  @Test
+  public void case9() throws Exception {
+    String testAppId = "case9";
+    // test different quorum configurations:[5,3,3]
+    registerShuffleServer(testAppId, 5, 3, 3, true);
+
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
+
+    // attempt to send data to "all servers", but only the server 0,1,2 receive data actually
+    for (int i = 0; i < 5; i++) {
+      List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+        0, 0, 0, 3, 25, blockIdBitmap,
+        expectedData, Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2,
+            shuffleServerInfo3, shuffleServerInfo4));
+      SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+      assertTrue(result.getSuccessBlockIds().size() == 3);
+      assertTrue(result.getFailedBlockIds().size() == 0);
+    }
+
+    // we cannot read any blocks from server 3, 4
+    ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null);
+    assertTrue(readClient.readShuffleBlockData() == null);
+
+    // we can also read blocks from server 0,1,2
+    readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null);
+    validateResult(readClient, expectedData);
+  }
+
+  @Test
+  public void case10() throws Exception {
+    String testAppId = "case10";
+    // test different quorum configurations:[5,3,3]
+    registerShuffleServer(testAppId, 5, 3, 3, true);
+
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
+
+    // attempt to send data to "all servers", but the secondary round is activated due to failures in primary round.
+    for (int i = 0; i < 5; i++) {
+      List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+        0, 0, 0, 3, 25, blockIdBitmap,
+        expectedData, Lists.newArrayList(shuffleServerInfo0, fakedShuffleServerInfo1, shuffleServerInfo2,
+            shuffleServerInfo3, shuffleServerInfo4));
+      SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+      assertTrue(result.getSuccessBlockIds().size() == 3);
+      assertTrue(result.getFailedBlockIds().size() == 0);
+    }
+
+    // we cannot read any blocks from server 1 due to failures
+    ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo1), null);
+   assertTrue(readClient.readShuffleBlockData() == null);
+
+    // we can also read blocks from server 3,4
+    readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null);
+    validateResult(readClient, expectedData);
+  }
+
+  @Test
+  public void case11() throws Exception {
+    String testAppId = "case11";
+    // test different quorum configurations:[5,4,2]
+    registerShuffleServer(testAppId, 5, 4, 2, true);
+
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
+
+    // attempt to send data to "all servers", but only the server 0,1,2 receive data actually
+    for (int i = 0; i < 5; i++) {
+      List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+        0, 0, 0, 3, 25, blockIdBitmap,
+        expectedData, Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2,
+          shuffleServerInfo3, shuffleServerInfo4));
+      SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+      assertTrue(result.getSuccessBlockIds().size() == 3);
+      assertTrue(result.getFailedBlockIds().size() == 0);
+    }
+
+    // we cannot read any blocks from server 4 because the secondary round is skipped
+    ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo4), null);
+    assertTrue(readClient.readShuffleBlockData() == null);
+
+    // we can read blocks from server 0,1,2,3
+    readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2, shuffleServerInfo3), null);
+    validateResult(readClient, expectedData);
+  }
+
+  @Test
+  public void case12() throws Exception {
+    String testAppId = "case12";
+    // test when replica skipping is disabled.
+    registerShuffleServer(testAppId, 3, 2, 2, false);
+
+    Map<Long, byte[]> expectedData = Maps.newHashMap();
+    Roaring64NavigableMap blockIdBitmap = Roaring64NavigableMap.bitmapOf();
+    Roaring64NavigableMap taskIdBitmap = Roaring64NavigableMap.bitmapOf(0);
+
+
+    for (int i = 0; i < 5; i++) {
+      List<ShuffleBlockInfo> blocks = createShuffleBlockList(
+        0, 0, 0, 3, 25, blockIdBitmap,
+        expectedData, Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2));
+      SendShuffleDataResult result = shuffleWriteClientImpl.sendShuffleData(testAppId, blocks);
+      assertTrue(result.getSuccessBlockIds().size() == 3);
+      assertTrue(result.getFailedBlockIds().size() == 0);
+    }
+
+    // we can read blocks from server 0
+    ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo0), null);
+    validateResult(readClient, expectedData);
+
+    // we can also read blocks from server 1
+    readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo1), null);
+    validateResult(readClient, expectedData);
+
+    // we can also read blocks from server 2
+    readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
+      testAppId, 0, 0, 100, 1,
+      10, 1000, "", blockIdBitmap, taskIdBitmap,
+      Lists.newArrayList(shuffleServerInfo2), null);
     validateResult(readClient, expectedData);
   }
 

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
@@ -100,7 +100,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
   public void clearResourceTest() throws Exception {
     final ShuffleWriteClient shuffleWriteClient =
         ShuffleClientFactory.getInstance().createShuffleWriteClient(
-            "GRPC", 2, 10000L, 4, 1, 1, 1);
+            "GRPC", 2, 10000L, 4, 1, 1, 1, true);
     shuffleWriteClient.registerCoordinators("127.0.0.1:19999");
     shuffleWriteClient.registerShuffle(
         new ShuffleServerInfo("127.0.0.1-20001", "127.0.0.1", 20001),

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
@@ -87,7 +87,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   @Before
   public void createClient() {
     shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
-      1, 1, 1);
+      1, 1, 1, true);
   }
 
   @After


### PR DESCRIPTION
### What changes were proposed in this pull request?
Write client send blocks in two rounds.
In the primary round, we only send [0, replicaWrite) data.
In the secondary round, we send [replicaWrite, replica) data.
When  the primary round is totally successful, the secondary round can be skipped. 

### Why are the changes needed?
Without this patch, the  quorum writer will send whole replica times of blocks even all RPCs are successful.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
All previous UTs and new UTs.