### PR TITLE
[Improvement]  Filter the interface address that don't have broadcast address

### DIFF
--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
@@ -108,9 +109,12 @@ public class RssUtils {
       if (!ni.isUp() || ni.isLoopback() || ni.isPointToPoint() || ni.isVirtual()) {
         continue;
       }
-      Enumeration<InetAddress> ad = ni.getInetAddresses();
-      while (ad.hasMoreElements()) {
-        InetAddress ia = ad.nextElement();
+      for (InterfaceAddress ifa : ni.getInterfaceAddresses()) {
+        InetAddress ia = ifa.getAddress();
+        InetAddress brd = ifa.getBroadcast();
+        if (brd == null || brd.isAnyLocalAddress()) {
+          continue;
+        }
         if (!ia.isLinkLocalAddress() && !ia.isAnyLocalAddress() && !ia.isLoopbackAddress()
             && ia instanceof Inet4Address && ia.isReachable(5000)) {
           if (!ia.isSiteLocalAddress()) {

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -113,6 +113,7 @@ public class RssUtils {
         InetAddress ia = ifa.getAddress();
         InetAddress brd = ifa.getBroadcast();
         if (brd == null || brd.isAnyLocalAddress()) {
+          LOGGER.info("ip {} was filtered, because it don't have effective broadcast address", ia.getHostAddress());
           continue;
         }
         if (!ia.isLinkLocalAddress() && !ia.isAnyLocalAddress() && !ia.isLoopbackAddress()
@@ -120,8 +121,13 @@ public class RssUtils {
           if (!ia.isSiteLocalAddress()) {
             return ia.getHostAddress();
           } else if (siteLocalAddress == null) {
+            LOGGER.info("ip {} was candidate, if there is no better choice, we will choose it", ia.getHostAddress());
             siteLocalAddress = ia.getHostAddress();
+          } else {
+            LOGGER.info("ip {} was filtered, because it's not first effect site local address", ia.getHostAddress());
           }
+        } else {
+          LOGGER.info("ip {} was filtered, because it's just a local address or loop address", ia.getHostAddress());
         }
       }
     }

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -126,8 +126,16 @@ public class RssUtils {
           } else {
             LOGGER.info("ip {} was filtered, because it's not first effect site local address", ia.getHostAddress());
           }
+        } else if(!(ia instanceof Inet4Address)) {
+          LOGGER.info("ip {} was filtered, because it's just a ipv6 address", ia.getHostAddress());
+        } else if (ia.isLinkLocalAddress()) {
+          LOGGER.info("ip {} was filtered, because it's just a link local address", ia.getHostAddress());
+        } else if (ia.isAnyLocalAddress()) {
+          LOGGER.info("ip {} was filtered, because it's just a any local address", ia.getHostAddress());
+        } else if (ia.isLoopbackAddress()) {
+          LOGGER.info("ip {} was filtered, because it's just a loop back address", ia.getHostAddress());
         } else {
-          LOGGER.info("ip {} was filtered, because it's just a local address or loop address", ia.getHostAddress());
+          LOGGER.info("ip {} was filtered, because it's just not reachable address", ia.getHostAddress());
         }
       }
     }

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -126,7 +126,7 @@ public class RssUtils {
           } else {
             LOGGER.info("ip {} was filtered, because it's not first effect site local address", ia.getHostAddress());
           }
-        } else if(!(ia instanceof Inet4Address)) {
+        } else if (!(ia instanceof Inet4Address)) {
           LOGGER.info("ip {} was filtered, because it's just a ipv6 address", ia.getHostAddress());
         } else if (ia.isLinkLocalAddress()) {
           LOGGER.info("ip {} was filtered, because it's just a link local address", ia.getHostAddress());


### PR DESCRIPTION
### What changes were proposed in this pull request?
Filter the interface address that don't have broadcast address

### Why are the changes needed?
Some machines have multiple interface address, but some interface address don't have broadcast address, we can't use it to communicate, so we should filter it.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual Test