### PR TITLE
[Bugfix] Shade jar should contain lz4 jar

### DIFF
--- a/client-mr/pom.xml
+++ b/client-mr/pom.xml
@@ -142,6 +142,7 @@
                                     <include>com.fasterxml.jackson.core:jackson-annotations</include>
                                     <include>org.roaringbitmap:RoaringBitmap</include>
                                     <include>org.roaringbitmap:shims</include>
+                                    <include>net.jpountz.lz4:lz4</include>
                                 </includes>
                             </artifactSet>
                             <finalName>${project.artifactId}-${project.version}</finalName>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Include lz4 jar in our shade jar

### Why are the changes needed?
If we don't have this patch, we will encounter exception that we can't load Lz4 class.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test
