### PR TITLE
[Improvement][WIP] Support in-place decompression on MR memory.

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
@@ -21,11 +21,13 @@ package org.apache.hadoop.mapreduce.task.reduce;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.IOUtils;
 
+import com.tencent.rss.common.RssShuffleUtils;
 import com.tencent.rss.common.exception.RssException;
 
 // In MR shuffle, MapOutput encapsulates the logic to fetch map task's output data via http.
@@ -33,27 +35,36 @@ import com.tencent.rss.common.exception.RssException;
 public class RssBypassWriter {
   private static final Log LOG = LogFactory.getLog(RssBypassWriter.class);
 
-  public static void write(MapOutput mapOutput, byte[] buffer) {
+  public static void write(MapOutput mapOutput, byte[] compressedData,
+                           int unCompressedLength) {
     // Write and commit uncompressed data to MapOutput.
     // In the majority of cases, merger allocates memory to accept data,
     // but when data size exceeds the threshold, merger can also allocate disk.
     // So, we should consider the two situations, respectively.
     if (mapOutput instanceof InMemoryMapOutput) {
-      write((InMemoryMapOutput) mapOutput, buffer);
+      write((InMemoryMapOutput) mapOutput, compressedData, unCompressedLength);
     } else if (mapOutput instanceof OnDiskMapOutput) {
-      write((OnDiskMapOutput) mapOutput, buffer);
+      write((OnDiskMapOutput) mapOutput, compressedData, unCompressedLength);
     } else {
       throw new IllegalStateException("Merger reserve unknown type of MapOutput："
         + mapOutput.getClass().getCanonicalName());
     }
   }
 
-  private static void write(InMemoryMapOutput inMemoryMapOutput, byte[] buffer) {
-    byte[] memory = inMemoryMapOutput.getMemory();
-    System.arraycopy(buffer, 0, memory, 0, buffer.length);
+  private static void write(InMemoryMapOutput inMemoryMapOutput,
+                            byte[] compressedData,
+                            int unCompressedLength) {
+    byte[] mrMemoryBuffer = inMemoryMapOutput.getMemory();
+    // we decompress data on MR's memory directly to avoid extra allocate and copy
+    RssShuffleUtils.inplaceDecompressData(
+      ByteBuffer.wrap(mrMemoryBuffer),
+      ByteBuffer.wrap(compressedData),
+      unCompressedLength);
   }
 
-  private static void write(OnDiskMapOutput onDiskMapOutput, byte[] buffer) {
+  private static void write(OnDiskMapOutput onDiskMapOutput,
+                            byte[] compressedData,
+                            int unCompressedLength) {
     OutputStream disk = null;
     try {
       Class clazz = Class.forName(OnDiskMapOutput.class.getName());
@@ -68,9 +79,11 @@ public class RssBypassWriter {
       throw new RssException("OnDiskMapOutput should not contain null disk stream");
     }
 
-    // Copy data to local-disk
+    // Copy data to local-disk, we still need to allocate buffer
+    byte[] uncompressed = RssShuffleUtils.decompressData(
+      ByteBuffer.wrap(compressedData), unCompressedLength, false).array();
     try {
-      disk.write(buffer, 0, buffer.length);
+      disk.write(uncompressed, 0, unCompressedLength);
       disk.close();
     } catch (IOException ioe) {
       // Close the streams

--- a/common/src/main/java/com/tencent/rss/common/RssShuffleUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/RssShuffleUtils.java
@@ -57,4 +57,9 @@ public class RssShuffleUtils {
     fastDecompressor.decompress(data, data.position(), uncompressData, 0, uncompressLength);
     return uncompressData;
   }
+
+  public static void inplaceDecompressData(ByteBuffer desc, ByteBuffer src, int uncompressLength) {
+    LZ4FastDecompressor fastDecompressor = LZ4Factory.fastestInstance().fastDecompressor();
+    fastDecompressor.decompress(src, src.position(), desc, 0, uncompressLength);
+  }
 }

--- a/common/src/test/java/com/tencent/rss/common/RssShuffleUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/RssShuffleUtilsTest.java
@@ -21,6 +21,7 @@ package com.tencent.rss.common;
 import com.google.common.collect.Lists;
 import org.junit.Test;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Random;
 
@@ -32,16 +33,29 @@ public class RssShuffleUtilsTest {
     List<Integer> testSizes = Lists.newArrayList(
       1, 1024, 128 * 1024, 512 * 1024, 1024 * 1024, 4 * 1024 * 1024);
     for (int size : testSizes) {
-      singleTest(size);
+      singleTest1(size);
+      singleTest2(size);
     }
   }
 
-  private void singleTest(int size) {
+  private void singleTest1(int size) {
     byte[] buf = new byte[size];
     new Random().nextBytes(buf);
 
     byte[] compressed = RssShuffleUtils.compressData(buf);
     byte[] uncompressed = RssShuffleUtils.decompressData(compressed, size);
     assertArrayEquals(buf, uncompressed);
+  }
+
+  private void singleTest2(int size) {
+    byte[] srcBuffer = new byte[size];
+    new Random().nextBytes(srcBuffer);
+
+    byte[] desBuffer = new byte[size];
+
+    byte[] compressed = RssShuffleUtils.compressData(srcBuffer);
+    RssShuffleUtils.inplaceDecompressData(ByteBuffer.wrap(desBuffer), ByteBuffer.wrap(compressed), size);
+
+    assertArrayEquals(srcBuffer, desBuffer);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add an in-place writer to decompress on the memory buffer, which is allocated by MR Reduce.
2. Remove buffer allocation on RSS MR client

### Why are the changes needed?
Shorten the data path on the reduce side.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Just a minor change, add an UT on in-place writer.
