### PR TITLE
[Improvement] Parallelize github workflow to speed up CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,14 @@ jobs:
 
     runs-on: ubuntu-20.04
 
+    strategy:
+      matrix:
+        profile:
+          - spark2
+          - spark3
+          - mr
+      fail-fast: false
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 8
@@ -39,27 +47,11 @@ jobs:
         java-version: '8'
         distribution: 'adopt'
         cache: maven
-    - name: Build with Maven with Profile spark2
-      run: mvn -B package --file pom.xml -Pspark2
-    - name: Upload spark2 test results to report
+    - name: Build with Maven with Profile ${{ matrix.profile }}
+      run: mvn -B package --file pom.xml -P${{ matrix.profile }}
+    - name: Upload ${{ matrix.profile }} test results to report
       if: failure()
       uses: actions/upload-artifact@v2
       with:
-        name: test-results-of-rss-spark2
-        path: "**/target/surefire-reports/*.txt"
-    - name: Build with Maven with Profile spark3
-      run: mvn -B package --file pom.xml -Pspark3
-    - name: Upload spark3 test results to report
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-of-rss-spark3
-        path: "**/target/surefire-reports/*.txt"
-    - name: Build with Maven with Profile mr
-      run: mvn -B package --file pom.xml -Pmr
-    - name: Upload mr test results to report
-      if: failure()
-      uses: actions/upload-artifact@v2
-      with:
-        name: test-results-of-rss-mr
+        name: test-results-of-rss-${{ matrix.profile }}
         path: "**/target/surefire-reports/*.txt"


### PR DESCRIPTION
### What changes were proposed in this pull request?

Parallelize github workflow to speed up CI.

### Why are the changes needed?

Reduced wall-clock time of CI from ~1 hour to ~25 minutes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/Firestorm/actions/runs/2362806351