### PR TITLE
[Improvement] Migrate to JUnit 5

### DIFF
--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.serializer.SerializationFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.api.ShuffleWriteClient;
@@ -40,8 +40,8 @@ import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SortWriteBufferManagerTest {
 

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferTest.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.io.serializer.Deserializer;
 import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.io.serializer.Serializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SortWriteBufferTest {
 

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -22,12 +22,12 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import org.apache.hadoop.mapred.JobConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.util.RssClientConfig;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RssMRUtilsTest {
 

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.mapred.TaskCompletionEvent;
 import org.apache.hadoop.mapreduce.RssMRUtils;
 import org.apache.hadoop.mapreduce.TaskType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -60,7 +60,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.MRConfig;
 import org.apache.hadoop.mapreduce.TaskType;
 import org.apache.hadoop.util.Progress;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMasterTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMasterTest.java
@@ -23,11 +23,11 @@ import java.io.File;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRJobConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssMRAppMasterTest {
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/RssSparkShuffleUtilsTest.java
@@ -23,14 +23,14 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.SparkConf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.util.RssClientConfig;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssSparkShuffleUtilsTest {
   @Test

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/AbstractRssReaderTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.spark.shuffle.reader;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.esotericsoftware.kryo.io.Output;
 import com.google.common.collect.Lists;

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -18,9 +18,9 @@
 
 package org.apache.spark.shuffle.reader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.google.common.collect.Lists;
@@ -41,7 +41,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.executor.ShuffleReadMetrics;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.Serializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -18,8 +18,8 @@
 
 package org.apache.spark.shuffle.writer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -35,7 +35,7 @@ import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WriteBufferManagerTest {
 

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferTest.java
@@ -18,13 +18,13 @@
 
 package org.apache.spark.shuffle.writer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.SerializationStream;
 import org.apache.spark.serializer.Serializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.reflect.ClassTag$;
 
 public class WriteBufferTest {

--- a/client-spark/spark2/pom.xml
+++ b/client-spark/spark2/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -25,9 +25,9 @@ import com.google.common.collect.Lists;
 import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -36,9 +36,9 @@ import com.tencent.rss.client.response.RssAccessClusterResponse;
 
 import static com.tencent.rss.client.response.ResponseStatusCode.ACCESS_DENIED;
 import static com.tencent.rss.client.response.ResponseStatusCode.SUCCESS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -47,12 +47,12 @@ import static org.mockito.Mockito.when;
 public class DelegationRssShuffleManagerTest {
   private static MockedStatic<RssSparkShuffleUtils> mockedStaticRssShuffleUtils;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     mockedStaticRssShuffleUtils = mockStatic(RssSparkShuffleUtils.class, Mockito.CALLS_REAL_METHODS);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     mockedStaticRssShuffleUtils.close();
   }

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -34,7 +34,7 @@ import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import scala.Option;
 

--- a/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark2/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -40,10 +40,7 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.RssShuffleHandle;
 import org.apache.spark.shuffle.RssShuffleManager;
 import org.apache.spark.util.EventLoop;
-import org.hamcrest.core.StringStartsWith;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import scala.Product2;
 import scala.Tuple2;
 import scala.collection.mutable.MutableList;
@@ -53,9 +50,10 @@ import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -64,9 +62,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class RssShuffleWriterTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void checkBlockSendResultTest() {
@@ -113,18 +108,18 @@ public class RssShuffleWriterTest {
     // case 2: partial blocks aren't sent before spark.rss.writer.send.check.timeout,
     // Runtime exception will be thrown
     manager.addSuccessBlockIds(taskId, Sets.newHashSet(1L, 2L));
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(StringStartsWith.startsWith("Timeout:"));
-    rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L));
+    Throwable e2 = assertThrows(RuntimeException.class, () ->
+        rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
+    assertTrue(e2.getMessage().startsWith("Timeout:"));
 
     manager.clearTaskMeta(taskId);
 
     // case 3: partial blocks are sent failed, Runtime exception will be thrown
     manager.addSuccessBlockIds(taskId, Sets.newHashSet(1L, 2L));
     manager.addFailedBlockIds(taskId, Sets.newHashSet(3L));
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(StringStartsWith.startsWith("Send failed:"));
-    rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L));
+    Throwable e3 = assertThrows(RuntimeException.class, () ->
+        rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
+    assertTrue(e3.getMessage().startsWith("Send failed:"));
     manager.clearTaskMeta(taskId);
     assertTrue(manager.getSuccessBlockIds(taskId).isEmpty());
     assertTrue(manager.getFailedBlockIds(taskId).isEmpty());

--- a/client-spark/spark3/pom.xml
+++ b/client-spark/spark3/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>netty-all</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/DelegationRssShuffleManagerTest.java
@@ -26,9 +26,9 @@ import com.google.common.collect.Lists;
 import com.tencent.rss.storage.util.StorageType;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -37,9 +37,9 @@ import com.tencent.rss.client.response.RssAccessClusterResponse;
 
 import static com.tencent.rss.client.response.ResponseStatusCode.ACCESS_DENIED;
 import static com.tencent.rss.client.response.ResponseStatusCode.SUCCESS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -48,12 +48,12 @@ import static org.mockito.Mockito.when;
 public class DelegationRssShuffleManagerTest {
   private static MockedStatic<RssSparkShuffleUtils> mockedStaticRssShuffleUtils;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     mockedStaticRssShuffleUtils = mockStatic(RssSparkShuffleUtils.class, Mockito.CALLS_REAL_METHODS);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     mockedStaticRssShuffleUtils.close();
   }

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/reader/RssShuffleReaderTest.java
@@ -29,7 +29,7 @@ import org.apache.spark.executor.TaskMetrics;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.serializer.Serializer;
 import org.apache.spark.shuffle.RssShuffleHandle;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import scala.Option;
 

--- a/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
+++ b/client-spark/spark3/src/test/java/org/apache/spark/shuffle/writer/RssShuffleWriterTest.java
@@ -42,10 +42,7 @@ import org.apache.spark.shuffle.RssShuffleHandle;
 import org.apache.spark.shuffle.RssShuffleManager;
 import org.apache.spark.shuffle.TestUtils;
 import org.apache.spark.util.EventLoop;
-import org.hamcrest.core.StringStartsWith;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import scala.Product2;
 import scala.Tuple2;
 import scala.collection.mutable.MutableList;
@@ -55,8 +52,9 @@ import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -65,9 +63,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 public class RssShuffleWriterTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void checkBlockSendResultTest() {
@@ -120,17 +115,17 @@ public class RssShuffleWriterTest {
     // case 2: partial blocks aren't sent before spark.rss.writer.send.check.timeout,
     // Runtime exception will be thrown
     successBlocks.put("taskId", Sets.newHashSet(1L, 2L));
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(StringStartsWith.startsWith("Timeout:"));
-    rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L));
+    Throwable e2 = assertThrows(RuntimeException.class, () ->
+        rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
+    assertTrue(e2.getMessage().startsWith("Timeout:"));
     successBlocks.clear();
 
     // case 3: partial blocks are sent failed, Runtime exception will be thrown
     successBlocks.put("taskId", Sets.newHashSet(1L, 2L));
     failBlocks.put("taskId", Sets.newHashSet(3L));
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage(StringStartsWith.startsWith("Send failed:"));
-    rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L));
+    Throwable e3 = assertThrows(RuntimeException.class, () ->
+        rssShuffleWriter.checkBlockSendResult(Sets.newHashSet(1L, 2L, 3L)));
+    assertTrue(e3.getMessage().startsWith("Send failed:"));
     successBlocks.clear();
     failBlocks.clear();
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -48,10 +48,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>

--- a/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
+++ b/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
@@ -18,13 +18,13 @@
 
 package com.tencent.rss.client;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.util.ClientUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ClientUtilsTest {
 

--- a/client/src/test/java/com/tencent/rss/client/TestUtils.java
+++ b/client/src/test/java/com/tencent/rss/client/TestUtils.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestUtils {
 

--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
@@ -18,10 +18,10 @@
 
 package com.tencent.rss.client.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.google.common.collect.Lists;
@@ -41,9 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.roaringbitmap.longlong.LongIterator;
@@ -53,8 +51,6 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
   private static final String EXPECTED_EXCEPTION_MESSAGE = "Exception should be thrown";
   private static AtomicLong ATOMIC_LONG = new AtomicLong(0);
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void readTest1() throws Exception {

--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleWriteClientImplTest.java
@@ -18,7 +18,7 @@
 
 package com.tencent.rss.client.impl;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -35,7 +35,7 @@ import com.tencent.rss.common.ShuffleServerInfo;
 
 import java.nio.ByteBuffer;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShuffleWriteClientImplTest {
 

--- a/common/src/test/java/com/tencent/rss/common/ArgumentsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/ArgumentsTest.java
@@ -18,10 +18,10 @@
 
 package com.tencent.rss.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
 public class ArgumentsTest {

--- a/common/src/test/java/com/tencent/rss/common/RssShuffleUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/RssShuffleUtilsTest.java
@@ -19,12 +19,12 @@
 package com.tencent.rss.common;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 public class RssShuffleUtilsTest {
   @Test

--- a/common/src/test/java/com/tencent/rss/common/ShufflePartitionedBlockTest.java
+++ b/common/src/test/java/com/tencent/rss/common/ShufflePartitionedBlockTest.java
@@ -18,18 +18,13 @@
 
 package com.tencent.rss.common;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Random;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class ShufflePartitionedBlockTest {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void shufflePartitionedBlockTest() {

--- a/common/src/test/java/com/tencent/rss/common/config/ConfigOptionTest.java
+++ b/common/src/test/java/com/tencent/rss/common/config/ConfigOptionTest.java
@@ -18,9 +18,13 @@
 
 package com.tencent.rss.common.config;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ConfigOptionTest {
 

--- a/common/src/test/java/com/tencent/rss/common/config/RssConfTest.java
+++ b/common/src/test/java/com/tencent/rss/common/config/RssConfTest.java
@@ -18,11 +18,11 @@
 
 package com.tencent.rss.common.config;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RssConfTest {
 

--- a/common/src/test/java/com/tencent/rss/common/metrics/MetricsManagerTest.java
+++ b/common/src/test/java/com/tencent/rss/common/metrics/MetricsManagerTest.java
@@ -19,8 +19,8 @@
 package com.tencent.rss.common.metrics;
 
 import static io.prometheus.client.Collector.MetricFamilySamples;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MetricsManagerTest {
 

--- a/common/src/test/java/com/tencent/rss/common/util/ChecksumUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/ChecksumUtilsTest.java
@@ -18,7 +18,7 @@
 
 package com.tencent.rss.common.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -29,7 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Random;
 import java.util.zip.CRC32;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ChecksumUtilsTest {
 

--- a/common/src/test/java/com/tencent/rss/common/util/ExitUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/ExitUtilsTest.java
@@ -18,12 +18,12 @@
 
 package com.tencent.rss.common.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.tencent.rss.common.util.ExitUtils.ExitException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExitUtilsTest {
 

--- a/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
@@ -27,17 +27,17 @@ import java.util.Objects;
 import java.util.Random;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataSegment;
 import com.tencent.rss.common.ShuffleIndexResult;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RssUtilsTest {
 

--- a/common/src/test/java/com/tencent/rss/common/util/UnitConverterTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/UnitConverterTest.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.common.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class UnitConverterTest {
 

--- a/common/src/test/java/com/tencent/rss/common/web/JettyServerTest.java
+++ b/common/src/test/java/com/tencent/rss/common/web/JettyServerTest.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.common.web;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.util.ExitUtils;
@@ -31,7 +31,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.thread.ExecutorThreadPool;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JettyServerTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessCandidatesCheckerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessCandidatesCheckerTest.java
@@ -26,40 +26,37 @@ import java.util.Objects;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccessCandidatesCheckerTest {
-  @ClassRule
-  public static final TemporaryFolder tmpDir = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }
 
   @Test
-  public void test() throws Exception {
-    File cfgFile = tmpDir.newFile();
+  public void test(@TempDir File tempDir) throws Exception {
+    File cfgFile = File.createTempFile("tmp", ".conf", tempDir);
     String cfgFileName = cfgFile.getAbsolutePath();
     final String filePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("coordinator.conf")).getFile();
     CoordinatorConf conf = new CoordinatorConf(filePath);
-    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, tmpDir.getRoot().toURI().toString());
+    conf.set(CoordinatorConf.COORDINATOR_ACCESS_CANDIDATES_PATH, tempDir.toURI().toString());
     conf.setString(CoordinatorConf.COORDINATOR_ACCESS_CHECKERS,
         "com.tencent.rss.coordinator.AccessCandidatesChecker");
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessClusterLoadCheckerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessClusterLoadCheckerTest.java
@@ -23,25 +23,25 @@ import java.util.Objects;
 
 import com.google.common.collect.Lists;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AccessClusterLoadCheckerTest {
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/AccessManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/AccessManagerTest.java
@@ -22,23 +22,23 @@ import java.util.Random;
 
 import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.util.Constants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccessManagerTest {
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ApplicationManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ApplicationManagerTest.java
@@ -21,16 +21,16 @@ package com.tencent.rss.coordinator;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.util.Constants;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ApplicationManagerTest {
 
@@ -40,17 +40,17 @@ public class ApplicationManagerTest {
   private String remotePath2 = "hdfs://path2";
   private String remotePath3 = "hdfs://path3";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     CoordinatorMetrics.register();
   }
 
-  @AfterClass
+  @AfterAll
   public static void clear() {
     CoordinatorMetrics.clear();
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorConf conf = new CoordinatorConf();
     conf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, appExpiredTime);

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/BasicAssignmentStrategyTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/BasicAssignmentStrategyTest.java
@@ -18,10 +18,10 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.common.collect.Sets;
 import com.tencent.rss.common.PartitionRange;
 import java.util.Iterator;
@@ -29,9 +29,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BasicAssignmentStrategyTest {
 
@@ -40,7 +40,7 @@ public class BasicAssignmentStrategyTest {
   private BasicAssignmentStrategy strategy;
   private int shuffleNodesMax = 7;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorConf ssc = new CoordinatorConf();
     ssc.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, shuffleNodesMax);
@@ -48,7 +48,7 @@ public class BasicAssignmentStrategyTest {
     strategy = new BasicAssignmentStrategy(clusterManager);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     clusterManager.clear();
   }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ClientConfManagerTest.java
@@ -29,41 +29,38 @@ import java.util.Set;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.util.Constants;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientConfManagerTest {
-  @ClassRule
-  public static final TemporaryFolder tmpDir = new TemporaryFolder();
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }
 
   @Test
-  public void test() throws Exception {
-    File cfgFile = tmpDir.newFile();
+  public void test(@TempDir File tempDir) throws Exception {
+    File cfgFile = File.createTempFile("tmp", ".conf", tempDir);
     String cfgFileName = cfgFile.getAbsolutePath();
     final String filePath = Objects.requireNonNull(
         getClass().getClassLoader().getResource("coordinator.conf")).getFile();
     CoordinatorConf conf = new CoordinatorConf(filePath);
-    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, tmpDir.getRoot().toURI().toString());
+    conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_PATH, tempDir.toURI().toString());
     conf.set(CoordinatorConf.COORDINATOR_DYNAMIC_CLIENT_CONF_ENABLED, true);
     ApplicationManager applicationManager = new ApplicationManager(conf);
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorConfTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorConfTest.java
@@ -18,10 +18,10 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Objects;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoordinatorConfTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorMetricsTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorMetricsTest.java
@@ -25,15 +25,15 @@ import java.nio.file.Files;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.config.RssBaseConf;
 import com.tencent.rss.common.metrics.TestUtils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoordinatorMetricsTest {
 
@@ -42,7 +42,7 @@ public class CoordinatorMetricsTest {
   private static final String SERVER_GRPC_URL = "http://127.0.0.1:12345/metrics/grpc";
   private static CoordinatorServer coordinatorServer;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     String remotePath1 = "hdfs://path1";
     File cfgFile = Files.createTempFile("coordinatorMetricsTest", ".conf").toFile();
@@ -60,7 +60,7 @@ public class CoordinatorMetricsTest {
     coordinatorServer.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     coordinatorServer.stopServer();
   }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorServerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorServerTest.java
@@ -18,12 +18,12 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.tencent.rss.common.util.ExitUtils;
 import com.tencent.rss.common.util.ExitUtils.ExitException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CoordinatorServerTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorUtilsTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/CoordinatorUtilsTest.java
@@ -19,11 +19,11 @@
 package com.tencent.rss.coordinator;
 
 import com.tencent.rss.common.PartitionRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CoordinatorUtilsTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionBalanceAssignmentStrategyTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionBalanceAssignmentStrategyTest.java
@@ -26,13 +26,13 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PartitionBalanceAssignmentStrategyTest {
 
@@ -41,7 +41,7 @@ public class PartitionBalanceAssignmentStrategyTest {
   private int shuffleNodesMax = 5;
   private Set<String> tags = Sets.newHashSet("test");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorConf ssc = new CoordinatorConf();
     ssc.setInteger(CoordinatorConf.COORDINATOR_SHUFFLE_NODES_MAX, shuffleNodesMax);
@@ -168,7 +168,7 @@ public class PartitionBalanceAssignmentStrategyTest {
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     clusterManager.clear();
   }

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionRangeAssignmentTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionRangeAssignmentTest.java
@@ -18,8 +18,8 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
 import com.tencent.rss.common.PartitionRange;
@@ -28,7 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PartitionRangeAssignmentTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionRangeTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/PartitionRangeTest.java
@@ -18,11 +18,11 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.tencent.rss.common.PartitionRange;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PartitionRangeTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/ServerNodeTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/ServerNodeTest.java
@@ -18,14 +18,14 @@
 
 package com.tencent.rss.coordinator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServerNodeTest {
 

--- a/coordinator/src/test/java/com/tencent/rss/coordinator/SimpleClusterManagerTest.java
+++ b/coordinator/src/test/java/com/tencent/rss/coordinator/SimpleClusterManagerTest.java
@@ -26,23 +26,23 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SimpleClusterManagerTest {
 
   private Set<String> testTags = Sets.newHashSet("test");
 
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessCandidatesCheckerHdfsTest.java
@@ -25,9 +25,9 @@ import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.AccessCandidatesChecker;
 import com.tencent.rss.coordinator.AccessInfo;
@@ -37,18 +37,18 @@ import com.tencent.rss.coordinator.CoordinatorMetrics;
 import com.tencent.rss.storage.HdfsTestBase;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccessCandidatesCheckerHdfsTest extends HdfsTestBase {
-  @Before
+  @BeforeEach
   public void setUp() {
     CoordinatorMetrics.register();
   }
 
-  @After
+  @AfterEach
   public void clear() {
     CoordinatorMetrics.clear();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/AccessClusterTest.java
@@ -24,9 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.factory.CoordinatorClientFactory;
@@ -37,17 +35,16 @@ import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServer;
 import com.tencent.rss.server.ShuffleServerConf;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccessClusterTest extends CoordinatorTestBase {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
-  public void test() throws Exception {
-    File cfgFile = tmpFolder.newFile();
+  public void test(@TempDir File tempDir) throws Exception {
+    File cfgFile = File.createTempFile("tmp", ".conf", tempDir);
     FileWriter fileWriter = new FileWriter(cfgFile);
     PrintWriter printWriter = new PrintWriter(fileWriter);
     printWriter.println("9527");

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ClientConfManagerHdfsTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.ApplicationManager;
 import com.tencent.rss.coordinator.ClientConfManager;
@@ -33,10 +33,10 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.storage.HdfsTestBase;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ClientConfManagerHdfsTest extends HdfsTestBase {
 

--- a/integration-test/common/src/test/java/com/tencent/rss/test/CoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/CoordinatorGrpcTest.java
@@ -40,22 +40,22 @@ import com.tencent.rss.proto.RssProtos.PartitionRangeAssignment;
 import com.tencent.rss.proto.RssProtos.ShuffleServerId;
 import com.tencent.rss.server.ShuffleServer;
 import com.tencent.rss.server.ShuffleServerConf;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class CoordinatorGrpcTest extends CoordinatorTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.set(RssBaseConf.RPC_METRICS_ENABLED, true);

--- a/integration-test/common/src/test/java/com/tencent/rss/test/CoordinatorTestBase.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/CoordinatorTestBase.java
@@ -19,20 +19,20 @@ package com.tencent.rss.test;
 
 import com.tencent.rss.client.factory.CoordinatorClientFactory;
 import com.tencent.rss.client.impl.grpc.CoordinatorGrpcClient;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public class CoordinatorTestBase extends IntegrationTestBase {
 
   protected CoordinatorClientFactory factory = new CoordinatorClientFactory("GRPC");
   protected CoordinatorGrpcClient coordinatorClient;
-  @Before
+  @BeforeEach
   public void createClient() {
     coordinatorClient =
         (CoordinatorGrpcClient) factory.createCoordinatorClient(LOCALHOST, COORDINATOR_PORT_1);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     if (coordinatorClient != null) {
       coordinatorClient.close();

--- a/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
@@ -30,10 +30,10 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
@@ -49,8 +49,8 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
   private ShuffleServerGrpcClient shuffleServerClient;
@@ -61,7 +61,7 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
   private List<ShuffleServerInfo> shuffleServerInfo =
       Lists.newArrayList(new ShuffleServerInfo("127.0.0.1-20001", LOCALHOST, SHUFFLE_SERVER_PORT));
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     serverTmpDir.deleteOnExit();
     CoordinatorConf coordinatorConf = getCoordinatorConf();
@@ -75,12 +75,12 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/FetchClientConfTest.java
@@ -27,9 +27,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.request.RssFetchClientConfRequest;
 import com.tencent.rss.client.request.RssFetchRemoteStorageRequest;
@@ -38,18 +36,16 @@ import com.tencent.rss.client.response.RssFetchClientConfResponse;
 import com.tencent.rss.client.response.RssFetchRemoteStorageResponse;
 import com.tencent.rss.coordinator.ApplicationManager;
 import com.tencent.rss.coordinator.CoordinatorConf;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class FetchClientConfTest extends CoordinatorTestBase {
 
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
-
   @Test
-  public void test() throws Exception {
-    File clientConfFile = tmpFolder.newFile();
+  public void test(@TempDir File tempDir) throws Exception {
+    File clientConfFile = File.createTempFile("tmp", ".conf", tempDir);
     FileWriter fileWriter = new FileWriter(clientConfFile);
     PrintWriter printWriter = new PrintWriter(fileWriter);
     printWriter.println("spark.mock.1  1234");
@@ -97,10 +93,10 @@ public class FetchClientConfTest extends CoordinatorTestBase {
   }
 
   @Test
-  public void testFetchRemoteStorage() throws Exception {
+  public void testFetchRemoteStorage(@TempDir File tempDir) throws Exception {
     String remotePath1 = "hdfs://path1";
     String remotePath2 = "hdfs://path2";
-    File cfgFile = tmpFolder.newFile();
+    File cfgFile = File.createTempFile("tmp", ".conf", tempDir);
     Map<String, String> dynamicConf = Maps.newHashMap();
     dynamicConf.put(CoordinatorConf.COORDINATOR_REMOTE_STORAGE_PATH.key(), remotePath1);
     writeRemoteStorageConf(cfgFile, dynamicConf);

--- a/integration-test/common/src/test/java/com/tencent/rss/test/HealthCheckCoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/HealthCheckCoordinatorGrpcTest.java
@@ -28,8 +28,8 @@ import com.tencent.rss.coordinator.ServerNode;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.io.Files;
 import java.io.File;
@@ -38,10 +38,10 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HealthCheckCoordinatorGrpcTest extends CoordinatorTestBase  {
 
@@ -49,7 +49,7 @@ public class HealthCheckCoordinatorGrpcTest extends CoordinatorTestBase  {
   private static File tempDataFile = new File(serverTmpDir, "data");
   private static int writeDataSize;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     serverTmpDir.deleteOnExit();
     long totalSize = serverTmpDir.getTotalSpace();

--- a/integration-test/common/src/test/java/com/tencent/rss/test/IntegrationTestBase.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/IntegrationTestBase.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
+import org.junit.jupiter.api.AfterAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.coordinator.CoordinatorMetrics;
@@ -59,7 +59,7 @@ abstract public class IntegrationTestBase extends HdfsTestBase {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownServers() throws Exception {
     for (CoordinatorServer coordinator : coordinators) {
       coordinator.stopServer();

--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
@@ -27,10 +27,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
@@ -49,15 +49,15 @@ import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultiStorageFaultToleranceTest extends ShuffleReadWriteBase {
   private ShuffleServerGrpcClient shuffleServerClient;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/multi_storage_fault";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     ShuffleServerConf shuffleServerConf = getShuffleServerConf();
@@ -78,12 +78,12 @@ public class MultiStorageFaultToleranceTest extends ShuffleReadWriteBase {
     createAndStartServers(shuffleServerConf, coordinatorConf);
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
@@ -30,10 +30,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
@@ -65,17 +65,17 @@ import com.tencent.rss.storage.handler.impl.UploadedHdfsClientReadHandler;
 import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultiStorageTest extends ShuffleReadWriteBase {
   private ShuffleServerGrpcClient shuffleServerClient;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/multi_storage";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();
@@ -101,12 +101,12 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
     createAndStartServers(shuffleServerConf, coordinatorConf);
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/PartitionBalanceCoordinatorGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/PartitionBalanceCoordinatorGrpcTest.java
@@ -25,17 +25,17 @@ import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PartitionBalanceCoordinatorGrpcTest extends CoordinatorTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setLong("rss.coordinator.app.expired", 2000);

--- a/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
@@ -26,10 +26,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.factory.ShuffleServerClientFactory;
@@ -51,9 +51,9 @@ import com.tencent.rss.server.ShuffleServer;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class QuorumTest extends ShuffleReadWriteBase {
 
@@ -86,7 +86,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     return new MockedShuffleServer(shuffleServerConf);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void initCluster() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -145,7 +145,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     coordinators = Lists.newArrayList();
   }
 
-  @Before
+  @BeforeEach
   public void InitEnv() throws Exception {
     // spark.rss.data.replica=3
     // spark.rss.data.replica.write=2
@@ -158,7 +158,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
       .getInstance().getShuffleServerClient("GRPC", shuffleServerInfo2)).adjustTimeout(100);
   }
 
-  @After
+  @AfterEach
   public void cleanEnv() throws Exception {
     if (shuffleWriteClientImpl != null) {
       shuffleWriteClientImpl.close();

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerGrpcTest.java
@@ -28,9 +28,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.api.ShuffleWriteClient;
@@ -61,10 +61,10 @@ import com.tencent.rss.server.ShuffleServerGrpcMetrics;
 import com.tencent.rss.server.ShuffleServerMetrics;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerGrpcTest extends IntegrationTestBase {
 
@@ -72,7 +72,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
   private AtomicInteger atomicInteger = new AtomicInteger(0);
   private static Long EVENT_THRESHOLD_SIZE = 2048L;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setLong(CoordinatorConf.COORDINATOR_APP_EXPIRED, 2000);
@@ -91,7 +91,7 @@ public class ShuffleServerGrpcTest extends IntegrationTestBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithHdfsTest.java
@@ -25,10 +25,10 @@ import java.util.Map.Entry;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
@@ -44,15 +44,15 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleServerWithHdfsTest extends ShuffleReadWriteBase {
 
   private ShuffleServerGrpcClient shuffleServerClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -62,12 +62,12 @@ public class ShuffleServerWithHdfsTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithLocalTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithLocalTest.java
@@ -28,10 +28,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -49,16 +49,16 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
 
   private ShuffleServerGrpcClient shuffleServerClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -74,12 +74,12 @@ public class ShuffleServerWithLocalTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemLocalHdfsTest.java
@@ -25,10 +25,10 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.grpc.ShuffleServerGrpcClient;
@@ -48,17 +48,17 @@ import com.tencent.rss.storage.handler.impl.LocalFileQuorumClientReadHandler;
 import com.tencent.rss.storage.handler.impl.MemoryQuorumClientReadHandler;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
 
   private ShuffleServerGrpcClient shuffleServerClient;
   private static String REMOTE_STORAGE = HDFS_URI + "rss/test";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -78,12 +78,12 @@ public class ShuffleServerWithMemLocalHdfsTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemoryTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithMemoryTest.java
@@ -25,10 +25,10 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.grpc.ShuffleServerGrpcClient;
@@ -47,16 +47,16 @@ import com.tencent.rss.storage.handler.impl.LocalFileQuorumClientReadHandler;
 import com.tencent.rss.storage.handler.impl.MemoryQuorumClientReadHandler;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
 
   private ShuffleServerGrpcClient shuffleServerClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -74,12 +74,12 @@ public class ShuffleServerWithMemoryTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
@@ -26,10 +26,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
@@ -44,10 +44,10 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
 
@@ -56,7 +56,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
   private static ShuffleServerInfo shuffleServerInfo2;
   private ShuffleWriteClientImpl shuffleWriteClientImpl;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -84,13 +84,13 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
         new ShuffleServerInfo("127.0.0.1-20001", shuffleServers.get(1).getIp(), SHUFFLE_SERVER_PORT + 1);
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleWriteClientImpl = new ShuffleWriteClientImpl(ClientType.GRPC.name(), 3, 1000, 1,
       1, 1, 1, true);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleWriteClientImpl.close();
   }

--- a/integration-test/mr/pom.xml
+++ b/integration-test/mr/pom.xml
@@ -109,12 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/LargeSorterTest.java
@@ -25,8 +25,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.LargeSorter;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.util.Tool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -34,7 +34,7 @@ import com.tencent.rss.storage.util.StorageType;
 
 public class LargeSorterTest extends MRIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/MRIntegrationTestBase.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/MRIntegrationTestBase.java
@@ -42,11 +42,11 @@ import org.apache.hadoop.mapreduce.v2.TestMRJobs;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class MRIntegrationTestBase extends IntegrationTestBase {
 
@@ -68,7 +68,7 @@ public class MRIntegrationTestBase extends IntegrationTestBase {
   private static final Path TEST_RESOURCES_DIR = new Path(TEST_ROOT_DIR,
       "localizedResources");
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpMRYarn() throws IOException {
     mrYarnCluster = new MiniMRYarnCluster("test");
     conf.set(MRJobConfig.MR_AM_STAGING_DIR, "/apps_staging_dir");
@@ -79,7 +79,7 @@ public class MRIntegrationTestBase extends IntegrationTestBase {
     localFs.setPermission(APP_JAR, new FsPermission("700"));
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException {
     if (mrYarnCluster != null) {
       mrYarnCluster.stop();
@@ -168,8 +168,7 @@ public class MRIntegrationTestBase extends IntegrationTestBase {
   }
 
   private void runMRApp(Configuration conf, Tool tool, String[] args) throws Exception {
-    assertEquals(tool.getClass().getName() + " failed", 0,
-        ToolRunner.run(conf, tool, args));
+    assertEquals(0, ToolRunner.run(conf, tool, args), tool.getClass().getName() + " failed");
   }
 
   protected Tool getTestTool() {

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/SecondarySortTest.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/SecondarySortTest.java
@@ -35,8 +35,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.util.Tool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -46,7 +46,7 @@ public class SecondarySortTest extends MRIntegrationTestBase {
 
   String inputPath = "secondary_sort_input";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/WordCountTest.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/WordCountTest.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.mapred.WordCount;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.util.Tool;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -48,7 +48,7 @@ public class WordCountTest extends MRIntegrationTestBase {
       "banana", "fruit", "cherry", "Chinese", "America", "Japan",
       "tomato");
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/AutoAccessTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/AutoAccessTest.java
@@ -31,23 +31,19 @@ import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.RssShuffleManager;
 import org.apache.spark.shuffle.ShuffleManager;
 import org.apache.spark.shuffle.sort.SortShuffleManager;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AutoAccessTest extends IntegrationTestBase {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
   public void test() throws Exception {

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/CombineByKeyTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/CombineByKeyTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.Tuple2;
 
 public class CombineByKeyTest extends SimpleTestBase {

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/DynamicFetchClientConfTest.java
@@ -28,20 +28,16 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.shuffle.RssShuffleManager;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DynamicFetchClientConfTest extends IntegrationTestBase {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
   public void test() throws Exception {

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/GroupByKeyTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/GroupByKeyTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import scala.Tuple2;
 
 public class GroupByKeyTest extends SimpleTestBase {

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionTest.java
@@ -30,7 +30,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Tuple2;

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithHdfsMultiStorageRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithHdfsMultiStorageRssTest.java
@@ -25,14 +25,14 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithHdfsMultiStorageRssTest extends RepartitionTest {
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithLocalFileRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithLocalFileRssTest.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -33,7 +33,7 @@ import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithLocalFileRssTest extends RepartitionTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithMemoryMultiStorageRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithMemoryMultiStorageRssTest.java
@@ -25,14 +25,14 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithMemoryMultiStorageRssTest extends RepartitionTest {
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithMemoryRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithMemoryRssTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -34,7 +34,7 @@ import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithMemoryRssTest extends RepartitionTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.set(CoordinatorConf.COORDINATOR_APP_EXPIRED, 5000L);

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithUploadMultiStorageRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/RepartitionWithUploadMultiStorageRssTest.java
@@ -25,14 +25,14 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
 public class RepartitionWithUploadMultiStorageRssTest extends RepartitionTest {
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SimpleTestBase.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SimpleTestBase.java
@@ -23,14 +23,14 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
 public abstract class SimpleTestBase extends SparkIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkClientWithLocalTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkClientWithLocalTest.java
@@ -26,10 +26,10 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -48,9 +48,9 @@ import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
@@ -61,7 +61,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
   private List<ShuffleServerInfo> shuffleServerInfo =
       Lists.newArrayList(new ShuffleServerInfo("127.0.0.1-20001", LOCALHOST, SHUFFLE_SERVER_PORT));
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     createCoordinatorServer(coordinatorConf);
@@ -76,12 +76,12 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     startServers();
   }
 
-  @Before
+  @BeforeEach
   public void createClient() {
     shuffleServerClient = new ShuffleServerGrpcClient(LOCALHOST, SHUFFLE_SERVER_PORT);
   }
 
-  @After
+  @AfterEach
   public void closeClient() {
     shuffleServerClient.close();
   }

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkFallbackReadTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkFallbackReadTest.java
@@ -32,22 +32,22 @@ import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.shuffle.RssSparkConfig;
 import org.apache.spark.sql.SparkSession;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import scala.Tuple2;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SparkFallbackReadTest extends SparkIntegrationTestBase {
 
   private static File tmpDir;
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     tmpDir = Files.createTempDir();
     File dataDir1 = new File(tmpDir, "data1");

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkIntegrationTestBase.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkIntegrationTestBase.java
@@ -28,7 +28,7 @@ import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class SparkIntegrationTestBase extends IntegrationTestBase {
 

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLMultiStorageRssTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLMultiStorageRssTest.java
@@ -25,18 +25,18 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SparkSQLMultiStorageRssTest extends SparkSQLTest {
   private static String basePath;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setLong("rss.coordinator.app.expired", 5000);

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLTest.java
@@ -31,7 +31,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManager.java
@@ -28,7 +28,7 @@ import com.google.common.io.Files;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -36,7 +36,7 @@ import com.tencent.rss.storage.util.StorageType;
 
 public class SparkSQLWithDelegationShuffleManager extends SparkSQLTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     final String candidates = Objects.requireNonNull(
         SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithDelegationShuffleManagerFallback.java
@@ -28,7 +28,7 @@ import com.google.common.io.Files;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
@@ -36,7 +36,7 @@ import com.tencent.rss.storage.util.StorageType;
 
 public class SparkSQLWithDelegationShuffleManagerFallback extends SparkSQLTest {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     final String candidates = Objects.requireNonNull(
         SparkSQLWithDelegationShuffleManager.class.getClassLoader().getResource("candidates")).getFile();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithMemoryLocalTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkSQLWithMemoryLocalTest.java
@@ -25,19 +25,19 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import org.apache.spark.SparkConf;
 import org.apache.spark.shuffle.RssSparkConfig;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.coordinator.CoordinatorConf;
 import com.tencent.rss.server.ShuffleServerConf;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SparkSQLWithMemoryLocalTest extends SparkSQLTest {
 
   private static String basePath;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     coordinatorConf.setLong("rss.coordinator.app.expired", 5000);

--- a/integration-test/spark3/src/test/java/com/tencent/rss/test/AQERepartitionTest.java
+++ b/integration-test/spark3/src/test/java/com/tencent/rss/test/AQERepartitionTest.java
@@ -35,15 +35,15 @@ import org.apache.spark.sql.Column;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.Dataset;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import scala.collection.JavaConverters;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AQERepartitionTest extends SparkIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/integration-test/spark3/src/test/java/com/tencent/rss/test/AQESkewedJoinTest.java
+++ b/integration-test/spark3/src/test/java/com/tencent/rss/test/AQESkewedJoinTest.java
@@ -34,18 +34,18 @@ import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanExec;
 import org.apache.spark.sql.execution.joins.SortMergeJoinExec;
 import org.apache.spark.sql.functions;
 import org.apache.spark.sql.internal.SQLConf;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AQESkewedJoinTest extends SparkIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupServers() throws Exception {
     CoordinatorConf coordinatorConf = getCoordinatorConf();
     Map<String, String> dynamicConf = Maps.newHashMap();

--- a/internal-client/pom.xml
+++ b/internal-client/pom.xml
@@ -41,9 +41,5 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <junit.version>4.13.1</junit.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>
+    <system.stubs.version>2.0.1</system.stubs.version>
     <log4j.core.version>2.17.1</log4j.core.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -129,6 +130,11 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -477,6 +483,12 @@
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-launcher</artifactId>
         <version>${junit.platform.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>uk.org.webcompere</groupId>
+        <artifactId>system-stubs-jupiter</artifactId>
+        <version>${system.stubs.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <metrics.version>3.1.0</metrics.version>
-    <mockito.inline.version>3.5.15</mockito.inline.version>
+    <mockito.version>3.12.4</mockito.version>
     <netty.version>4.1.68.Final</netty.version>
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -483,7 +483,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>${mockito.inline.version}</version>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
 
@@ -552,7 +552,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.5.15</version>
+        <version>${mockito.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <httpcore.version>4.4.4</httpcore.version>
     <java.version>1.8</java.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
-    <junit.version>4.13.1</junit.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <junit.platform.version>1.8.2</junit.platform.version>
     <system.stubs.version>2.0.1</system.stubs.version>
@@ -117,11 +116,6 @@
       <artifactId>error_prone_annotations</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
@@ -467,12 +461,6 @@
         <version>${prometheus.simpleclient.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
     <java.version>1.8</java.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <junit.version>4.13.1</junit.version>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
+    <junit.platform.version>1.8.2</junit.platform.version>
     <log4j.core.version>2.17.1</log4j.core.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -117,6 +119,16 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -453,6 +465,18 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-launcher</artifactId>
+        <version>${junit.platform.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/server/src/test/java/com/tencent/rss/server/HealthCheckTest.java
+++ b/server/src/test/java/com/tencent/rss/server/HealthCheckTest.java
@@ -18,14 +18,14 @@
 package com.tencent.rss.server;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HealthCheckTest {
 

--- a/server/src/test/java/com/tencent/rss/server/ShuffleServerConfTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleServerConfTest.java
@@ -19,24 +19,24 @@
 package com.tencent.rss.server;
 
 import com.tencent.rss.common.util.ByteUnit;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(SystemStubsExtension.class)
 public class ShuffleServerConfTest {
 
   private static final String confFile = ClassLoader.getSystemResource("confTest.conf").getFile();
-  @Rule
-  public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+  @SystemStub
+  private static EnvironmentVariables environmentVariables;
 
   @Test
   public void defaultConfTest() {

--- a/server/src/test/java/com/tencent/rss/server/ShuffleServerMetricsTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleServerMetricsTest.java
@@ -28,16 +28,16 @@ import java.util.concurrent.Future;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.metrics.TestUtils;
 import com.tencent.rss.storage.common.LocalStorage;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleServerMetricsTest {
 
@@ -48,7 +48,7 @@ public class ShuffleServerMetricsTest {
   private static final String STORAGE_HOST = "hdfs1";
   private static ShuffleServer shuffleServer;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     ShuffleServerConf ssc = new ShuffleServerConf();
     ssc.set(ShuffleServerConf.JETTY_HTTP_PORT, 12345);
@@ -64,7 +64,7 @@ public class ShuffleServerMetricsTest {
     shuffleServer.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     shuffleServer.stopServer();
     ShuffleServerMetrics.clear();

--- a/server/src/test/java/com/tencent/rss/server/ShuffleServerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleServerTest.java
@@ -21,10 +21,10 @@ package com.tencent.rss.server;
 import com.tencent.rss.common.util.ExitUtils;
 import com.tencent.rss.common.util.ExitUtils.ExitException;
 import com.tencent.rss.storage.util.StorageType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleServerTest {
 

--- a/server/src/test/java/com/tencent/rss/server/ShuffleTaskManagerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/ShuffleTaskManagerTest.java
@@ -28,8 +28,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.Sets;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.common.BufferSegment;
@@ -47,16 +47,16 @@ import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.handler.impl.HdfsClientReadHandler;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleTaskManagerTest extends HdfsTestBase {
 
   private static AtomicInteger ATOMIC_INT = new AtomicInteger(0);
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     ShuffleServerMetrics.clear();
   }

--- a/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/StorageCheckerTest.java
@@ -20,14 +20,13 @@ package com.tencent.rss.server;
 import com.google.common.collect.Lists;
 import com.tencent.rss.storage.common.LocalStorage;
 import com.tencent.rss.storage.util.StorageType;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StorageCheckerTest {
 

--- a/server/src/test/java/com/tencent/rss/server/buffer/BufferTestBase.java
+++ b/server/src/test/java/com/tencent/rss/server/buffer/BufferTestBase.java
@@ -21,8 +21,8 @@ package com.tencent.rss.server.buffer;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.ShufflePartitionedData;
@@ -31,12 +31,12 @@ import com.tencent.rss.server.ShuffleServerMetrics;
 
 public abstract class BufferTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     ShuffleServerMetrics.register();
   }
 
-  @AfterClass
+  @AfterAll
   public static void clear() {
     ShuffleServerMetrics.clear();
   }

--- a/server/src/test/java/com/tencent/rss/server/buffer/ShuffleBufferManagerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/buffer/ShuffleBufferManagerTest.java
@@ -31,18 +31,18 @@ import com.tencent.rss.server.StatusCode;
 import com.tencent.rss.server.storage.StorageManager;
 import com.tencent.rss.server.storage.StorageManagerFactory;
 import com.tencent.rss.storage.util.StorageType;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -54,7 +54,7 @@ public class ShuffleBufferManagerTest extends BufferTestBase {
   private ShuffleFlushManager mockShuffleFlushManager;
   private ShuffleServerConf conf;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new ShuffleServerConf();
     File tmpDir = Files.createTempDir();

--- a/server/src/test/java/com/tencent/rss/server/buffer/ShuffleBufferTest.java
+++ b/server/src/test/java/com/tencent/rss/server/buffer/ShuffleBufferTest.java
@@ -25,16 +25,16 @@ import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.ShufflePartitionedData;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ShuffleBufferTest extends BufferTestBase {
 

--- a/server/src/test/java/com/tencent/rss/server/storage/MultiStorageManagerTest.java
+++ b/server/src/test/java/com/tencent/rss/server/storage/MultiStorageManagerTest.java
@@ -21,7 +21,7 @@ package com.tencent.rss.server.storage;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.server.ShuffleDataFlushEvent;
@@ -30,7 +30,7 @@ import com.tencent.rss.storage.common.HdfsStorage;
 import com.tencent.rss.storage.common.LocalStorage;
 import com.tencent.rss.storage.util.StorageType;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MultiStorageManagerTest {
 

--- a/storage/src/test/java/com/tencent/rss/storage/HdfsShuffleHandlerTestBase.java
+++ b/storage/src/test/java/com/tencent/rss/storage/HdfsShuffleHandlerTestBase.java
@@ -18,8 +18,8 @@
 
 package com.tencent.rss.storage;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Lists;
 import com.tencent.rss.common.BufferSegment;

--- a/storage/src/test/java/com/tencent/rss/storage/HdfsTestBase.java
+++ b/storage/src/test/java/com/tencent/rss/storage/HdfsTestBase.java
@@ -26,6 +26,8 @@ import com.tencent.rss.common.util.ChecksumUtils;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.handler.impl.HdfsFileReader;
 import com.tencent.rss.storage.handler.impl.HdfsShuffleWriteHandler;
+
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
@@ -38,38 +40,35 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.io.TempDir;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HdfsTestBase implements Serializable {
 
-  @ClassRule
-  public static final TemporaryFolder tmpDir = new TemporaryFolder();
   public static Configuration conf;
   protected static String HDFS_URI;
   protected static FileSystem fs;
   protected static MiniDFSCluster cluster;
+  protected static File baseDir;
 
-  @BeforeClass
-  public static void setUpHdfs() throws IOException {
+  @BeforeAll
+  public static void setUpHdfs(@TempDir File tempDir) throws IOException {
     conf = new Configuration();
+    baseDir = tempDir;
     conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR,
-        tmpDir.getRoot().getAbsolutePath());
+        baseDir.getAbsolutePath());
     cluster = (new MiniDFSCluster.Builder(conf)).build();
     HDFS_URI = "hdfs://localhost:" + cluster.getNameNodePort() + "/";
     fs = (new Path(HDFS_URI)).getFileSystem(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownHdfs() throws IOException {
     fs.close();
     cluster.shutdown();
-    tmpDir.delete();
   }
 
   protected void compareBytes(List<byte[]> expected, List<ByteBuffer> actual) {

--- a/storage/src/test/java/com/tencent/rss/storage/common/LocalStorageTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/common/LocalStorageTest.java
@@ -18,18 +18,16 @@
 
 package com.tencent.rss.storage.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.tencent.rss.common.util.RssUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.roaringbitmap.RoaringBitmap;
 
 import java.io.File;
@@ -39,18 +37,17 @@ import java.util.List;
 
 public class LocalStorageTest {
 
-  @ClassRule
-  public static final TemporaryFolder tmpDir = new TemporaryFolder();
   private static File testBaseDir;
 
-  @BeforeClass
-  public static void setUp() throws IOException  {
-    testBaseDir = tmpDir.newFolder("test");
+  @BeforeAll
+  public static void setUp(@TempDir File tempDir) throws IOException  {
+    testBaseDir = new File(tempDir, "test");
+    testBaseDir.mkdir();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
-    tmpDir.delete();
+    testBaseDir.delete();
   }
 
   @Test

--- a/storage/src/test/java/com/tencent/rss/storage/common/ShuffleFileInfoTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/common/ShuffleFileInfoTest.java
@@ -19,11 +19,11 @@
 package com.tencent.rss.storage.common;
 
 import java.io.File;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleFileInfoTest {
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsClientReadHandlerTest.java
@@ -23,16 +23,16 @@ import com.google.common.collect.Sets;
 import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.storage.HdfsShuffleHandlerTestBase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class HdfsClientReadHandlerTest extends HdfsShuffleHandlerTestBase {
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsFileReaderTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsFileReaderTest.java
@@ -18,11 +18,6 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.tencent.rss.common.util.ChecksumUtils;
 import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
@@ -31,14 +26,14 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HdfsFileReaderTest extends HdfsTestBase {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void createStreamTest() throws IOException {
@@ -58,12 +53,8 @@ public class HdfsFileReaderTest extends HdfsTestBase {
     Path path = new Path(HDFS_URI, "createStreamFirstTest");
 
     assertFalse(fs.isFile(path));
-    try {
-      new HdfsFileReader(path, conf);
-      fail("Exception should be thrown");
-    } catch (IllegalStateException ise) {
-      ise.getMessage().startsWith(HDFS_URI + "createStreamFirstTest don't exist");
-    }
+    Throwable ise = assertThrows(IllegalStateException.class, () -> new HdfsFileReader(path, conf));
+    assertTrue(ise.getMessage().startsWith(HDFS_URI + "createStreamFirstTest don't exist"));
   }
 
   @Test

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsFileWriterTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsFileWriterTest.java
@@ -18,10 +18,6 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import java.io.EOFException;
@@ -31,14 +27,13 @@ import java.util.Random;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HdfsFileWriterTest extends HdfsTestBase {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void createStreamFirstTest() throws IOException {
@@ -71,12 +66,8 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     // disable the append support
     conf.setBoolean("dfs.support.append", false);
     assertTrue(fs.isFile(path));
-    try {
-      new HdfsFileWriter(path, conf);
-      fail("Exception should be thrown");
-    } catch (IllegalStateException ise) {
-      assertTrue(ise.getMessage().startsWith(path + " exists but append mode is not support!"));
-    }
+    Throwable ise = assertThrows(IllegalStateException.class, () -> new HdfsFileWriter(path, conf));
+    assertTrue(ise.getMessage().startsWith(path + " exists but append mode is not support!"));
   }
 
   @Test
@@ -85,12 +76,8 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     Path path = new Path(HDFS_URI, "createStreamDirectory");
     fs.mkdirs(path);
 
-    try {
-      new HdfsFileWriter(path, conf);
-      fail("Exception should be thrown");
-    } catch (IllegalStateException ise) {
-      assertTrue(ise.getMessage().startsWith(HDFS_URI + "createStreamDirectory is a directory!"));
-    }
+    Throwable ise = assertThrows(IllegalStateException.class, () -> new HdfsFileWriter(path, conf));
+    assertTrue(ise.getMessage().startsWith(HDFS_URI + "createStreamDirectory is a directory!"));
   }
 
   @Test
@@ -109,7 +96,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
     }
   }
 
-  @Test(expected = EOFException.class)
+  @Test
   public void writeBufferTest() throws IOException {
     byte[] data = new byte[32];
     new Random().nextBytes(data);
@@ -127,12 +114,12 @@ public class HdfsFileWriterTest extends HdfsTestBase {
         assertEquals(data[i], in.readByte());
       }
       // EOF exception is expected
-      in.readInt();
+      assertThrows(EOFException.class, in::readInt);
     }
 
   }
 
-  @Test(expected = EOFException.class)
+  @Test
   public void writeBufferArrayTest() throws IOException {
     int[] data = {1, 3, 5, 7, 9};
 
@@ -152,7 +139,7 @@ public class HdfsFileWriterTest extends HdfsTestBase {
         assertEquals(data[i], in.readInt());
       }
       // EOF exception is expected
-      in.readInt();
+      assertThrows(EOFException.class, in::readInt);
     }
   }
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsHandlerTest.java
@@ -18,7 +18,7 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -29,9 +29,7 @@ import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.io.IOException;
@@ -42,9 +40,6 @@ import java.util.Random;
 import java.util.Set;
 
 public class HdfsHandlerTest extends HdfsTestBase {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void initTest() throws IOException {

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsShuffleReadHandlerTest.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -31,7 +31,7 @@ import com.tencent.rss.storage.util.ShuffleStorageUtils;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 public class HdfsShuffleReadHandlerTest extends HdfsShuffleHandlerTestBase {

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsShuffleUploadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/HdfsShuffleUploadHandlerTest.java
@@ -18,10 +18,11 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Lists;
 import com.tencent.rss.common.util.ChecksumUtils;
@@ -39,14 +40,9 @@ import java.util.Random;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 
 public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void initTest() throws IOException, IllegalStateException {
@@ -62,8 +58,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
     HdfsShuffleUploadHandler handler = new HdfsShuffleUploadHandler(
         basePath, conf, "uploadTestCombine", 4096, true);
 
-    File dataFile1 = File.createTempFile("uploadTestCombine1", ".data", tmpDir.getRoot());
-    File dataFile2 = File.createTempFile("uploadTestCombine2", ".data", tmpDir.getRoot());
+    File dataFile1 = File.createTempFile("uploadTestCombine1", ".data", baseDir);
+    File dataFile2 = File.createTempFile("uploadTestCombine2", ".data", baseDir);
 
     byte[] data1 = new byte[10];
     new Random().nextBytes(data1);
@@ -77,8 +73,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       out.write(data2);
     }
 
-    File indexFile1 = File.createTempFile("uploadTestCombine1", ".index", tmpDir.getRoot());
-    File indexFile2 = File.createTempFile("uploadTestCombine2", ".index", tmpDir.getRoot());
+    File indexFile1 = File.createTempFile("uploadTestCombine1", ".index", baseDir);
+    File indexFile2 = File.createTempFile("uploadTestCombine2", ".index", baseDir);
 
     writeAndAssertResult(handler, dataFile1, dataFile2, indexFile1, indexFile2);
 
@@ -120,8 +116,7 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
         assertEquals(data2[i], dataStream.readByte());
       }
 
-      thrown.expect(EOFException.class);
-      dataStream.readByte();
+      assertThrows(EOFException.class, dataStream::readByte);
     }
   }
 
@@ -147,8 +142,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
     String basePath = HDFS_URI + "test_base";
     HdfsShuffleUploadHandler handler =
         new HdfsShuffleUploadHandler(basePath, conf, "uploadTestOneByOne", 4096, false);
-    File dataFile1 = File.createTempFile("uploadTestOneByOne1", ".data", tmpDir.getRoot());
-    File dataFile2 = File.createTempFile("uploadTestOneByOne2", ".data", tmpDir.getRoot());
+    File dataFile1 = File.createTempFile("uploadTestOneByOne1", ".data", baseDir);
+    File dataFile2 = File.createTempFile("uploadTestOneByOne2", ".data", baseDir);
 
     byte[] data1 = new byte[10];
     new Random().nextBytes(data1);
@@ -162,8 +157,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       out.write(data2);
     }
 
-    File indexFile1 = File.createTempFile("uploadTestOneByOne1", ".index", tmpDir.getRoot());
-    File indexFile2 = File.createTempFile("uploadTestOneByOne2", ".index", tmpDir.getRoot());
+    File indexFile1 = File.createTempFile("uploadTestOneByOne1", ".index", baseDir);
+    File indexFile2 = File.createTempFile("uploadTestOneByOne2", ".index", baseDir);
 
     writeAndAssertResult(handler, dataFile1, dataFile2, indexFile1, indexFile2);
 
@@ -215,8 +210,7 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
         assertEquals(data2[i], dataStream.readByte());
       }
 
-      thrown.expect(EOFException.class);
-      dataStream.readByte();
+      assertThrows(EOFException.class, dataStream::readByte);
     }
 
   }
@@ -226,8 +220,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
     String basePath = HDFS_URI + "test_base";
     HdfsShuffleUploadHandler handler =
         new HdfsShuffleUploadHandler(basePath, conf, "uploadTestCombineBestEffort", 4096, true);
-    File dataFile1 = File.createTempFile("uploadTestCombineBestEffort1", ".data", tmpDir.getRoot());
-    File dataFile2 = File.createTempFile("uploadTestCombineBestEffort2", ".data", tmpDir.getRoot());
+    File dataFile1 = File.createTempFile("uploadTestCombineBestEffort1", ".data", baseDir);
+    File dataFile2 = File.createTempFile("uploadTestCombineBestEffort2", ".data", baseDir);
     File dataFile3 = new File(dataFile1.getAbsolutePath() + "null");
 
     byte[] data1 = new byte[10];
@@ -242,7 +236,7 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       out.write(data2);
     }
 
-    File indexFile1 = File.createTempFile("uploadTestCombineBestEffort1", ".index", tmpDir.getRoot());
+    File indexFile1 = File.createTempFile("uploadTestCombineBestEffort1", ".index", baseDir);
     File indexFile2 = new File(indexFile1.getAbsolutePath() + "null");
     File indexFile3 = new File(indexFile1.getAbsolutePath() + "null");
 
@@ -285,8 +279,7 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       assertEquals(30L, indexStream.readLong());
 
       indexStream.seek(ShuffleStorageUtils.getIndexFileHeaderLen(2) + 5);
-      thrown.expect(EOFException.class);
-      indexStream.readByte();
+      assertThrows(EOFException.class, indexStream::readByte);
 
     }
   }
@@ -296,9 +289,9 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
     String basePath = HDFS_URI + "test_base";
     HdfsShuffleUploadHandler handler = new HdfsShuffleUploadHandler(
         basePath, conf, "uploadTestOneByOneBestEffort", 4096, false);
-    File dataFile1 = File.createTempFile("uploadTestOneByOneBestEffort1", ".data", tmpDir.getRoot());
+    File dataFile1 = File.createTempFile("uploadTestOneByOneBestEffort1", ".data", baseDir);
     File dataFile2 = new File(dataFile1.getAbsolutePath() + "null");
-    File dataFile3 = File.createTempFile("uploadTestOneByOneBestEffort3", ".data", tmpDir.getRoot());
+    File dataFile3 = File.createTempFile("uploadTestOneByOneBestEffort3", ".data", baseDir);
 
     byte[] data1 = new byte[10];
     new Random().nextBytes(data1);
@@ -312,7 +305,7 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       out.write(data2);
     }
 
-    File indexFile1 = File.createTempFile("uploadTestOneByOneBestEffort1", ".index", tmpDir.getRoot());
+    File indexFile1 = File.createTempFile("uploadTestOneByOneBestEffort1", ".index", baseDir);
     File indexFile2 = new File(indexFile1.getAbsolutePath() + "null");
     File indexFile3 = new File(indexFile1.getAbsolutePath() + "null");
 
@@ -359,8 +352,8 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       assertEquals(1, indexStream.readInt());
       assertEquals(5L, indexStream.readLong());
 
-      thrown.expect(EOFException.class);
-      indexStream.seek(ShuffleStorageUtils.getIndexFileHeaderLen(1) + 5 + 1);
+      assertThrows(EOFException.class, () ->
+          indexStream.seek(ShuffleStorageUtils.getIndexFileHeaderLen(1) + 5 + 1));
 
     }
 
@@ -407,9 +400,9 @@ public class HdfsShuffleUploadHandlerTest extends HdfsTestBase {
       HdfsShuffleUploadHandler handler = new HdfsShuffleUploadHandler(
           basePath, conf, "uploadTestOneByOneBestEffort", 4096, false);
 
-      File indexFile1 = File.createTempFile("writeHeaderTest1", ".index", tmpDir.getRoot());
-      File indexFile2 = File.createTempFile("writeHeaderTest2", ".index", tmpDir.getRoot());
-      File indexFile3 = File.createTempFile("writeHeaderTest3", ".index", tmpDir.getRoot());
+      File indexFile1 = File.createTempFile("writeHeaderTest1", ".index", baseDir);
+      File indexFile2 = File.createTempFile("writeHeaderTest2", ".index", baseDir);
+      File indexFile3 = File.createTempFile("writeHeaderTest3", ".index", baseDir);
 
       try (OutputStream out = new FileOutputStream(indexFile1)) {
         out.write(new byte[5]);

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/LocalFileHandlerTest.java
@@ -18,10 +18,10 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -45,7 +45,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LocalFileHandlerTest {
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsClientReadHandlerTest.java
@@ -25,7 +25,7 @@ import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.io.IOException;
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MultiStorageHdfsClientReadHandlerTest extends HdfsTestBase {
 

--- a/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandlerTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/handler/impl/MultiStorageHdfsShuffleReadHandlerTest.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.storage.handler.impl;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 public class MultiStorageHdfsShuffleReadHandlerTest extends HdfsShuffleHandlerTestBase {

--- a/storage/src/test/java/com/tencent/rss/storage/util/ShuffleHdfsStorageUtilsTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/util/ShuffleHdfsStorageUtilsTest.java
@@ -21,27 +21,25 @@ package com.tencent.rss.storage.util;
 import com.tencent.rss.storage.HdfsTestBase;
 import com.tencent.rss.storage.handler.impl.HdfsFileWriter;
 import org.apache.hadoop.fs.Path;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
 
   @Test
-  public void testUploadFile() {
+  public void testUploadFile(@TempDir File tempDir) {
     FileOutputStream fileOut = null;
     DataOutputStream dataOut = null;
     try {
-      TemporaryFolder tmpDir = new TemporaryFolder();
-      tmpDir.create();
-      File file = tmpDir.newFile("test");
+      File file = new File(tempDir, "test");
       fileOut = new FileOutputStream(file);
       dataOut = new DataOutputStream(fileOut);
       byte[] buf = new byte[2096];
@@ -56,7 +54,6 @@ public class ShuffleHdfsStorageUtilsTest extends HdfsTestBase {
       size = ShuffleStorageUtils.uploadFile(file, writer, 100);
       assertEquals(2096, size);
       writer.close();
-      tmpDir.delete();
     } catch (Exception e) {
       e.printStackTrace();
       fail();

--- a/storage/src/test/java/com/tencent/rss/storage/util/ShuffleStorageUtilsTest.java
+++ b/storage/src/test/java/com/tencent/rss/storage/util/ShuffleStorageUtilsTest.java
@@ -18,9 +18,9 @@
 
 package com.tencent.rss.storage.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -29,7 +29,7 @@ import com.tencent.rss.storage.common.FileBasedShuffleSegment;
 import com.tencent.rss.storage.handler.impl.DataFileSegment;
 import java.util.List;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShuffleStorageUtilsTest {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Migrated all tests to JUnit 5 (jupiter 5.8.2, platform 1.8.2).
2. Removed JUnit 4 dependency.
3. Introduced `uk.org.webcompere.system-stubs-jupiter` for testing `EnvironmentVariables`.
4. Upgraded mockito to 3.12.4.

### Why are the changes needed?

JUnit 5 brings multiple useful features so tests are easier to read and write.
And [many projects](https://issues.apache.org/jira/browse/CALCITE-2457?jql=text%20~%20%22junit%205%22) had begun the migration to JUnit 5.
It's easier and better to migrate and start writing test in JUnit 5 now.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

https://github.com/kaijchen/Firestorm/actions/runs/2368861389