### PR TITLE
[Bugfix] Fix taskAttemptId length error

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -38,19 +38,29 @@ import com.tencent.rss.common.exception.RssException;
 public class RssMRUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssMRUtils.class);
+  private static int MAX_TASK_LENGTH = 17;
+  private static int MAX_ATTEMPT_LENGTH = 3;
+  private static long MAX_TASK_ID = (1 << MAX_TASK_LENGTH) - 1;
+  private static long MAX_ATTEMPT_ID = ( 1 << MAX_ATTEMPT_LENGTH) - 1;
 
-  // Class TaskAttemptId have two field id and mapId, mapId is 4 low byte,
-  // id is high 4 byte.
+  // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 20 bits,
+  // mapId is 17 bits, id is 3 bits.
   public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID) {
     long lowBytes = taskAttemptID.getTaskID().getId();
-    long highBytes = (long)taskAttemptID.getId() << 32;
-    return highBytes + lowBytes;
+    if (lowBytes > MAX_TASK_ID) {
+      throw new RssException("TaskAttempt " + taskAttemptID + " low bytes " + lowBytes + " exceed");
+    }
+    long highBytes = (long)taskAttemptID.getId();
+    if (highBytes > MAX_ATTEMPT_ID) {
+      throw new RssException("TaskAttempt " + taskAttemptID + " high bytes " + highBytes + " exceed");
+    }
+    return (highBytes << MAX_TASK_LENGTH) + lowBytes;
   }
 
   public static TaskAttemptID createMRTaskAttemptId(JobID jobID, TaskType taskType,
                                                     long rssTaskAttemptId) {
-    TaskID taskID = new TaskID(jobID, taskType, (int)rssTaskAttemptId);
-    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> 32));
+    TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & MAX_TASK_ID));
+    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH));
   }
 
   public static ShuffleWriteClient createShuffleClient(JobConf jobConf) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -38,13 +38,13 @@ import com.tencent.rss.common.exception.RssException;
 public class RssMRUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssMRUtils.class);
-  private static int MAX_TASK_LENGTH = 17;
-  private static int MAX_ATTEMPT_LENGTH = 3;
+  private static int MAX_TASK_LENGTH = 19;
+  private static int MAX_ATTEMPT_LENGTH = 2;
   private static long MAX_TASK_ID = (1 << MAX_TASK_LENGTH) - 1;
-  private static long MAX_ATTEMPT_ID = ( 1 << MAX_ATTEMPT_LENGTH) - 1;
+  private static long MAX_ATTEMPT_ID = (1 << MAX_ATTEMPT_LENGTH) - 1;
 
-  // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 20 bits,
-  // mapId is 17 bits, id is 3 bits.
+  // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 21 bits,
+  // mapId is 19 bits, id is 2 bits.
   public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID) {
     long lowBytes = taskAttemptID.getTaskID().getId();
     if (lowBytes > MAX_TASK_ID) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -25,9 +25,11 @@ import org.apache.hadoop.mapred.JobConf;
 import org.junit.jupiter.api.Test;
 
 import com.tencent.rss.client.util.RssClientConfig;
+import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions..assertTrue;
 
 public class RssMRUtilsTest {
 
@@ -35,12 +37,26 @@ public class RssMRUtilsTest {
   public void TaskAttemptIdTest() {
     long taskAttemptId = 0x1000ad12;
     TaskAttemptID mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, taskAttemptId);
+    boolean isException = false;
+    try {
+      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
+    } catch (RssException e) {
+      isException = true;
+    }
+    assertTrue(isException);
+    taskAttemptId = (1 << 18) + 0x123;
+    mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId);
     long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
     assertEquals(taskAttemptId, testId);
-    taskAttemptId = 0xff1000ad12L;
-    mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId);
-    testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
-    assertEquals(taskAttemptId, testId);
+    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 17));
+    mrTaskAttemptId = new TaskAttemptID(taskID, 2);
+    isException = false;
+    try {
+      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
+    } catch (RssException e) {
+      isException = true;
+    }
+    assertTrue(isException);
   }
 
   @Test

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -29,7 +29,7 @@ import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.storage.util.StorageType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions..assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RssMRUtilsTest {
 
@@ -44,11 +44,11 @@ public class RssMRUtilsTest {
       isException = true;
     }
     assertTrue(isException);
-    taskAttemptId = (1 << 18) + 0x123;
+    taskAttemptId = (1 << 20) + 0x123;
     mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId);
     long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
     assertEquals(taskAttemptId, testId);
-    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 17));
+    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 19));
     mrTaskAttemptId = new TaskAttemptID(taskID, 2);
     isException = false;
     try {

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/writer/WriteBufferManagerTest.java
@@ -136,14 +136,14 @@ public class WriteBufferManagerTest {
 
     // seqNo = 1, partitionId = 0, taskId = 0
     sbi = wbm.createShuffleBlock(0, mockWriterBuffer);
-    assertEquals(17592186044416L, sbi.getBlockId());
+    assertEquals(35184372088832L, sbi.getBlockId());
 
     // seqNo = 0, partitionId = 1, taskId = 0
     sbi = wbm.createShuffleBlock(1, mockWriterBuffer);
-    assertEquals(1048576L, sbi.getBlockId());
+    assertEquals(2097152L, sbi.getBlockId());
 
     // seqNo = 1, partitionId = 1, taskId = 0
     sbi = wbm.createShuffleBlock(1, mockWriterBuffer);
-    assertEquals(17592187092992L, sbi.getBlockId());
+    assertEquals(35184374185984L, sbi.getBlockId());
   }
 }

--- a/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
+++ b/client/src/test/java/com/tencent/rss/client/ClientUtilsTest.java
@@ -34,10 +34,10 @@ public class ClientUtilsTest {
   public void getBlockIdTest() {
     // max value of blockId
     assertEquals(
-        new Long(9223372036854775807L), ClientUtils.getBlockId(16777215, 1048575, 524287));
+        new Long(854558029292503039L), ClientUtils.getBlockId(16777215, 1048575, 24287));
     // just a random test
     assertEquals(
-        new Long(1759218709299300L), ClientUtils.getBlockId(100, 100, 100));
+        new Long(3518437418598500L), ClientUtils.getBlockId(100, 100, 100));
     // min value of blockId
     assertEquals(
         new Long(0L), ClientUtils.getBlockId(0, 0, 0));
@@ -48,16 +48,16 @@ public class ClientUtilsTest {
       assertTrue(e.getMessage().contains("Can't support partitionId[16777216], the max value should be 16777215"));
     }
     try {
-      ClientUtils.getBlockId(0, 1048576, 0);
+      ClientUtils.getBlockId(0, 2097152, 0);
       fail(EXCEPTION_EXPECTED);
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Can't support taskAttemptId[1048576], the max value should be 1048575"));
+      assertTrue(e.getMessage().contains("Can't support taskAttemptId[2097152], the max value should be 2097151"));
     }
     try {
-      ClientUtils.getBlockId(0, 0, 524288);
+      ClientUtils.getBlockId(0, 0, 262144);
       fail(EXCEPTION_EXPECTED);
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("Can't support sequence[524288], the max value should be 524287"));
+      assertTrue(e.getMessage().contains("Can't support sequence[262144], the max value should be 262143"));
     }
   }
 }

--- a/common/src/main/java/com/tencent/rss/common/util/Constants.java
+++ b/common/src/main/java/com/tencent/rss/common/util/Constants.java
@@ -27,8 +27,8 @@ public class Constants {
   // BlockId is long and consist of partitionId, taskAttemptId, atomicInt
   // the length of them are ATOMIC_INT_MAX_LENGTH + PARTITION_ID_MAX_LENGTH + TASK_ATTEMPT_ID_MAX_LENGTH = 63
   public static final int PARTITION_ID_MAX_LENGTH = 24;
-  public static final int TASK_ATTEMPT_ID_MAX_LENGTH = 20;
-  public static final int ATOMIC_INT_MAX_LENGTH = 19;
+  public static final int TASK_ATTEMPT_ID_MAX_LENGTH = 21;
+  public static final int ATOMIC_INT_MAX_LENGTH = 18;
   public static long MAX_SEQUENCE_NO = (1 << Constants.ATOMIC_INT_MAX_LENGTH) - 1;
   public static long MAX_PARTITION_ID = (1 << Constants.PARTITION_ID_MAX_LENGTH) - 1;
   public static long MAX_TASK_ATTEMPT_ID = (1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) - 1;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rss TaskAttemptId length is 20, we should guarantee the map task id length is less than that value. And we adjust the length of task to run more tasks.

### Why are the changes needed?
If we don't have this patch,  task cannot retry succesfully. Task will throw exception
Can't support taskAttemptId[4294976976], the max value should be 1048575
        at com.tencent.rss.client.util.ClientUtils.getBlockId(ClientUtils.java:43)
        at org.apache.hadoop.mapred.SortWriteBufferManager.createShuffleBlock(SortWriteBufferManager.java:292)

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add new UT
