### PR TITLE
[Bugfix] executor should get remote storage from ShuffleHandle

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkShuffleUtils.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.CoordinatorClient;
 import com.tencent.rss.client.factory.CoordinatorClientFactory;
+import com.tencent.rss.common.RemoteStorageInfo;
 
 public class RssSparkShuffleUtils {
 
@@ -110,5 +111,17 @@ public class RssSparkShuffleUtils {
       LOG.error(msg);
       throw new IllegalArgumentException(msg);
     }
+  }
+
+  public static Configuration getRemoteStorageHadoopConf(
+      SparkConf sparkConf, RemoteStorageInfo remoteStorageInfo) {
+    Configuration readerHadoopConf = RssSparkShuffleUtils.newHadoopConfiguration(sparkConf);
+    final Map<String, String> shuffleRemoteStorageConf = remoteStorageInfo.getConfItems();
+    if (shuffleRemoteStorageConf != null && !shuffleRemoteStorageConf.isEmpty()) {
+      for (Map.Entry<String, String> entry : shuffleRemoteStorageConf.entrySet()) {
+        readerHadoopConf.set(entry.getKey(), entry.getValue());
+      }
+    }
+    return readerHadoopConf;
   }
 }

--- a/common/src/main/java/com/tencent/rss/common/RemoteStorageInfo.java
+++ b/common/src/main/java/com/tencent/rss/common/RemoteStorageInfo.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.ArrayUtils;
@@ -115,6 +116,19 @@ public class RemoteStorageInfo implements Serializable {
     }
 
     return true;
+  }
+
+  @Override
+  public String toString() {
+    if (isEmpty()) {
+      return "Empty Remote Storage";
+    } else if (confItems == null) {
+      return String.join(Constants.COMMA_SPLIT_CHAR, path, "null conf");
+    } else if (confItems.isEmpty()) {
+      return String.join(Constants.COMMA_SPLIT_CHAR, path, "empty conf");
+    } else {
+      return String.join(Constants.COMMA_SPLIT_CHAR, path, Joiner.on(",").withKeyValueSeparator("=").join(confItems));
+    }
   }
 
   @Override

--- a/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
+++ b/coordinator/src/main/java/com/tencent/rss/coordinator/ApplicationManager.java
@@ -74,7 +74,7 @@ public class ApplicationManager {
 
   public void refreshRemoteStorage(String remoteStoragePath, String remoteStorageConf) {
     if (!StringUtils.isEmpty(remoteStoragePath)) {
-      LOG.info("Refresh remote storage with {}", remoteStoragePath);
+      LOG.info("Refresh remote storage with {} {}", remoteStoragePath, remoteStorageConf);
       Set<String> paths = Sets.newHashSet(remoteStoragePath.split(Constants.COMMA_SPLIT_CHAR));
       Map<String, Map<String, String>> confKVs = CoordinatorUtils.extractRemoteStorageConf(remoteStorageConf);
       // add remote path if not exist

--- a/integration-test/spark2/src/test/java/com/tencent/rss/test/GetReaderTest.java
+++ b/integration-test/spark2/src/test/java/com/tencent/rss/test/GetReaderTest.java
@@ -137,5 +137,17 @@ public class GetReaderTest extends IntegrationTestBase {
     commonHadoopConf = jsc2.hadoopConfiguration();
     assertNull(commonHadoopConf.get("k1"));
     assertNull(commonHadoopConf.get("k2"));
+
+    // mock the scenario that get reader in an executor
+    rssShuffleManager.setRemoteStorage(null);
+    rssShuffleReader = (RssShuffleReader) rssShuffleManager.getReader(
+        rssShuffleHandle, 0, 0, mockTaskContextImpl);
+    hadoopConf =  rssShuffleReader.getHadoopConf();
+    assertEquals("v1", hadoopConf.get("k1"));
+    assertEquals("v2", hadoopConf.get("k2"));
+    // hadoop conf of reader and spark context should be isolated
+    commonHadoopConf = jsc2.hadoopConfiguration();
+    assertNull(commonHadoopConf.get("k1"));
+    assertNull(commonHadoopConf.get("k2"));
   }
 }

--- a/integration-test/spark3/src/test/java/com/tencent/rss/test/GetReaderTest.java
+++ b/integration-test/spark3/src/test/java/com/tencent/rss/test/GetReaderTest.java
@@ -147,6 +147,18 @@ public class GetReaderTest extends IntegrationTestBase {
     commonHadoopConf = jsc2.hadoopConfiguration();
     assertNull(commonHadoopConf.get("k1"));
     assertNull(commonHadoopConf.get("k2"));
+
+    // mock the scenario that get reader in an executor
+    rssShuffleManager.setRemoteStorage(null);
+    rssShuffleReader = (RssShuffleReader) rssShuffleManager.getReader(
+        rssShuffleHandle, 0, 0, new MockTaskContext(), new TempShuffleReadMetrics());
+    hadoopConf =  rssShuffleReader.getHadoopConf();
+    assertEquals("v1", hadoopConf.get("k1"));
+    assertEquals("v2", hadoopConf.get("k2"));
+    // hadoop conf of reader and spark context should be isolated
+    commonHadoopConf = jsc2.hadoopConfiguration();
+    assertNull(commonHadoopConf.get("k1"));
+    assertNull(commonHadoopConf.get("k2"));
   }
 
   private static class MockTaskContext extends TaskContext {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Executor get remote storage info from RssShuffleHadle.


### Why are the changes needed?
The driver's ShuffleManager register shuffle and fetch the remote storage and put then in the RssShuffleHandle. The remote storage in executor's ShuffleManager is useless and the task should get remote storage from RssShuffleHandle when it get reader.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Normal  ut and system test