### PR TITLE
[Bugfix] Map side avoid producing too many blocks

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -88,6 +88,8 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
     SerializationFactory serializationFactory = new SerializationFactory(jobConf);
     long maxSegmentSize = jobConf.getLong(RssMRConfig.RSS_CLIENT_MAX_SEGMENT_SIZE,
         RssMRConfig.RSS_CLIENT_DEFAULT_MAX_SEGMENT_SIZE);
+    int sendThreadNum = jobConf.getInt(RssMRConfig.RSS_CLIENT_SEND_THREAD_NUM,
+        RssMRConfig.RSS_CLIENT_DEFAULT_SEND_THREAD_NUM);
     bufferManager = new SortWriteBufferManager(
         (long)ByteUnit.MiB.toBytes(sortmb),
         taskAttemptId,
@@ -108,7 +110,8 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
         bitmapSplitNum,
         maxSegmentSize,
         numMaps,
-        isMemoryShuffleEnabled(storageType));
+        isMemoryShuffleEnabled(storageType),
+        sendThreadNum);
   }
 
   private Map<Integer, List<ShuffleServerInfo>> createAssignmentMap(JobConf jobConf) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBuffer.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBuffer.java
@@ -37,7 +37,6 @@ public class SortWriteBuffer<K, V> extends OutputStream  {
   private final List<WrappedBuffer> buffers = Lists.newArrayList();
   private final List<Record<K>> records = Lists.newArrayList();
   private int dataLength = 0;
-  private int totalKeyLength = 0;
   private long sortTime = 0;
   private final RawComparator<K> comparator;
   private long maxSegmentSize;
@@ -136,7 +135,7 @@ public class SortWriteBuffer<K, V> extends OutputStream  {
 
   private boolean compact(int lastIndex, int lastOffset, int dataLength) {
     if (lastIndex != currentIndex) {
-      LOG.info("compact lastIndex {}, currentIndex {}, lastOffset {} currentOffset {} dataLength {}",
+      LOG.debug("compact lastIndex {}, currentIndex {}, lastOffset {} currentOffset {} dataLength {}",
           lastIndex, currentIndex, lastOffset, currentOffset, dataLength);
       WrappedBuffer buffer = new WrappedBuffer(lastOffset + dataLength);
       // copy data
@@ -192,10 +191,6 @@ public class SortWriteBuffer<K, V> extends OutputStream  {
 
   public int getDataLength() {
     return dataLength;
-  }
-
-  public int getTotalKeyLength() {
-    return totalKeyLength;
   }
 
   public long getCopyTime() {

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -88,12 +88,7 @@ public class SortWriteBufferManager<K, V> {
   private final int numMaps;
   private long copyTime = 0;
   private long sortTime = 0;
-  private final ExecutorService sendExecutorService = Executors.newFixedThreadPool(
-      5,
-      new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("send-thread-%d")
-      .build());
+  private final ExecutorService sendExecutorService;
 
   public SortWriteBufferManager(
       long maxMemSize,
@@ -115,7 +110,8 @@ public class SortWriteBufferManager<K, V> {
       int bitmapSplitNum,
       long maxSegmentSize,
       int numMaps,
-      boolean isMemoryShuffleEnabled) {
+      boolean isMemoryShuffleEnabled,
+      int sendThreadNum) {
     this.maxMemSize = maxMemSize;
     this.taskAttemptId = taskAttemptId;
     this.batch = batch;
@@ -136,6 +132,12 @@ public class SortWriteBufferManager<K, V> {
     this.maxSegmentSize = maxSegmentSize;
     this.numMaps = numMaps;
     this.isMemoryShuffleEnabled = isMemoryShuffleEnabled;
+    this.sendExecutorService  = Executors.newFixedThreadPool(
+        sendThreadNum,
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("send-thread-%d")
+            .build());
   }
 
   // todo: Single Buffer should also have its size limit
@@ -173,7 +175,7 @@ public class SortWriteBufferManager<K, V> {
     waitSendBuffers.sort(new Comparator<SortWriteBuffer<K, V>>() {
       @Override
       public int compare(SortWriteBuffer<K, V> o1, SortWriteBuffer<K, V> o2) {
-        return o1.getDataLength() - o2.getDataLength();
+        return o2.getDataLength() - o1.getDataLength();
       }
     });
     int sendSize = batch;
@@ -189,9 +191,7 @@ public class SortWriteBufferManager<K, V> {
       index++;
     }
     List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
-    long keyLength = 0;
     for (SortWriteBuffer buffer : selectBuffers) {
-      keyLength += buffer.getTotalKeyLength();
       buffers.remove(buffer.getPartitionId());
       ShuffleBlockInfo block = createShuffleBlock(buffer);
       shuffleBlocks.add(block);
@@ -201,7 +201,6 @@ public class SortWriteBufferManager<K, V> {
       }
       partitionToBlocks.get(block.getPartitionId()).add(block.getBlockId());
     }
-    long finalKeyLength = keyLength;
     sendExecutorService.submit(new Runnable() {
       @Override
       public void run() {
@@ -220,7 +219,6 @@ public class SortWriteBufferManager<K, V> {
           try {
             memoryLock.lock();
             memoryUsedSize.addAndGet(-size);
-            memoryUsedSize.addAndGet(-finalKeyLength);
             inSendListBytes.addAndGet(-size);
             full.signalAll();
           } finally {
@@ -328,6 +326,11 @@ public class SortWriteBufferManager<K, V> {
     } finally {
       executor.shutdown();
     }
+  }
+
+  // Only for test
+  List<SortWriteBuffer<K, V>> getWaitSendBuffers() {
+    return waitSendBuffers;
   }
 
   // it's run in single thread, and is not thread safe

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -52,6 +52,10 @@ public class RssMRConfig {
       RssClientConfig.RSS_DATA_REPLICA_READ_DEFAULT_VALUE;
   public static final String RSS_DATA_REPLICA_SKIP_ENABLED =
       MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED;
+  public static final String RSS_CLIENT_SEND_THREAD_NUM =
+      MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_CLIENT_SEND_THREAD_NUM;
+  public static final int RSS_CLIENT_DEFAULT_SEND_THREAD_NUM =
+      RssClientConfig.RSS_CLIENT_DEFAULT_SEND_NUM;
   public static boolean RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE =
       RssClientConfig.RSS_DATA_REPLICA_SKIP_ENABLED_DEFAULT_VALUE;
   public static final String RSS_HEARTBEAT_INTERVAL =

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -41,6 +41,7 @@ import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,7 +77,8 @@ public class SortWriteBufferManagerTest {
         1,
         100,
         1000,
-        true);
+        true,
+        5);
     Random random = new Random();
     for (int i = 0; i < 1000; i++) {
       byte[] key = new byte[20];
@@ -122,7 +124,8 @@ public class SortWriteBufferManagerTest {
         1,
         100,
         1000,
-        true);
+        true,
+        5);
     byte[] key = new byte[20];
     byte[] value = new byte[1024];
     random.nextBytes(key);
@@ -167,7 +170,8 @@ public class SortWriteBufferManagerTest {
         1,
         100,
         2000,
-        true);
+        true,
+        5);
     Random random = new Random();
     for (int i = 0; i < 1000; i++) {
       byte[] key = new byte[20];
@@ -177,6 +181,21 @@ public class SortWriteBufferManagerTest {
       manager.addRecord(1, new BytesWritable(key), new BytesWritable(value));
     }
     manager.waitSendFinished();
+    assertTrue(manager.getWaitSendBuffers().isEmpty());
+    for (int i = 0; i < 14; i++) {
+      byte[] key = new byte[20];
+      byte[] value = new byte[i * 100];
+      random.nextBytes(key);
+      random.nextBytes(value);
+      manager.addRecord(i, new BytesWritable(key), new BytesWritable(value));
+    }
+    assertEquals(4, manager.getWaitSendBuffers().size());
+    for (int i = 0; i < 4; i++) {
+      int dataLength = manager.getWaitSendBuffers().get(i).getDataLength();
+      assertEquals((3 - i) * 100 + 28, dataLength);
+    }
+    manager.waitSendFinished();
+    assertTrue(manager.getWaitSendBuffers().isEmpty());
   }
 
   class MockShuffleWriteClient implements ShuffleWriteClient {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -216,7 +216,8 @@ public class FetcherTest {
       1,
       100,
       2000,
-      true);
+      true,
+        5);
 
     for (String key : keysToValues.keySet()) {
       String value = keysToValues.get(key);

--- a/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
+++ b/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
@@ -49,6 +49,8 @@ public class RssClientConfig {
   public static final String RSS_REMOTE_STORAGE_PATH = "rss.remote.storage.path";
   public static final String RSS_INDEX_READ_LIMIT = "rss.index.read.limit";
   public static final int RSS_INDEX_READ_LIMIT_DEFAULT_VALUE = 500;
+  public static final String RSS_CLIENT_SEND_THREAD_NUM = "rss.client.send.thread.num";
+  public static final int RSS_CLIENT_DEFAULT_SEND_NUM = 5;
   public static String RSS_CLIENT_READ_BUFFER_SIZE = "rss.client.read.buffer.size";
   // When the size of read buffer reaches the half of JVM region (i.e., 32m),
   // it will incur humongous allocation, so we set it to 14m.


### PR DESCRIPTION
### What changes were proposed in this pull request?
We change the sort order, we should send bigger size block, otherwise we will produce too many blocks. And it will take too much time to send them.

### Why are the changes needed?
If we don't have this patch,  the task will fail because of timeout.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New ut
