### PR TITLE
[Bugfix] MR Reduce should only fetch one attempt of each map task

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.mapreduce.task.reduce;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -43,8 +43,8 @@ public class RssEventFetcher<K,V> {
   private final int maxEventsToFetch;
   private JobConf jobConf;
 
-  private Set<TaskAttemptID> successMaps = new HashSet<TaskAttemptID>();
-  private Set<TaskAttemptID> obsoleteMaps = new HashSet<TaskAttemptID>();
+  private List<TaskAttemptID> successMaps = new LinkedList<>();
+  private List<TaskAttemptID> obsoleteMaps = new LinkedList<>();
   private int tipFailedCount = 0;
   private final int totalMapsCount;
 
@@ -104,7 +104,6 @@ public class RssEventFetcher<K,V> {
     //    fetching from those maps.
     // 3. Remove TIPFAILED maps from neededOutputs since we don't need their
     //    outputs at all.
-    successMaps.contains(event);
     switch (event.getTaskStatus()) {
       case SUCCEEDED:
         successMaps.add(event.getTaskAttemptId());

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -74,7 +74,8 @@ public class RssEventFetcher<K,V> {
     for (TaskAttemptID taskAttemptID: successMaps) {
       if (!obsoleteMaps.contains(taskAttemptID)) {
         int mapIndex = taskAttemptID.getTaskID().getId();
-        // we only need to just one attempt of each map task.
+        // There can be multiple successful attempts on same map task.
+        // So we only need to accept one of them.
         if (!mapIndexBitmap.contains(mapIndex)) {
           long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID);
           taskIdBitmap.addLong(rssTaskId);

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssFetcher.java
@@ -220,9 +220,12 @@ public class RssFetcher<K,V> {
     String statusString = copyBlockCount + " / " + copyBlockCount + " copied.";
     status.setStateString(statusString);
 
+    if (copyTime == 0) {
+      copyTime = 1;
+    }
     double bytesPerMillis = (double) unCompressionLength / copyTime;
     double transferRate = bytesPerMillis * BYTES_PER_MILLIS_TO_MBS;
-    progress.setStatus("copy(" + copyBlockCount + " of " + copyBlockCount + " at "
+    progress.setStatus("copy(" + copyBlockCount + " of " + totalBlockCount + " at "
       + mbpsFormat.format(transferRate) + " MB/s)");
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
MR Reduce should only fetch one attempt of each map task.

### Why are the changes needed?
Without this PR, the Reduce will assume to accept all attempt of each map task and fail in taskID check.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
By hand.
