### PR TITLE
[Improvement] Supports MR application  re-execute

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -57,7 +57,7 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
   @Override
   public void init(Context context) throws IOException, ClassNotFoundException {
     JobConf jobConf = context.getJobConf();
-    jobConf.addResource(RssMRConfig.RSS_EXTRA_CONF_FILE);
+    jobConf.addResource(RssMRConfig.RSS_CONF_FILE);
     reporter = context.getReporter();
     keyClass = (Class<K>)jobConf.getMapOutputKeyClass();
     valClass = (Class<V>)jobConf.getMapOutputValueClass();

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -33,14 +33,14 @@ import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.mapreduce.RssMRUtils;
 import org.apache.hadoop.mapreduce.TaskCounter;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.util.ByteUnit;
 import com.tencent.rss.storage.util.StorageType;
-import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RssMapOutputCollector<K extends Object, V extends Object>
     implements MapOutputCollector<K, V> {
@@ -75,7 +75,8 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
         RssMRConfig.RSS_CLIENT_DEFAULT_MEMORY_THRESHOLD);
     ApplicationAttemptId applicationAttemptId = RssMRUtils.getApplicationAttemptId();
     String appId = applicationAttemptId.toString();
-    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(mapTask.getTaskID(), applicationAttemptId.getAttemptId());
+    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(mapTask.getTaskID(),
+        applicationAttemptId.getAttemptId());
     double sendThreshold = jobConf.getDouble(RssMRConfig.RSS_CLIENT_SEND_THRESHOLD,
         RssMRConfig.RSS_CLIENT_DEFAULT_SEND_THRESHOLD);
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -38,10 +38,14 @@ import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.util.ByteUnit;
 import com.tencent.rss.storage.util.StorageType;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RssMapOutputCollector<K extends Object, V extends Object>
     implements MapOutputCollector<K, V> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(RssMapOutputCollector.class);
   private Task.TaskReporter reporter;
   private Class<K> keyClass;
   private Class<V> valClass;
@@ -53,6 +57,7 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
   @Override
   public void init(Context context) throws IOException, ClassNotFoundException {
     JobConf jobConf = context.getJobConf();
+    jobConf.addResource(RssMRConfig.RSS_EXTRA_CONF_FILE);
     reporter = context.getReporter();
     keyClass = (Class<K>)jobConf.getMapOutputKeyClass();
     valClass = (Class<V>)jobConf.getMapOutputValueClass();
@@ -63,13 +68,14 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
     }
     partitions = jobConf.getNumReduceTasks();
     MapTask mapTask = context.getMapTask();
-    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(mapTask.getTaskID());
     int batch = jobConf.getInt(RssMRConfig.RSS_CLIENT_BATCH_TRIGGER_NUM,
         RssMRConfig.RSS_CLIENT_DEFAULT_BATCH_TRIGGER_NUM);
     RawComparator<K> comparator = jobConf.getOutputKeyComparator();
     double memoryThreshold = jobConf.getDouble(RssMRConfig.RSS_CLIENT_MEMORY_THRESHOLD,
         RssMRConfig.RSS_CLIENT_DEFAULT_MEMORY_THRESHOLD);
-    String appId = RssMRUtils.getApplicationAttemptId().toString();
+    ApplicationAttemptId applicationAttemptId = RssMRUtils.getApplicationAttemptId();
+    String appId = applicationAttemptId.toString();
+    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(mapTask.getTaskID(), applicationAttemptId.getAttemptId());
     double sendThreshold = jobConf.getDouble(RssMRConfig.RSS_CLIENT_SEND_THRESHOLD,
         RssMRConfig.RSS_CLIENT_DEFAULT_SEND_THRESHOLD);
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -115,6 +115,8 @@ public class RssMRConfig {
   public static String RSS_ACCESS_TIMEOUT_MS = MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ACCESS_TIMEOUT_MS;
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE;
 
+  public static String RSS_EXTRA_CONF_FILE = "extra.xml";
+
   public static Set<String> RSS_MANDATORY_CLUSTER_CONF = Sets.newHashSet(
       RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);
 }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -115,7 +115,7 @@ public class RssMRConfig {
   public static String RSS_ACCESS_TIMEOUT_MS = MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_ACCESS_TIMEOUT_MS;
   public static int RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE = RssClientConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE;
 
-  public static String RSS_EXTRA_CONF_FILE = "extra.xml";
+  public static String RSS_CONF_FILE = "rss_conf.xml";
 
   public static Set<String> RSS_MANDATORY_CLUSTER_CONF = Sets.newHashSet(
       RSS_STORAGE_TYPE, RSS_REMOTE_STORAGE_PATH);

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -69,7 +69,7 @@ public class RssMRUtils {
       throw new RssException("appAttemptId " + appAttemptId + " is wrong");
     }
     TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & MAX_TASK_ID));
-    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH) + 1000 * (appAttemptId -1));
+    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH) + 1000 * (appAttemptId - 1));
   }
 
   public static ShuffleWriteClient createShuffleClient(JobConf jobConf) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -44,7 +44,8 @@ public class RssMRUtils {
   private static long MAX_ATTEMPT_ID = (1 << MAX_ATTEMPT_LENGTH) - 1;
 
   // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 21 bits,
-  // mapId is 19 bits, id is 2 bits.
+  // mapId is 19 bits, id is 2 bits. MR have a trick logic, taskAttemptId will increase
+  // 1000 * (appAttemptId - 1), so we will decrease it.
   public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID, int appAttemptId) {
     long lowBytes = taskAttemptID.getTaskID().getId();
     if (lowBytes > MAX_TASK_ID) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -45,22 +45,31 @@ public class RssMRUtils {
 
   // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 21 bits,
   // mapId is 19 bits, id is 2 bits.
-  public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID) {
+  public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID, int appAttemptId) {
     long lowBytes = taskAttemptID.getTaskID().getId();
     if (lowBytes > MAX_TASK_ID) {
       throw new RssException("TaskAttempt " + taskAttemptID + " low bytes " + lowBytes + " exceed");
     }
-    long highBytes = (long)taskAttemptID.getId();
-    if (highBytes > MAX_ATTEMPT_ID) {
+    if (appAttemptId < 1) {
+      throw new RssException("appAttemptId " + appAttemptId + " is wrong");
+    }
+    long highBytes = (long)taskAttemptID.getId() - (appAttemptId - 1) * 1000;
+    if (highBytes > MAX_ATTEMPT_ID || highBytes < 0) {
       throw new RssException("TaskAttempt " + taskAttemptID + " high bytes " + highBytes + " exceed");
     }
     return (highBytes << MAX_TASK_LENGTH) + lowBytes;
   }
 
-  public static TaskAttemptID createMRTaskAttemptId(JobID jobID, TaskType taskType,
-                                                    long rssTaskAttemptId) {
+  public static TaskAttemptID createMRTaskAttemptId(
+      JobID jobID,
+      TaskType taskType,
+      long rssTaskAttemptId,
+      int appAttemptId) {
+    if (appAttemptId < 1) {
+      throw new RssException("appAttemptId " + appAttemptId + " is wrong");
+    }
     TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & MAX_TASK_ID));
-    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH));
+    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH) + 1000 * (appAttemptId -1));
   }
 
   public static ShuffleWriteClient createShuffleClient(JobConf jobConf) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -47,16 +47,19 @@ public class RssEventFetcher<K,V> {
   private List<TaskAttemptID> obsoleteMaps = new LinkedList<>();
   private int tipFailedCount = 0;
   private final int totalMapsCount;
+  private final int appAttemptId;
 
   public RssEventFetcher(TaskAttemptID reduce,
                          TaskUmbilicalProtocol umbilical,
                          JobConf jobConf,
-                         int maxEventsToFetch) {
+                         int maxEventsToFetch,
+                         int appAttemptId) {
     this.jobConf = jobConf;
     this.totalMapsCount = jobConf.getNumMapTasks();
     this.reduce = reduce;
     this.umbilical = umbilical;
     this.maxEventsToFetch = maxEventsToFetch;
+    this.appAttemptId = appAttemptId;
   }
 
   public Roaring64NavigableMap fetchAllRssTaskIds() {
@@ -73,6 +76,8 @@ public class RssEventFetcher<K,V> {
     String errMsg = "TaskAttemptIDs are inconsistent with map tasks";
     for (TaskAttemptID taskAttemptID: successMaps) {
       if (!obsoleteMaps.contains(taskAttemptID)) {
+        long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, appAttemptId);
+        taskIdBitmap.addLong(rssTaskId);
         int mapIndex = taskAttemptID.getTaskID().getId();
         // There can be multiple successful attempts on same map task.
         // So we only need to accept one of them.

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -77,7 +77,6 @@ public class RssEventFetcher<K,V> {
     for (TaskAttemptID taskAttemptID: successMaps) {
       if (!obsoleteMaps.contains(taskAttemptID)) {
         long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, appAttemptId);
-        taskIdBitmap.addLong(rssTaskId);
         int mapIndex = taskAttemptID.getTaskID().getId();
         // There can be multiple successful attempts on same map task.
         // So we only need to accept one of them.

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -82,7 +82,6 @@ public class RssEventFetcher<K,V> {
         // There can be multiple successful attempts on same map task.
         // So we only need to accept one of them.
         if (!mapIndexBitmap.contains(mapIndex)) {
-          long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID);
           taskIdBitmap.addLong(rssTaskId);
           if (mapIndex < totalMapsCount) {
             mapIndexBitmap.addLong(mapIndex);

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssEventFetcher.java
@@ -49,11 +49,12 @@ public class RssEventFetcher<K,V> {
   private final int totalMapsCount;
   private final int appAttemptId;
 
-  public RssEventFetcher(TaskAttemptID reduce,
-                         TaskUmbilicalProtocol umbilical,
-                         JobConf jobConf,
-                         int maxEventsToFetch,
-                         int appAttemptId) {
+  public RssEventFetcher(
+      int appAttemptId,
+      TaskAttemptID reduce,
+      TaskUmbilicalProtocol umbilical,
+      JobConf jobConf,
+      int maxEventsToFetch) {
     this.jobConf = jobConf;
     this.totalMapsCount = jobConf.getNumMapTasks();
     this.reduce = reduce;

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
@@ -80,6 +80,7 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
   private int indexReadLimit;
   private int readBufferSize;
   private RemoteStorageInfo remoteStorageInfo;
+  private int appAttemptId;
 
   @Override
   public void init(ShuffleConsumerPlugin.Context context) {
@@ -88,6 +89,8 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
 
     this.reduceId = context.getReduceId();
     this.jobConf = context.getJobConf();
+    jobConf.addResource(RssMRConfig.RSS_EXTRA_CONF_FILE);
+
     this.umbilical = context.getUmbilical();
     this.reporter = context.getReporter();
     this.metrics = new ShuffleClientMetrics(reduceId, jobConf);
@@ -98,6 +101,7 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
 
     // rss init
     this.appId = RssMRUtils.getApplicationAttemptId().toString();
+    this.appAttemptId = RssMRUtils.getApplicationAttemptId().getAttemptId();
     this.storageType = jobConf.get(RssMRConfig.RSS_STORAGE_TYPE);
     this.replicaWrite = jobConf.getInt(RssMRConfig.RSS_DATA_REPLICA_WRITE,
       RssMRConfig.RSS_DATA_REPLICA_WRITE_DEFAULT_VALUE);
@@ -149,7 +153,7 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
 
     // get map-completion events to generate RSS taskIDs
     final RssEventFetcher<K,V> eventFetcher =
-      new RssEventFetcher<K,V>(reduceId, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher<K,V>(reduceId, umbilical, jobConf, MAX_EVENTS_TO_FETCH, appAttemptId);
     Roaring64NavigableMap taskIdBitmap = eventFetcher.fetchAllRssTaskIds();
 
     LOG.info("In reduce: " + reduceId

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
@@ -153,7 +153,7 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
 
     // get map-completion events to generate RSS taskIDs
     final RssEventFetcher<K,V> eventFetcher =
-      new RssEventFetcher<K,V>(reduceId, umbilical, jobConf, MAX_EVENTS_TO_FETCH, appAttemptId);
+      new RssEventFetcher<K,V>(appAttemptId, reduceId, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap taskIdBitmap = eventFetcher.fetchAllRssTaskIds();
 
     LOG.info("In reduce: " + reduceId

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
@@ -89,7 +89,7 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
 
     this.reduceId = context.getReduceId();
     this.jobConf = context.getJobConf();
-    jobConf.addResource(RssMRConfig.RSS_EXTRA_CONF_FILE);
+    jobConf.addResource(RssMRConfig.RSS_CONF_FILE);
 
     this.umbilical = context.getUmbilical();
     this.reporter = context.getReporter();

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.mapreduce.v2.app;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -31,10 +29,10 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -62,6 +60,7 @@ public class RssMRAppMaster {
 
   public static void main(String[] args) {
 
+
     JobConf conf = new JobConf(new Path(MRJobConfig.JOB_CONF_FILE));
     int numReduceTasks = conf.getInt(MRJobConfig.NUM_REDUCES, 0);
     if (numReduceTasks > 0) {
@@ -77,6 +76,7 @@ public class RssMRAppMaster {
       ShuffleAssignmentsInfo response = client.getShuffleAssignments(
           appId, 0, numReduceTasks,
           1, Sets.newHashSet(Constants.SHUFFLE_SERVER_VERSION));
+
       Map<ShuffleServerInfo, List<PartitionRange>> serverToPartitionRanges = response.getServerToPartitionRanges();
       final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
           new ThreadFactory() {
@@ -108,6 +108,21 @@ public class RssMRAppMaster {
           heartbeatInterval,
           TimeUnit.MILLISECONDS);
 
+      JobConf extraConf = new JobConf();
+      extraConf.clear();
+      // write shuffle worker assignments to submit work directory
+      // format is as below:
+      // mapreduce.rss.assignment.partition.1:server1,server2
+      // mapreduce.rss.assignment.partition.2:server3,server4
+      // ...
+      response.getPartitionToServers().entrySet().forEach(entry -> {
+        List<String> servers = Lists.newArrayList();
+        for (ShuffleServerInfo server : entry.getValue()) {
+          servers.add(server.getHost() + ":" + server.getPort());
+        }
+        extraConf.set(RssMRConfig.RSS_ASSIGNMENT_PREFIX + entry.getKey(), StringUtils.join(servers, ","));
+      });
+
       // get remote storage from coordinator if necessary
       boolean dynamicConfEnabled = conf.getBoolean(RssMRConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED,
           RssMRConfig.RSS_DYNAMIC_CLIENT_CONF_ENABLED_DEFAULT_VALUE);
@@ -117,16 +132,17 @@ public class RssMRAppMaster {
         Map<String, String> clusterClientConf = client.fetchClientConf(
             conf.getInt(RssMRConfig.RSS_ACCESS_TIMEOUT_MS,
                 RssMRConfig.RSS_ACCESS_TIMEOUT_MS_DEFAULT_VALUE));
-        RssMRUtils.applyDynamicClientConf(conf, clusterClientConf);
+        RssMRUtils.applyDynamicClientConf(extraConf, clusterClientConf);
       }
+
       String storageType = conf.get(RssMRConfig.RSS_STORAGE_TYPE);
       RemoteStorageInfo defaultRemoteStorage =
           new RemoteStorageInfo(conf.get(RssMRConfig.RSS_REMOTE_STORAGE_PATH, ""));
       RemoteStorageInfo remoteStorage = ClientUtils.fetchRemoteStorage(
         appId, defaultRemoteStorage, dynamicConfEnabled, storageType, client);
       // set the remote storage with actual value
-      conf.set(RssMRConfig.RSS_REMOTE_STORAGE_PATH, remoteStorage.getPath());
-      conf.set(RssMRConfig.RSS_REMOTE_STORAGE_CONF, remoteStorage.getConfString());
+      extraConf.set(RssMRConfig.RSS_REMOTE_STORAGE_PATH, remoteStorage.getPath());
+      extraConf.set(RssMRConfig.RSS_REMOTE_STORAGE_CONF, remoteStorage.getConfString());
 
       LOG.info("Start to register shuffle");
       long start = System.currentTimeMillis();
@@ -136,19 +152,7 @@ public class RssMRAppMaster {
       });
       LOG.info("Finish register shuffle with " + (System.currentTimeMillis() - start) + " ms");
 
-      // write shuffle worker assignments to submit work directory
-      // format is as below:
-      // mapreduce.rss.assignment.partition.1:server1,server2
-      // mapreduce.rss.assignment.partition.2:server3,server4
-      // ...
-
-      response.getPartitionToServers().entrySet().forEach(entry -> {
-        List<String> servers = Lists.newArrayList();
-        for (ShuffleServerInfo server : entry.getValue()) {
-          servers.add(server.getHost() + ":" + server.getPort());
-        }
-        conf.set(RssMRConfig.RSS_ASSIGNMENT_PREFIX + entry.getKey(), StringUtils.join(servers, ","));
-      });
+      writeExtraConf(conf, extraConf);
 
       // close slow start
       conf.setFloat(MRJobConfig.COMPLETED_MAPS_FOR_REDUCE_SLOWSTART, 1.0f);
@@ -162,11 +166,42 @@ public class RssMRAppMaster {
         throw new RuntimeException("jobDir is empty");
       }
       Path jobConfFile = new Path(jobDirStr, MRJobConfig.JOB_CONF_FILE);
+
       updateConf(conf, jobConfFile);
     }
     // remove org.apache.hadoop.mapreduce.v2.app.MRAppMaster
     ArrayUtils.remove(args, 0);
     MRAppMaster.main(args);
+  }
+
+  static void writeExtraConf(JobConf conf, JobConf extraConf) {
+    try {
+      FileSystem fs = new Cluster(conf).getFileSystem();
+      String jobDirStr = conf.get(MRJobConfig.MAPREDUCE_JOB_DIR);
+      Path assignmentFile = new Path(jobDirStr, RssMRConfig.RSS_EXTRA_CONF_FILE);
+
+      try (FSDataOutputStream out =
+               FileSystem.create(fs, assignmentFile,
+                   new FsPermission(JobSubmissionFiles.JOB_FILE_PERMISSION))) {
+        extraConf.writeXml(out);
+      }
+      FileStatus status = fs.getFileStatus(assignmentFile);
+      long currentTs = status.getModificationTime();
+      String uri = fs.getUri() + Path.SEPARATOR + assignmentFile.toUri();
+      String files = conf.get(MRJobConfig.CACHE_FILES);
+      conf.set(MRJobConfig.CACHE_FILES, files == null ? uri : uri + "," + files);
+      String ts = conf.get(MRJobConfig.CACHE_FILE_TIMESTAMPS);
+      conf.set(MRJobConfig.CACHE_FILE_TIMESTAMPS,
+          ts == null ? String.valueOf(currentTs) : currentTs + "," + ts);
+      String vis = conf.get(MRJobConfig.CACHE_FILE_VISIBILITIES);
+      conf.set(MRJobConfig.CACHE_FILE_VISIBILITIES, vis == null ? "false" : "false" + "," + vis);
+      long size = status.getLen();
+      String sizes = conf.get(MRJobConfig.CACHE_FILES_SIZES);
+      conf.set(MRJobConfig.CACHE_FILES_SIZES, sizes == null ? String.valueOf(size) : size + "," + sizes);
+    } catch (Exception e) {
+      LOG.error("Upload extra conf exception", e);
+      throw new RuntimeException("Upload extra conf exception ", e);
+    }
   }
 
   // After we modify some configurations, we should update configuration for Application
@@ -175,19 +210,13 @@ public class RssMRAppMaster {
   // We choose to delete it and override with the new configuration in the HDFS.
   static void updateConf(JobConf conf, Path jobConfFile) {
     try {
-      FileSystem fs = new Cluster(conf).getFileSystem();
-      fs.delete(jobConfFile, true);
-      try (FSDataOutputStream out =
-             FileSystem.create(fs, jobConfFile,
-                 new FsPermission(JobSubmissionFiles.JOB_FILE_PERMISSION))) {
+      File newFile = new File(MRJobConfig.JOB_CONF_FILE + ".bak");
+      try (FileOutputStream out = new FileOutputStream(newFile)) {
           conf.writeXml(out);
       }
       File file = new File(MRJobConfig.JOB_CONF_FILE);
       file.delete();
-      try (InputStream input = fs.open(jobConfFile);
-           OutputStream output = new FileOutputStream(file)) {
-        IOUtils.copy(input, output);
-      }
+      newFile.renameTo(file);
     } catch (Exception e) {
       LOG.error("Modify job conf exception", e);
       throw new RuntimeException("Modify job conf exception ", e);

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -158,6 +158,8 @@ public class RssMRAppMaster {
       conf.setFloat(MRJobConfig.COMPLETED_MAPS_FOR_REDUCE_SLOWSTART, 1.0f);
       LOG.warn("close slow start, because RSS does not support it yet");
 
+      // MapReduce don't set setKeepContainersAcrossApplicationAttempts in AppContext, there will be no container
+      // to be shared between attempts. Rss don't support shared container between attempts.
       conf.setBoolean(MRJobConfig.MR_AM_JOB_RECOVERY_ENABLE, false);
       LOG.warn("close recovery enable, because RSS doesn't support it yet");
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -180,7 +180,7 @@ public class RssMRAppMaster {
     try {
       FileSystem fs = new Cluster(conf).getFileSystem();
       String jobDirStr = conf.get(MRJobConfig.MAPREDUCE_JOB_DIR);
-      Path assignmentFile = new Path(jobDirStr, RssMRConfig.RSS_EXTRA_CONF_FILE);
+      Path assignmentFile = new Path(jobDirStr, RssMRConfig.RSS_CONF_FILE);
 
       try (FSDataOutputStream out =
                FileSystem.create(fs, assignmentFile,

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -36,23 +36,23 @@ public class RssMRUtilsTest {
   @Test
   public void TaskAttemptIdTest() {
     long taskAttemptId = 0x1000ad12;
-    TaskAttemptID mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, taskAttemptId);
+    TaskAttemptID mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, taskAttemptId, 1);
     boolean isException = false;
     try {
-      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
+      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
     } catch (RssException e) {
       isException = true;
     }
     assertTrue(isException);
     taskAttemptId = (1 << 20) + 0x123;
-    mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId);
-    long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
+    mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId, 1);
+    long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
     assertEquals(taskAttemptId, testId);
     TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 19));
     mrTaskAttemptId = new TaskAttemptID(taskID, 2);
     isException = false;
     try {
-      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId);
+      RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
     } catch (RssException e) {
       isException = true;
     }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -55,12 +55,12 @@ public class EvenFetcherTest {
       .thenReturn(getMockedCompletionEventsUpdate(0, mapTaskNum));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
-      );
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+          1);
       expected.addLong(rssTaskId);
     }
 
@@ -116,13 +116,13 @@ public class EvenFetcherTest {
       .thenReturn(getMockedCompletionEventsUpdate(MAX_EVENTS_TO_FETCH * 2, 3));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
 
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
-      );
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+          1);
       expected.addLong(rssTaskId);
     }
     Roaring64NavigableMap taskIdBitmap = ef.fetchAllRssTaskIds();
@@ -142,12 +142,12 @@ public class EvenFetcherTest {
         Sets.newHashSet(45, 67), Sets.newHashSet()));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
-      );
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+          1);
       expected.addLong(rssTaskId);
     }
     try {
@@ -172,12 +172,12 @@ public class EvenFetcherTest {
         Sets.newHashSet(), Sets.newHashSet(101)));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
-      );
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+          1);
       expected.addLong(rssTaskId);
     }
     try {
@@ -207,20 +207,20 @@ public class EvenFetcherTest {
     ExceptionReporter reporter = mock(ExceptionReporter.class);
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
 
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       if (!tipFailed.contains(mapIndex) && !obsoleted.contains(mapIndex)) {
         long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
-        );
+          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+            1);
         expected.addLong(rssTaskId);
       }
       if (obsoleted.contains(mapIndex)) {
         long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 1)
-        );
+          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 1),
+            1);
         expected.addLong(rssTaskId);
       }
     }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -59,8 +59,7 @@ public class EvenFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
-          1);
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
       expected.addLong(rssTaskId);
     }
 
@@ -87,9 +86,7 @@ public class EvenFetcherTest {
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
-          1
-      );
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
       expected.addLong(rssTaskId);
     }
 
@@ -214,8 +211,7 @@ public class EvenFetcherTest {
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       if (!tipFailed.contains(mapIndex) && !obsoleted.contains(mapIndex)) {
         long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
-            1);
+          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
         expected.addLong(rssTaskId);
       }
       if (obsoleted.contains(mapIndex)) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -83,11 +83,12 @@ public class EvenFetcherTest {
         Sets.newHashSet()));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
+      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0)
+        new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0),
+          1
       );
       expected.addLong(rssTaskId);
     }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -55,7 +55,7 @@ public class EvenFetcherTest {
       .thenReturn(getMockedCompletionEventsUpdate(0, mapTaskNum));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
@@ -82,7 +82,7 @@ public class EvenFetcherTest {
         Sets.newHashSet()));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
@@ -114,7 +114,7 @@ public class EvenFetcherTest {
       .thenReturn(getMockedCompletionEventsUpdate(MAX_EVENTS_TO_FETCH * 2, 3));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
 
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
@@ -140,7 +140,7 @@ public class EvenFetcherTest {
         Sets.newHashSet(45, 67), Sets.newHashSet()));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
@@ -170,7 +170,7 @@ public class EvenFetcherTest {
         Sets.newHashSet(), Sets.newHashSet(101)));
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
       long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
@@ -205,7 +205,7 @@ public class EvenFetcherTest {
     ExceptionReporter reporter = mock(ExceptionReporter.class);
 
     RssEventFetcher ef =
-      new RssEventFetcher(tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH, 1);
+      new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
 
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMasterTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMasterTest.java
@@ -42,6 +42,8 @@ public class RssMRAppMasterTest {
     assertTrue(file.exists());
     JobConf newJobConf = new JobConf(new Path(MRJobConfig.JOB_CONF_FILE));
     assertEquals("B", newJobConf.get("A"));
+    File testFile = new File("test");
+    testFile.deleteOnExit();
     file.deleteOnExit();
   }
 }

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/FailoverAppMaster.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/FailoverAppMaster.java
@@ -1,6 +1,7 @@
 /*
- *Tencent is pleased to support the open source community by making Firestorm-Spark remote shuffle server available.
-
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
  * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/FailoverAppMaster.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/FailoverAppMaster.java
@@ -1,0 +1,31 @@
+/*
+ *Tencent is pleased to support the open source community by making Firestorm-Spark remote shuffle server available.
+
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.tencent.rss.test;
+
+import org.apache.hadoop.mapreduce.RssMRUtils;
+import org.apache.hadoop.mapreduce.v2.app.RssMRAppMaster;
+import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
+
+public class FailoverAppMaster {
+  public static void main(String[] args) {
+    ApplicationAttemptId applicationAttemptId = RssMRUtils.getApplicationAttemptId();
+    if (applicationAttemptId.getAttemptId() == 1)  {
+      System.exit(1);
+    }
+    RssMRAppMaster.main(args);
+  }
+}

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/LargeSorterTest.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/LargeSorterTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import com.google.common.collect.Maps;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.LargeSorter;
+import org.apache.hadoop.mapreduce.MRJobConfig;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.util.Tool;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +57,7 @@ public class LargeSorterTest extends MRIntegrationTestBase {
   protected void updateRssConfiguration(Configuration jobConf) {
     jobConf.setInt(LargeSorter.NUM_MAP_TASKS, 1);
     jobConf.setInt(LargeSorter.MBS_PER_MAP, 256);
+    jobConf.set(MRJobConfig.MR_AM_COMMAND_OPTS, "-XX:+TraceClassLoading com.tencent.rss.test.FailoverAppMaster");
   }
 
   @Override

--- a/integration-test/mr/src/test/java/com/tencent/rss/test/MRIntegrationTestBase.java
+++ b/integration-test/mr/src/test/java/com/tencent/rss/test/MRIntegrationTestBase.java
@@ -144,6 +144,8 @@ public class MRIntegrationTestBase extends IntegrationTestBase {
       if (!prop.contains("classes") && !prop.contains("grpc") && !prop.contains("rss-")
         && !prop.contains("shuffle-storage")) {
         newProps = newProps + ":" + prop;
+      } else if (prop.contains("mr") && prop.contains("integration-test")) {
+        newProps = newProps + ":" + prop;
       }
     }
     System.setProperty("java.class.path", newProps);


### PR DESCRIPTION
### What changes were proposed in this pull request?
We increase a extra configuration to store rss configuration information, we don't modify the job.xml on the HDFS any more.

### Why are the changes needed?
If we don't have this patch, mr application cannot re-execute successfully. We will encounter the exception

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
new UT
