### PR TITLE
[Improvement] Optimize taskAttemptId format in MR application

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -45,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.ShuffleWriteClient;
 import com.tencent.rss.client.response.SendShuffleDataResult;
-import com.tencent.rss.client.util.ClientUtils;
 import com.tencent.rss.common.RssShuffleUtils;
 import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.hadoop.io.RawComparator;
 import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.hadoop.mapreduce.RssMRUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -293,7 +294,7 @@ public class SortWriteBufferManager<K, V> {
     final byte[] compressed = RssShuffleUtils.compressData(data);
     final long crc32 = ChecksumUtils.getCrc32(compressed);
     compressTime += System.currentTimeMillis() - start;
-    final long blockId = ClientUtils.getBlockId(partitionId, taskAttemptId, getNextSeqNo(partitionId));
+    final long blockId = RssMRUtils.getBlockId(partitionId, taskAttemptId, getNextSeqNo(partitionId));
     uncompressedDataLen += data.length;
     // add memory to indicate bytes which will be sent to shuffle server
     inSendListBytes.addAndGet(wb.getDataLength());

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
@@ -1,0 +1,28 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.hadoop.mapreduce;
+
+import com.tencent.rss.client.util.IdHelper;
+
+public class MRIdHelper implements IdHelper {
+
+  @Override
+  public long getTaskAttemptId(long blockId) {
+    return 0;
+  }
+}

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
@@ -15,6 +15,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package org.apache.hadoop.mapreduce;
 
 import com.tencent.rss.client.util.IdHelper;

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/MRIdHelper.java
@@ -23,6 +23,6 @@ public class MRIdHelper implements IdHelper {
 
   @Override
   public long getTaskAttemptId(long blockId) {
-    return 0;
+    return RssMRUtils.getTaskAttemptId(blockId);
   }
 }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -167,8 +167,12 @@ public class RssMRUtils {
   }
 
   public static long getBlockId(int partitionId, long taskAttemptId, int nextSeqNo) {
-    int attemptId = (int)(taskAttemptId >> (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
-    int atomicInt = (nextSeqNo << MAX_ATTEMPT_LENGTH) + attemptId;
+    long attemptId = taskAttemptId >> (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH);
+    if (attemptId <0 || attemptId > MAX_ATTEMPT_ID) {
+      throw new RuntimeException("Can't support attemptId [" + attemptId
+          + "], the max value should be " + MAX_ATTEMPT_ID);
+    }
+    long  atomicInt = (nextSeqNo << MAX_ATTEMPT_LENGTH) + attemptId;
     if (atomicInt < 0 || atomicInt > Constants.MAX_SEQUENCE_NO) {
       throw new RuntimeException("Can't support sequence [" + atomicInt
           + "], the max value should be " + Constants.MAX_SEQUENCE_NO);
@@ -180,7 +184,7 @@ public class RssMRUtils {
     long taskId = taskAttemptId - (attemptId << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
     if ( taskId < 0 ||  taskId > Constants.MAX_TASK_ATTEMPT_ID) {
       throw new RuntimeException("Can't support taskId["
-          + taskAttemptId + "], the max value should be " + Constants.MAX_TASK_ATTEMPT_ID);
+          + taskId + "], the max value should be " + Constants.MAX_TASK_ATTEMPT_ID);
     }
     return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
         + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) + taskId;
@@ -189,7 +193,7 @@ public class RssMRUtils {
   public static long getTaskAttemptId(long blockId) {
     long mapId = blockId & Constants.MAX_TASK_ATTEMPT_ID;
     long attemptId = (blockId >> (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH))
-        & Constants.MAX_TASK_ATTEMPT_ID;
+        & MAX_ATTEMPT_ID;
     return (attemptId << (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + mapId;
   }
 }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import com.tencent.rss.common.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
@@ -35,6 +34,7 @@ import com.tencent.rss.client.api.ShuffleWriteClient;
 import com.tencent.rss.client.factory.ShuffleClientFactory;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
+import com.tencent.rss.common.util.Constants;
 
 public class RssMRUtils {
 

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
+import com.tencent.rss.common.util.Constants;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
@@ -38,17 +39,15 @@ import com.tencent.rss.common.exception.RssException;
 public class RssMRUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(RssMRUtils.class);
-  private static int MAX_TASK_LENGTH = 19;
-  private static int MAX_ATTEMPT_LENGTH = 2;
-  private static long MAX_TASK_ID = (1 << MAX_TASK_LENGTH) - 1;
-  private static long MAX_ATTEMPT_ID = (1 << MAX_ATTEMPT_LENGTH) - 1;
+  private static final int MAX_ATTEMPT_LENGTH = 6;
+  private static final long MAX_ATTEMPT_ID = (1 << MAX_ATTEMPT_LENGTH) - 1;
 
   // Class TaskAttemptId have two field id and mapId, rss taskAttemptID have 21 bits,
   // mapId is 19 bits, id is 2 bits. MR have a trick logic, taskAttemptId will increase
   // 1000 * (appAttemptId - 1), so we will decrease it.
   public static long convertTaskAttemptIdToLong(TaskAttemptID taskAttemptID, int appAttemptId) {
     long lowBytes = taskAttemptID.getTaskID().getId();
-    if (lowBytes > MAX_TASK_ID) {
+    if (lowBytes > Constants.MAX_TASK_ATTEMPT_ID) {
       throw new RssException("TaskAttempt " + taskAttemptID + " low bytes " + lowBytes + " exceed");
     }
     if (appAttemptId < 1) {
@@ -58,7 +57,7 @@ public class RssMRUtils {
     if (highBytes > MAX_ATTEMPT_ID || highBytes < 0) {
       throw new RssException("TaskAttempt " + taskAttemptID + " high bytes " + highBytes + " exceed");
     }
-    return (highBytes << MAX_TASK_LENGTH) + lowBytes;
+    return (highBytes << (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + lowBytes;
   }
 
   public static TaskAttemptID createMRTaskAttemptId(
@@ -69,8 +68,9 @@ public class RssMRUtils {
     if (appAttemptId < 1) {
       throw new RssException("appAttemptId " + appAttemptId + " is wrong");
     }
-    TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & MAX_TASK_ID));
-    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >> MAX_TASK_LENGTH) + 1000 * (appAttemptId - 1));
+    TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & Constants.MAX_TASK_ATTEMPT_ID));
+    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >>
+        (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + 1000 * (appAttemptId - 1));
   }
 
   public static ShuffleWriteClient createShuffleClient(JobConf jobConf) {
@@ -164,5 +164,32 @@ public class RssMRUtils {
 
   public static String getString(JobConf rssJobConf, JobConf mrJobConf, String key, String defaultValue) {
     return rssJobConf.get(key, mrJobConf.get(key, defaultValue));
+  }
+
+  public static long getBlockId(int partitionId, long taskAttemptId, int nextSeqNo) {
+    int attemptId = (int)(taskAttemptId >> (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+    int atomicInt = (nextSeqNo << MAX_ATTEMPT_LENGTH) + attemptId;
+    if (atomicInt < 0 || atomicInt > Constants.MAX_SEQUENCE_NO) {
+      throw new RuntimeException("Can't support sequence [" + atomicInt
+          + "], the max value should be " + Constants.MAX_SEQUENCE_NO);
+    }
+    if (partitionId < 0 || partitionId > Constants.MAX_PARTITION_ID) {
+      throw new RuntimeException("Can't support partitionId["
+          + partitionId + "], the max value should be " + Constants.MAX_PARTITION_ID);
+    }
+    long taskId = taskAttemptId - (attemptId << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+    if ( taskId < 0 ||  taskId > Constants.MAX_TASK_ATTEMPT_ID) {
+      throw new RuntimeException("Can't support taskId["
+          + taskAttemptId + "], the max value should be " + Constants.MAX_TASK_ATTEMPT_ID);
+    }
+    return (atomicInt << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH))
+        + (partitionId << Constants.TASK_ATTEMPT_ID_MAX_LENGTH) + taskId;
+  }
+
+  public static long getTaskAttemptId(long blockId) {
+    long mapId = blockId & Constants.MAX_TASK_ATTEMPT_ID;
+    long attemptId = (blockId >> (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH))
+        & Constants.MAX_TASK_ATTEMPT_ID;
+    return (attemptId << (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + mapId;
   }
 }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRUtils.java
@@ -69,8 +69,8 @@ public class RssMRUtils {
       throw new RssException("appAttemptId " + appAttemptId + " is wrong");
     }
     TaskID taskID = new TaskID(jobID, taskType, (int)(rssTaskAttemptId & Constants.MAX_TASK_ATTEMPT_ID));
-    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId >>
-        (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + 1000 * (appAttemptId - 1));
+    return new TaskAttemptID(taskID, (int)(rssTaskAttemptId
+        >> (Constants.TASK_ATTEMPT_ID_MAX_LENGTH + Constants.PARTITION_ID_MAX_LENGTH)) + 1000 * (appAttemptId - 1));
   }
 
   public static ShuffleWriteClient createShuffleClient(JobConf jobConf) {
@@ -168,7 +168,7 @@ public class RssMRUtils {
 
   public static long getBlockId(int partitionId, long taskAttemptId, int nextSeqNo) {
     long attemptId = taskAttemptId >> (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH);
-    if (attemptId <0 || attemptId > MAX_ATTEMPT_ID) {
+    if (attemptId < 0 || attemptId > MAX_ATTEMPT_ID) {
       throw new RuntimeException("Can't support attemptId [" + attemptId
           + "], the max value should be " + MAX_ATTEMPT_ID);
     }
@@ -181,8 +181,9 @@ public class RssMRUtils {
       throw new RuntimeException("Can't support partitionId["
           + partitionId + "], the max value should be " + Constants.MAX_PARTITION_ID);
     }
-    long taskId = taskAttemptId - (attemptId << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
-    if ( taskId < 0 ||  taskId > Constants.MAX_TASK_ATTEMPT_ID) {
+    long taskId = taskAttemptId - (attemptId
+        << (Constants.PARTITION_ID_MAX_LENGTH + Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
+    if (taskId < 0 ||  taskId > Constants.MAX_TASK_ATTEMPT_ID) {
       throw new RuntimeException("Can't support taskId["
           + taskId + "], the max value should be " + Constants.MAX_TASK_ATTEMPT_ID);
     }

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssShuffle.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.mapred.ShuffleConsumerPlugin;
 import org.apache.hadoop.mapred.Task;
 import org.apache.hadoop.mapred.TaskStatus;
 import org.apache.hadoop.mapred.TaskUmbilicalProtocol;
+import org.apache.hadoop.mapreduce.MRIdHelper;
 import org.apache.hadoop.mapreduce.RssMRConfig;
 import org.apache.hadoop.mapreduce.RssMRUtils;
 import org.apache.hadoop.util.Progress;
@@ -172,7 +173,8 @@ public class RssShuffle<K, V> implements ShuffleConsumerPlugin<K, V>, ExceptionR
       }
       CreateShuffleReadClientRequest request = new CreateShuffleReadClientRequest(
         appId, 0, reduceId.getTaskID().getId(), storageType, basePath, indexReadLimit, readBufferSize,
-        partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, serverInfoList, readerJobConf);
+        partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, serverInfoList,
+        readerJobConf, new MRIdHelper());
       ShuffleReadClient shuffleReadClient = ShuffleClientFactory.getInstance().createShuffleReadClient(request);
       RssFetcher fetcher = new RssFetcher(mrJobConf, reduceId, taskStatus, merger, copyPhase, reporter, metrics,
         shuffleReadClient, blockIdBitmap.getLongCardinality());

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -36,7 +36,9 @@ public class RssMRUtilsTest {
   @Test
   public void TaskAttemptIdTest() {
     long taskAttemptId = 0x1000ad12;
-    TaskAttemptID mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, taskAttemptId, 1);
+    org.apache.hadoop.mapred.JobID jobID = new org.apache.hadoop.mapred.JobID();
+    TaskID taskId =  new TaskID(jobID, TaskType.MAP, (int) taskAttemptId);
+    TaskAttemptID mrTaskAttemptId = new TaskAttemptID(taskId, 3);
     boolean isException = false;
     try {
       RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
@@ -48,7 +50,7 @@ public class RssMRUtilsTest {
     mrTaskAttemptId = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, taskAttemptId, 1);
     long testId = RssMRUtils.convertTaskAttemptIdToLong(mrTaskAttemptId, 1);
     assertEquals(taskAttemptId, testId);
-    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 19));
+    TaskID taskID = new TaskID(new org.apache.hadoop.mapred.JobID(), TaskType.MAP, (int)(1 << 21));
     mrTaskAttemptId = new TaskAttemptID(taskID, 2);
     isException = false;
     try {

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/RssMRUtilsTest.java
@@ -36,7 +36,7 @@ public class RssMRUtilsTest {
   @Test
   public void TaskAttemptIdTest() {
     long taskAttemptId = 0x1000ad12;
-    org.apache.hadoop.mapred.JobID jobID = new org.apache.hadoop.mapred.JobID();
+    JobID jobID = new JobID();
     TaskID taskId =  new TaskID(jobID, TaskType.MAP, (int) taskAttemptId);
     TaskAttemptID mrTaskAttemptId = new TaskAttemptID(taskId, 3);
     boolean isException = false;
@@ -59,6 +59,20 @@ public class RssMRUtilsTest {
       isException = true;
     }
     assertTrue(isException);
+  }
+
+  @Test
+  public void BlockConvertTest() {
+    JobID jobID =  new JobID();
+    TaskID taskId =  new TaskID(jobID, TaskType.MAP, 233);
+    TaskAttemptID taskAttemptID = new TaskAttemptID(taskId, 1);
+    long taskAttemptId = RssMRUtils.convertTaskAttemptIdToLong(taskAttemptID, 1);
+    long blockId = RssMRUtils.getBlockId(1, taskAttemptId, 0);
+    long newTaskAttemptId = RssMRUtils.getTaskAttemptId(blockId);
+    assertEquals(taskAttemptId, newTaskAttemptId);
+    blockId = RssMRUtils.getBlockId(2, taskAttemptId, 2);
+    newTaskAttemptId = RssMRUtils.getTaskAttemptId(blockId);
+    assertEquals(taskAttemptId, newTaskAttemptId);
   }
 
   @Test

--- a/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
+++ b/client-spark/common/src/test/java/org/apache/spark/shuffle/reader/RssShuffleDataIteratorTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
 import com.tencent.rss.client.util.ClientUtils;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import com.tencent.rss.common.util.ChecksumUtils;
 import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.storage.handler.impl.HdfsShuffleWriteHandler;
@@ -86,7 +87,7 @@ public class RssShuffleDataIteratorTest extends AbstractRssReaderTest {
   private RssShuffleDataIterator getDataIterator(String basePath, Roaring64NavigableMap blockIdBitmap, Roaring64NavigableMap taskIdBitmap) {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(
         StorageType.HDFS.name(), "appId", 0, 1, 100, 2,
-        10, 10000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 10000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     return new RssShuffleDataIterator(KRYO_SERIALIZER, readClient,
         new ShuffleReadMetrics());
   }

--- a/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
@@ -23,6 +23,7 @@ import com.tencent.rss.client.api.ShuffleWriteClient;
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
 import com.tencent.rss.client.impl.ShuffleWriteClientImpl;
 import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
+import com.tencent.rss.client.util.DefaultIdHelper;
 
 public class ShuffleClientFactory {
 
@@ -47,6 +48,6 @@ public class ShuffleClientFactory {
         request.getPartitionId(), request.getIndexReadLimit(), request.getPartitionNumPerRange(),
         request.getPartitionNum(), request.getReadBufferSize(), request.getBasePath(),
         request.getBlockIdBitmap(), request.getTaskIdBitmap(), request.getShuffleServerInfoList(),
-        request.getHadoopConf());
+        request.getHadoopConf(), request.getIdHelper());
   }
 }

--- a/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
+++ b/client/src/main/java/com/tencent/rss/client/factory/ShuffleClientFactory.java
@@ -23,7 +23,6 @@ import com.tencent.rss.client.api.ShuffleWriteClient;
 import com.tencent.rss.client.impl.ShuffleReadClientImpl;
 import com.tencent.rss.client.impl.ShuffleWriteClientImpl;
 import com.tencent.rss.client.request.CreateShuffleReadClientRequest;
-import com.tencent.rss.client.util.DefaultIdHelper;
 
 public class ShuffleClientFactory {
 

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.tencent.rss.client.util.IdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
@@ -39,7 +40,6 @@ import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
 import com.tencent.rss.common.util.ChecksumUtils;
-import com.tencent.rss.common.util.Constants;
 import com.tencent.rss.common.util.RssUtils;
 import com.tencent.rss.storage.factory.ShuffleHandlerFactory;
 import com.tencent.rss.storage.handler.api.ClientReadHandler;
@@ -61,6 +61,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
   private AtomicLong copyTime = new AtomicLong(0);
   private AtomicLong crcCheckTime = new AtomicLong(0);
   private ClientReadHandler clientReadHandler;
+  private final IdHelper idHelper;
 
   public ShuffleReadClientImpl(
       String storageType,
@@ -75,11 +76,13 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
       Roaring64NavigableMap blockIdBitmap,
       Roaring64NavigableMap taskIdBitmap,
       List<ShuffleServerInfo> shuffleServerInfoList,
-      Configuration hadoopConf) {
+      Configuration hadoopConf,
+      IdHelper idHelper) {
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
     this.blockIdBitmap = blockIdBitmap;
     this.taskIdBitmap = taskIdBitmap;
+    this.idHelper = idHelper;
 
     CreateShuffleReadHandlerRequest request = new CreateShuffleReadHandlerRequest();
     request.setStorageType(storageType);
@@ -98,7 +101,7 @@ public class ShuffleReadClientImpl implements ShuffleReadClient {
 
     List<Long> removeBlockIds = Lists.newArrayList();
     blockIdBitmap.forEach(bid -> {
-      if (!taskIdBitmap.contains(bid & Constants.MAX_TASK_ATTEMPT_ID)) {
+      if (!taskIdBitmap.contains(idHelper.getTaskAttemptId(bid))) {
         removeBlockIds.add(bid);
       }
     });

--- a/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
+++ b/client/src/main/java/com/tencent/rss/client/impl/ShuffleReadClientImpl.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
-import com.tencent.rss.client.util.IdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
@@ -35,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;
+import com.tencent.rss.client.util.IdHelper;
 import com.tencent.rss.common.BufferSegment;
 import com.tencent.rss.common.ShuffleDataResult;
 import com.tencent.rss.common.ShuffleServerInfo;

--- a/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
@@ -20,11 +20,11 @@ package com.tencent.rss.client.request;
 
 import java.util.List;
 
-import com.tencent.rss.client.util.IdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import com.tencent.rss.client.util.DefaultIdHelper;
+import com.tencent.rss.client.util.IdHelper;
 import com.tencent.rss.common.ShuffleServerInfo;
 
 public class CreateShuffleReadClientRequest {

--- a/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
@@ -20,6 +20,8 @@ package com.tencent.rss.client.request;
 
 import java.util.List;
 
+import com.tencent.rss.client.util.DefaultIdHelper;
+import com.tencent.rss.client.util.IdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -40,11 +42,42 @@ public class CreateShuffleReadClientRequest {
   private Roaring64NavigableMap taskIdBitmap;
   private List<ShuffleServerInfo> shuffleServerInfoList;
   private Configuration hadoopConf;
+  private IdHelper idHelper;
 
-  public CreateShuffleReadClientRequest(String appId, int shuffleId, int partitionId, String storageType,
-      String basePath, int indexReadLimit, int readBufferSize, int partitionNumPerRange,
-      int partitionNum, Roaring64NavigableMap blockIdBitmap, Roaring64NavigableMap taskIdBitmap,
-      List<ShuffleServerInfo> shuffleServerInfoList, Configuration hadoopConf) {
+  public CreateShuffleReadClientRequest(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      String storageType,
+      String basePath,
+      int indexReadLimit,
+      int readBufferSize,
+      int partitionNumPerRange,
+      int partitionNum,
+      Roaring64NavigableMap blockIdBitmap,
+      Roaring64NavigableMap taskIdBitmap,
+      List<ShuffleServerInfo> shuffleServerInfoList,
+      Configuration hadoopConf) {
+    this(appId, shuffleId, partitionId, storageType, basePath, indexReadLimit, readBufferSize,
+        partitionNumPerRange, partitionNum, blockIdBitmap, taskIdBitmap, shuffleServerInfoList,
+        hadoopConf, new DefaultIdHelper());
+  }
+
+  public CreateShuffleReadClientRequest(
+      String appId,
+      int shuffleId,
+      int partitionId,
+      String storageType,
+      String basePath,
+      int indexReadLimit,
+      int readBufferSize,
+      int partitionNumPerRange,
+      int partitionNum,
+      Roaring64NavigableMap blockIdBitmap,
+      Roaring64NavigableMap taskIdBitmap,
+      List<ShuffleServerInfo> shuffleServerInfoList,
+      Configuration hadoopConf,
+      IdHelper idHelper) {
     this.appId = appId;
     this.shuffleId = shuffleId;
     this.partitionId = partitionId;
@@ -58,6 +91,7 @@ public class CreateShuffleReadClientRequest {
     this.taskIdBitmap = taskIdBitmap;
     this.shuffleServerInfoList = shuffleServerInfoList;
     this.hadoopConf = hadoopConf;
+    this.idHelper = idHelper;
   }
 
   public String getAppId() {
@@ -110,5 +144,9 @@ public class CreateShuffleReadClientRequest {
 
   public Configuration getHadoopConf() {
     return hadoopConf;
+  }
+
+  public IdHelper getIdHelper() {
+    return idHelper;
   }
 }

--- a/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
+++ b/client/src/main/java/com/tencent/rss/client/request/CreateShuffleReadClientRequest.java
@@ -20,11 +20,11 @@ package com.tencent.rss.client.request;
 
 import java.util.List;
 
-import com.tencent.rss.client.util.DefaultIdHelper;
 import com.tencent.rss.client.util.IdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import com.tencent.rss.client.util.DefaultIdHelper;
 import com.tencent.rss.common.ShuffleServerInfo;
 
 public class CreateShuffleReadClientRequest {

--- a/client/src/main/java/com/tencent/rss/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/com/tencent/rss/client/util/DefaultIdHelper.java
@@ -15,6 +15,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.tencent.rss.client.util;
 
 import com.tencent.rss.common.util.Constants;

--- a/client/src/main/java/com/tencent/rss/client/util/DefaultIdHelper.java
+++ b/client/src/main/java/com/tencent/rss/client/util/DefaultIdHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.tencent.rss.client.util;
+
+import com.tencent.rss.common.util.Constants;
+
+public class DefaultIdHelper implements IdHelper {
+  @Override
+  public long getTaskAttemptId(long blockId) {
+    return blockId & Constants.MAX_TASK_ATTEMPT_ID;
+  }
+}

--- a/client/src/main/java/com/tencent/rss/client/util/IdHelper.java
+++ b/client/src/main/java/com/tencent/rss/client/util/IdHelper.java
@@ -1,0 +1,24 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * Firestorm-Spark remote shuffle server available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * https://opensource.org/licenses/Apache-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.rss.client.util;
+
+public interface IdHelper {
+
+  long getTaskAttemptId(long blockId);
+}

--- a/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
+++ b/client/src/test/java/com/tencent/rss/client/impl/ShuffleReadClientImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.tencent.rss.client.TestUtils;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import com.tencent.rss.common.ShufflePartitionedBlock;
 import com.tencent.rss.common.util.ChecksumUtils;
 import com.tencent.rss.common.util.Constants;
@@ -65,7 +66,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
         blockIdBitmap);
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -74,7 +75,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
     blockIdBitmap.addLong(Constants.MAX_TASK_ATTEMPT_ID - 1);
     taskIdBitmap.addLong(Constants.MAX_TASK_ATTEMPT_ID - 1);
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     TestUtils.validateResult(readClient, expectedData);
     try {
       // can't find all expected block id, data loss
@@ -103,7 +104,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
-        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -137,7 +138,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
-        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -157,7 +158,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
-        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     Path dataFile = new Path(basePath + "/appId/0/0-1/test1_0.data");
     // data file is deleted after readClient checkExpectedBlockIds
     fs.delete(new Path(basePath + "/appId/0/0-1/test1_0.data"), true);
@@ -193,7 +194,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
-        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     // index file is deleted after iterator initialization, it should be ok, all index infos are read already
     Path indexFile = new Path(basePath + "/appId/0/0-1/test_0.index");
     fs.delete(indexFile, true);
@@ -221,10 +222,10 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient1 = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 0, 100, 2, 10, 100,
-        basePath, blockIdBitmap1, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap1, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     ShuffleReadClientImpl readClient2 = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 100,
-        basePath, blockIdBitmap2, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap2, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     TestUtils.validateResult(readClient1, expectedData1);
     readClient1.checkProcessedBlockIds();
     readClient1.close();
@@ -247,7 +248,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
-        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     // crc32 is incorrect
     try (MockedStatic<ChecksumUtils> checksumUtilsMock = Mockito.mockStatic(ChecksumUtils.class)) {
       checksumUtilsMock.when(() -> ChecksumUtils.getCrc32((ByteBuffer) any())).thenReturn(-1L);
@@ -270,7 +271,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 1, 100, 2, 10, 1000,
         "basePath", Roaring64NavigableMap.bitmapOf(), Roaring64NavigableMap.bitmapOf(),
-        Lists.newArrayList(), new Configuration());
+        Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     assertNull(readClient.readShuffleBlockData());
     readClient.checkProcessedBlockIds();
   }
@@ -293,7 +294,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         "appId", 0, 0, 100, 2, 10, 100,
-        basePath, wrongBlockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        basePath, wrongBlockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     assertNull(readClient.readShuffleBlockData());
     try {
       readClient.checkProcessedBlockIds();
@@ -316,35 +317,35 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     // test with different indexReadLimit to validate result
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 1, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 2, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 3, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 10, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 11, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -366,7 +367,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     assertEquals(15, readClient.getProcessedBlockIds().getLongCardinality());
@@ -392,7 +393,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     assertEquals(20, readClient.getProcessedBlockIds().getLongCardinality());
@@ -415,7 +416,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+        10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     assertEquals(15, readClient.getProcessedBlockIds().getLongCardinality());
@@ -440,7 +441,7 @@ public class ShuffleReadClientImplTest extends HdfsTestBase {
     writeTestData(writeHandler, 5, 30, 0, Maps.newHashMap(), Roaring64NavigableMap.bitmapOf());
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(), "appId", 0, 1, 100, 1,
-      10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration());
+      10, 1000, basePath, blockIdBitmap, taskIdBitmap, Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
 
     TestUtils.validateResult(readClient, expectedData);
     assertEquals(25, readClient.getProcessedBlockIds().getLongCardinality());

--- a/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/DiskErrorToleranceTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -110,7 +111,7 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
     shuffleServerClient.finishShuffle(rf1);
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         appId, 0, 0, 100, 1, 10, 1000, null,
-        blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1), shuffleServerInfo, conf);
+        blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1), shuffleServerInfo, conf, new DefaultIdHelper());
     validateResult(readClient, expectedData);
 
     File shuffleData = new File(data2, appId);
@@ -138,7 +139,7 @@ public class DiskErrorToleranceTest extends ShuffleReadWriteBase {
 
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         appId, 0, 0, 100, 1, 10, 1000, null,
-        blockIdBitmap2, Roaring64NavigableMap.bitmapOf(2), shuffleServerInfo, conf);
+        blockIdBitmap2, Roaring64NavigableMap.bitmapOf(2), shuffleServerInfo, conf, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     shuffleData = new File(data1, appId);
     assertTrue(shuffleData.exists());

--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageFaultToleranceTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.apache.hadoop.hdfs.server.common.HdfsServerConstants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,7 +242,7 @@ public class MultiStorageFaultToleranceTest extends ShuffleReadWriteBase {
                                 Roaring64NavigableMap taskBitmap, Map<Long, byte[]> expectedData) {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, shuffleId, partitionId, 100, 1, 10, 1000, REMOTE_STORAGE, blockBitmap, taskBitmap,
-        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf);
+        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf, new DefaultIdHelper());
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
     while (csb != null && csb.getByteBuffer() != null) {

--- a/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/MultiStorageTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.Uninterruptibles;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -222,22 +223,22 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 0, 100, 1, 10, 1000, REMOTE_STORAGE,
-        blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), conf);
+        blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), conf, new DefaultIdHelper());
     validateResult(readClient, expectedData, blockIdBitmap1);
 
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 1, 100, 1, 10, 1000, REMOTE_STORAGE,
-        blockIdBitmap2, Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), conf);
+        blockIdBitmap2, Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), conf, new DefaultIdHelper());
     validateResult(readClient, expectedData, blockIdBitmap2);
 
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 2, 100, 1, 10, 1000, REMOTE_STORAGE,
-        blockIdBitmap3, Roaring64NavigableMap.bitmapOf(2), Lists.newArrayList(), conf);
+        blockIdBitmap3, Roaring64NavigableMap.bitmapOf(2), Lists.newArrayList(), conf, new DefaultIdHelper());
     validateResult(readClient, expectedData, blockIdBitmap3);
 
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 4, 100, 1, 10, 1000, REMOTE_STORAGE,
-        blockIdBitmap4, Roaring64NavigableMap.bitmapOf(3), Lists.newArrayList(), conf);
+        blockIdBitmap4, Roaring64NavigableMap.bitmapOf(3), Lists.newArrayList(), conf, new DefaultIdHelper());
     validateResult(readClient, expectedData, blockIdBitmap4);
   }
 
@@ -368,7 +369,7 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 0, 100, 1, 10, 1000, REMOTE_STORAGE,
         blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1),
-        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf);
+        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf, new DefaultIdHelper());
 
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
@@ -468,7 +469,7 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 0, 0, 100, 1, 10, 1000, REMOTE_STORAGE,
         blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1, 2),
-        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf);
+        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf, new DefaultIdHelper());
 
     CompressedShuffleBlock csb = readClient.readShuffleBlockData();
     Roaring64NavigableMap matched = Roaring64NavigableMap.bitmapOf();
@@ -666,7 +667,7 @@ public class MultiStorageTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE_HDFS_2.name(),
         appId, 2, 0, 100, 1, 10, 1000, REMOTE_STORAGE,
         blockIdBitmap1, Roaring64NavigableMap.bitmapOf(1),
-        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf);
+        Lists.newArrayList(new ShuffleServerInfo("test", LOCALHOST, SHUFFLE_SERVER_PORT)), conf, new DefaultIdHelper());
     validateResult(readClient, expectedData, blockIdBitmap1);
     try {
       sendSinglePartitionToShuffleServer(appId, 3, 1,2, blocks2);

--- a/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/QuorumTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -219,7 +220,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, fakedShuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, fakedShuffleServerInfo2), null, new DefaultIdHelper());
     // The data should be read
     validateResult(readClient, expectedData);
 
@@ -308,7 +309,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -439,7 +440,7 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -566,21 +567,21 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo2), null, new DefaultIdHelper());
     assertTrue(readClient.readShuffleBlockData() == null);
 
     // we can read blocks from server 0,1
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
 
     // we can also read blocks from server 0,1,2
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -609,21 +610,21 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo1), null);
+      Lists.newArrayList(shuffleServerInfo1), null, new DefaultIdHelper());
     assertTrue(readClient.readShuffleBlockData() == null);
 
     // we can read blocks from server 2, which is sent in to secondary round
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
 
     // we can read blocks from server 0,1,2
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, fakedShuffleServerInfo1, shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, fakedShuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -652,14 +653,14 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null);
+      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null, new DefaultIdHelper());
     assertTrue(readClient.readShuffleBlockData() == null);
 
     // we can also read blocks from server 0,1,2
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -688,14 +689,14 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo1), null);
+      Lists.newArrayList(shuffleServerInfo1), null, new DefaultIdHelper());
    assertTrue(readClient.readShuffleBlockData() == null);
 
     // we can also read blocks from server 3,4
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null);
+      Lists.newArrayList(shuffleServerInfo3, shuffleServerInfo4), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -724,14 +725,14 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo4), null);
+      Lists.newArrayList(shuffleServerInfo4), null, new DefaultIdHelper());
     assertTrue(readClient.readShuffleBlockData() == null);
 
     // we can read blocks from server 0,1,2,3
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2, shuffleServerInfo3), null);
+      Lists.newArrayList(shuffleServerInfo0, shuffleServerInfo1, shuffleServerInfo2, shuffleServerInfo3), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 
@@ -759,21 +760,21 @@ public class QuorumTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo0), null);
+      Lists.newArrayList(shuffleServerInfo0), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
 
     // we can also read blocks from server 1
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo1), null);
+      Lists.newArrayList(shuffleServerInfo1), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
 
     // we can also read blocks from server 2
     readClient = new ShuffleReadClientImpl(StorageType.MEMORY_LOCALFILE.name(),
       testAppId, 0, 0, 100, 1,
       10, 1000, "", blockIdBitmap, taskIdBitmap,
-      Lists.newArrayList(shuffleServerInfo2), null);
+      Lists.newArrayList(shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
   }
 

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithHdfsTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleServerWithHdfsTest.java
@@ -24,6 +24,7 @@ import java.util.Map.Entry;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -102,7 +103,7 @@ public class ShuffleServerWithHdfsTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         appId, 0, 0, 100, 2, 10, 1000,
-        dataBasePath, bitmaps[0], Roaring64NavigableMap.bitmapOf(0), Lists.newArrayList(), new Configuration());
+        dataBasePath, bitmaps[0], Roaring64NavigableMap.bitmapOf(0), Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     assertNull(readClient.readShuffleBlockData());
     shuffleServerClient.finishShuffle(rfsr);
 
@@ -131,22 +132,22 @@ public class ShuffleServerWithHdfsTest extends ShuffleReadWriteBase {
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         appId, 0, 0, 100, 2, 10, 1000,
-        dataBasePath, bitmaps[0], Roaring64NavigableMap.bitmapOf(0), Lists.newArrayList(), new Configuration());
+        dataBasePath, bitmaps[0], Roaring64NavigableMap.bitmapOf(0), Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     validateResult(readClient, expectedData, bitmaps[0]);
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         appId, 0, 1, 100, 2, 10, 1000,
-        dataBasePath, bitmaps[1], Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), new Configuration());
+        dataBasePath, bitmaps[1], Roaring64NavigableMap.bitmapOf(1), Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     validateResult(readClient, expectedData, bitmaps[1]);
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         appId, 0, 2, 100, 2, 10, 1000,
-        dataBasePath, bitmaps[2], Roaring64NavigableMap.bitmapOf(2), Lists.newArrayList(), new Configuration());
+        dataBasePath, bitmaps[2], Roaring64NavigableMap.bitmapOf(2), Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     validateResult(readClient, expectedData, bitmaps[2]);
 
     readClient = new ShuffleReadClientImpl(StorageType.HDFS.name(),
         appId, 0, 3, 100, 2, 10, 1000,
-        dataBasePath, bitmaps[3], Roaring64NavigableMap.bitmapOf(3), Lists.newArrayList(), new Configuration());
+        dataBasePath, bitmaps[3], Roaring64NavigableMap.bitmapOf(3), Lists.newArrayList(), new Configuration(), new DefaultIdHelper());
     validateResult(readClient, expectedData, bitmaps[3]);
   }
 

--- a/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
+++ b/integration-test/common/src/test/java/com/tencent/rss/test/ShuffleWithRssClientTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -226,7 +227,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
         10, 1000, "", blockIdBitmap, taskIdBitmap,
-        Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2), null);
+        Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
 
     try {
       readClient.readShuffleBlockData();
@@ -242,7 +243,7 @@ public class ShuffleWithRssClientTest extends ShuffleReadWriteBase {
     assertTrue(commitResult);
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
         10, 1000, "", blockIdBitmap, taskIdBitmap,
-        Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2), null);
+        Lists.newArrayList(shuffleServerInfo1, shuffleServerInfo2), null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();

--- a/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkClientWithLocalTest.java
+++ b/integration-test/spark-common/src/test/java/com/tencent/rss/test/SparkClientWithLocalTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
+import com.tencent.rss.client.util.DefaultIdHelper;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -97,7 +98,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     blockIdBitmap.addLong((1 << Constants.TASK_ATTEMPT_ID_MAX_LENGTH));
     ShuffleReadClientImpl readClient;
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
-        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     try {
       // can't find all expected block id, data loss
@@ -128,7 +129,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 0, 100, 1, 10, 1000,
-        "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
 
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -149,7 +150,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 0, 100, 1, 10, 1000,
-        "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
     FileUtils.deleteDirectory(new File(DATA_DIR1.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
     FileUtils.deleteDirectory(new File(DATA_DIR2.getAbsolutePath() + "/" + testAppId + "/0/0-0"));
     // sleep to wait delete operation
@@ -188,10 +189,10 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient1 = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 0, 100, 2, 10, 100,
-        "", blockIdBitmap1, taskIdBitmap, shuffleServerInfo, null);
+        "", blockIdBitmap1, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
     ShuffleReadClientImpl readClient2 = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 1, 100, 2, 10, 100,
-        "", blockIdBitmap2, taskIdBitmap, shuffleServerInfo, null);
+        "", blockIdBitmap2, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
     validateResult(readClient1, expectedData1);
     readClient1.checkProcessedBlockIds();
     readClient1.close();
@@ -207,7 +208,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 1, 100, 2, 10, 1000,
         "", Roaring64NavigableMap.bitmapOf(), Roaring64NavigableMap.bitmapOf(),
-        shuffleServerInfo, null);
+        shuffleServerInfo, null, new DefaultIdHelper());
     assertNull(readClient.readShuffleBlockData());
     readClient.checkProcessedBlockIds();
   }
@@ -232,7 +233,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
         testAppId, 0, 0, 100, 1, 10, 100,
-        "", wrongBlockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        "", wrongBlockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
     assertNull(readClient.readShuffleBlockData());
     try {
       readClient.checkProcessedBlockIds();
@@ -265,7 +266,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
-        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
 
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -299,7 +300,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
 
     // unexpected taskAttemptId should be filtered
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
-        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null);
+        10, 1000, "", blockIdBitmap, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
 
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -326,7 +327,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     // test with un-changed expected blockId
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
         10, 1000, "", beforeAdded, taskIdBitmap,
-        shuffleServerInfo, null);
+        shuffleServerInfo, null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
@@ -334,7 +335,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     // test with changed expected blockId
     readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(), testAppId, 0, 0, 100, 1,
         10, 1000, "", blockIdBitmap, taskIdBitmap,
-        shuffleServerInfo, null);
+        shuffleServerInfo, null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();
@@ -364,7 +365,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
     sendTestData(testAppId, blocks);
     ShuffleReadClientImpl readClient = new ShuffleReadClientImpl(StorageType.LOCALFILE.name(),
       testAppId, 0, 0, 100, 1, 10, 1000,
-      "", expectedBlockIds, taskIdBitmap, shuffleServerInfo, null);
+      "", expectedBlockIds, taskIdBitmap, shuffleServerInfo, null, new DefaultIdHelper());
 
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
@@ -414,7 +415,7 @@ public class SparkClientWithLocalTest extends ShuffleReadWriteBase {
         blockIdBitmap,
         taskIdBitmap,
         shuffleServerInfo,
-        null);
+        null, new DefaultIdHelper());
     validateResult(readClient, expectedData);
     readClient.checkProcessedBlockIds();
     readClient.close();


### PR DESCRIPTION
### What changes were proposed in this pull request?
We use high bits to express task attempt times, task attempt times don't vary frequently. So we should not increase memory of bitmap.

### Why are the changes needed?
In our production environment, task often will be preempted. Four times is not enough, so we increase max attempts to  64.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Exist UT and manual test