### PR TITLE
[Bugfix] In MR, OBSOLETE/FAILED/KILLED event will not revoke success attempts

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -166,7 +166,7 @@ public class SortWriteBufferManager<K, V> {
     if (length > maxMemSize) {
       throw new RssException("record is too big");
     }
-    LOG.debug("memoryUsedSize {} increase {}", memoryUsedSize, length);
+    LOG.info("memoryUsedSize {} increase {}", memoryUsedSize, length);
     memoryUsedSize.addAndGet(length);
     if (memoryUsedSize.get() > maxMemSize * memoryThreshold
       && inSendListBytes.get() <= maxMemSize * sendThreshold) {
@@ -223,7 +223,7 @@ public class SortWriteBufferManager<K, V> {
         } finally {
           try {
             memoryLock.lock();
-            LOG.debug("memoryUsedSize {} decrease {}", memoryUsedSize, size);
+            LOG.info("memoryUsedSize {} decrease {}", memoryUsedSize, size);
             memoryUsedSize.addAndGet(-size);
             inSendListBytes.addAndGet(-size);
             full.signalAll();

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/EvenFetcherTest.java
@@ -207,17 +207,12 @@ public class EvenFetcherTest {
     RssEventFetcher ef =
       new RssEventFetcher(1, tid, umbilical, jobConf, MAX_EVENTS_TO_FETCH);
 
+    // OBSOLETE/FAILED/KILLED event will not revoke successful attempts
     Roaring64NavigableMap expected = Roaring64NavigableMap.bitmapOf();
     for (int mapIndex = 0; mapIndex < mapTaskNum; mapIndex++) {
-      if (!tipFailed.contains(mapIndex) && !obsoleted.contains(mapIndex)) {
+      if (!tipFailed.contains(mapIndex)) {
         long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
           new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 0), 1);
-        expected.addLong(rssTaskId);
-      }
-      if (obsoleted.contains(mapIndex)) {
-        long rssTaskId = RssMRUtils.convertTaskAttemptIdToLong(
-          new TaskAttemptID("12345", 1, TaskType.MAP, mapIndex, 1),
-            1);
         expected.addLong(rssTaskId);
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
In MR, OBSOLETE/FAILED/KILLED event will not revoke success attempts.


### Why are the changes needed?
Different from default MR shuffle, in rss shuffle, OBSOLETE/FAILED/KILLED events, 
we should not revoke successful attempts (maybe caused by "bad node" after map success).
This is because these map tasks have already sent their data to rss server.


### Does this PR introduce _any_ user-facing change?
 No


### How was this patch tested?
Update Previous UT 
