### PR TITLE
[Bugfix] Fix mapTask oom problems

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/RssMapOutputCollector.java
@@ -68,6 +68,13 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
     partitions = mrJobConf.getNumReduceTasks();
     MapTask mapTask = context.getMapTask();
     JobConf rssJobConf = new JobConf(RssMRConfig.RSS_CONF_FILE);
+    double sortThreshold = RssMRUtils.getDouble(rssJobConf, mrJobConf, RssMRConfig.RSS_CLIENT_SORT_MEMORY_USE_THRESHOLD,
+        RssMRConfig.RSS_CLIENT_DEFAULT_SORT_MEMORY_USE_THRESHOLD);
+    if (sortThreshold <= 0 || Double.compare(sortThreshold, 1.0) > 0) {
+      throw new IOException(
+          "Invalid  sort memory use threshold : " + sortThreshold);
+    }
+
     int batch = RssMRUtils.getInt(rssJobConf, mrJobConf, RssMRConfig.RSS_CLIENT_BATCH_TRIGGER_NUM,
         RssMRConfig.RSS_CLIENT_DEFAULT_BATCH_TRIGGER_NUM);
     RawComparator<K> comparator = mrJobConf.getOutputKeyComparator();
@@ -99,8 +106,10 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
         RssMRConfig.RSS_CLIENT_DEFAULT_MAX_SEGMENT_SIZE);
     int sendThreadNum = RssMRUtils.getInt(rssJobConf, mrJobConf, RssMRConfig.RSS_CLIENT_SEND_THREAD_NUM,
         RssMRConfig.RSS_CLIENT_DEFAULT_SEND_THREAD_NUM);
+    long maxBufferSize = RssMRUtils.getLong(rssJobConf, mrJobConf, RssMRConfig.RSS_WRITER_BUFFER_SIZE,
+        RssMRConfig.RSS_WRITER_BUFFER_SIZE_DEFAULT_VALUE);
     bufferManager = new SortWriteBufferManager(
-        (long)ByteUnit.MiB.toBytes(sortmb),
+        (long)(ByteUnit.MiB.toBytes(sortmb) * sortThreshold),
         taskAttemptId,
         batch,
         serializationFactory.getSerializer(keyClass),
@@ -121,7 +130,8 @@ public class RssMapOutputCollector<K extends Object, V extends Object>
         numMaps,
         isMemoryShuffleEnabled(storageType),
         sendThreadNum,
-        sendThreshold);
+        sendThreshold,
+        1024000L);
   }
 
   private Map<Integer, List<ShuffleServerInfo>> createAssignmentMap(JobConf jobConf) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBuffer.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBuffer.java
@@ -80,6 +80,11 @@ public class SortWriteBuffer<K, V> extends OutputStream  {
     return keyLength + valueLength;
   }
 
+  public void clear() {
+    buffers.clear();
+    records.clear();
+  }
+
   public synchronized byte[] getData() {
     int extraSize = 0;
     for (Record<K> record : records) {

--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -67,8 +67,8 @@ public class SortWriteBufferManager<K, V> {
   private final int batch;
   private final AtomicLong inSendListBytes = new AtomicLong(0);
   private final Map<Integer, List<ShuffleServerInfo>> partitionToServers;
-  private double memoryThreshold;
-  private double sendThreshold;
+  private final double memoryThreshold;
+  private final double sendThreshold;
   private final ReentrantLock memoryLock = new ReentrantLock();
   private final Condition full = memoryLock.newCondition();
   private final Serializer<K> keySerializer;
@@ -84,11 +84,12 @@ public class SortWriteBufferManager<K, V> {
   private final Set<Long> allBlockIds = Sets.newConcurrentHashSet();
   private final int bitmapSplitNum;
   private final Map<Integer, List<Long>> partitionToBlocks = Maps.newConcurrentMap();
-  private long maxSegmentSize;
+  private final long maxSegmentSize;
   private final boolean isMemoryShuffleEnabled;
   private final int numMaps;
   private long copyTime = 0;
   private long sortTime = 0;
+  private final long maxBufferSize;
   private final ExecutorService sendExecutorService;
 
   public SortWriteBufferManager(
@@ -113,7 +114,7 @@ public class SortWriteBufferManager<K, V> {
       int numMaps,
       boolean isMemoryShuffleEnabled,
       int sendThreadNum,
-      double sendThreshold) {
+      double sendThreshold, long maxBufferSize) {
     this.maxMemSize = maxMemSize;
     this.taskAttemptId = taskAttemptId;
     this.batch = batch;
@@ -135,6 +136,7 @@ public class SortWriteBufferManager<K, V> {
     this.numMaps = numMaps;
     this.isMemoryShuffleEnabled = isMemoryShuffleEnabled;
     this.sendThreshold = sendThreshold;
+    this.maxBufferSize = maxBufferSize;
     this.sendExecutorService  = Executors.newFixedThreadPool(
         sendThreadNum,
         new ThreadFactoryBuilder()
@@ -152,7 +154,7 @@ public class SortWriteBufferManager<K, V> {
         full.await();
       }
     } finally {
-      memoryLock.unlock();;
+      memoryLock.unlock();
     }
 
     if (!buffers.containsKey(partitionId)) {
@@ -168,12 +170,25 @@ public class SortWriteBufferManager<K, V> {
     }
     LOG.debug("memoryUsedSize {} increase {}", memoryUsedSize, length);
     memoryUsedSize.addAndGet(length);
+    if (buffer.getDataLength() > maxBufferSize) {
+      if (waitSendBuffers.remove(buffer)) {
+        sendBufferToServers(buffer);
+      } else {
+        LOG.error("waitSendBuffers don't contain buffer {}", buffer);
+      }
+    }
     if (memoryUsedSize.get() > maxMemSize * memoryThreshold
       && inSendListBytes.get() <= maxMemSize * sendThreshold) {
       sendBuffersToServers();
     }
     mapOutputRecordCounter.increment(1);
     mapOutputByteCounter.increment(length);
+  }
+
+  private void sendBufferToServers(SortWriteBuffer<K, V> buffer) {
+    List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
+    prepareBufferForSend(shuffleBlocks, buffer);
+    sendShuffleBlocks(shuffleBlocks);
   }
 
   // Only for test
@@ -188,32 +203,38 @@ public class SortWriteBufferManager<K, V> {
     if (batch > waitSendBuffers.size()) {
       sendSize = waitSendBuffers.size();
     }
-    List<SortWriteBuffer<K, V>> selectBuffers = Lists.newArrayList();
     Iterator<SortWriteBuffer<K, V>> iterator = waitSendBuffers.iterator();
     int index = 0;
+    List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
     while (iterator.hasNext() && index < sendSize) {
-      selectBuffers.add(iterator.next());
+      SortWriteBuffer buffer = iterator.next();
+      prepareBufferForSend(shuffleBlocks, buffer);
       iterator.remove();
       index++;
     }
-    List<ShuffleBlockInfo> shuffleBlocks = Lists.newArrayList();
-    for (SortWriteBuffer buffer : selectBuffers) {
-      buffers.remove(buffer.getPartitionId());
-      ShuffleBlockInfo block = createShuffleBlock(buffer);
-      shuffleBlocks.add(block);
-      allBlockIds.add(block.getBlockId());
-      if (!partitionToBlocks.containsKey(block.getPartitionId())) {
-        partitionToBlocks.putIfAbsent(block.getPartitionId(), Lists.newArrayList());
-      }
-      partitionToBlocks.get(block.getPartitionId()).add(block.getBlockId());
+    sendShuffleBlocks(shuffleBlocks);
+  }
+
+  private void prepareBufferForSend(List<ShuffleBlockInfo> shuffleBlocks, SortWriteBuffer buffer) {
+    buffers.remove(buffer.getPartitionId());
+    ShuffleBlockInfo block = createShuffleBlock(buffer);
+    buffer.clear();
+    shuffleBlocks.add(block);
+    allBlockIds.add(block.getBlockId());
+    if (!partitionToBlocks.containsKey(block.getPartitionId())) {
+      partitionToBlocks.putIfAbsent(block.getPartitionId(), Lists.newArrayList());
     }
+    partitionToBlocks.get(block.getPartitionId()).add(block.getBlockId());
+  }
+
+  private void sendShuffleBlocks(List<ShuffleBlockInfo> shuffleBlocks) {
     sendExecutorService.submit(new Runnable() {
       @Override
       public void run() {
         long size = 0;
         try {
           for (ShuffleBlockInfo block : shuffleBlocks) {
-             size += block.getFreeMemory();
+            size += block.getFreeMemory();
           }
           SendShuffleDataResult result = shuffleWriteClient.sendShuffleData(appId, shuffleBlocks);
           successBlockIds.addAll(result.getSuccessBlockIds());
@@ -341,7 +362,7 @@ public class SortWriteBufferManager<K, V> {
 
   // it's run in single thread, and is not thread safe
   private int getNextSeqNo(int partitionId) {
-    partitionToSeqNo.putIfAbsent(partitionId, new Integer(0));
+    partitionToSeqNo.putIfAbsent(partitionId, 0);
     int seqNo = partitionToSeqNo.get(partitionId);
     partitionToSeqNo.put(partitionId, seqNo + 1);
     return seqNo;

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/RssMRConfig.java
@@ -70,6 +70,12 @@ public class RssMRConfig {
   public static final String RSS_CLIENT_BATCH_TRIGGER_NUM =
       MR_RSS_CONFIG_PREFIX + "rss.client.batch.trigger.num";
   public static final int RSS_CLIENT_DEFAULT_BATCH_TRIGGER_NUM = 50;
+  public static final String RSS_CLIENT_SORT_MEMORY_USE_THRESHOLD =
+      MR_RSS_CONFIG_PREFIX + "rss.client.sort.memory.use.threshold";
+  public static final String RSS_WRITER_BUFFER_SIZE =
+      MR_RSS_CONFIG_PREFIX + RssClientConfig.RSS_WRITER_BUFFER_SIZE;
+  public static final long RSS_WRITER_BUFFER_SIZE_DEFAULT_VALUE = 1024 * 1024 * 14;
+  public static final double RSS_CLIENT_DEFAULT_SORT_MEMORY_USE_THRESHOLD = 0.9f;
   public static final String RSS_CLIENT_MEMORY_THRESHOLD =
       MR_RSS_CONFIG_PREFIX + "rss.client.memory.threshold";
   public static final double RSS_CLIENT_DEFAULT_MEMORY_THRESHOLD = 0.8f;

--- a/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapred/SortWriteBufferManagerTest.java
@@ -79,7 +79,8 @@ public class SortWriteBufferManagerTest {
         1000,
         true,
         5,
-        0.2f);
+        0.2f,
+        1024000L);
     Random random = new Random();
     for (int i = 0; i < 1000; i++) {
       byte[] key = new byte[20];
@@ -127,7 +128,8 @@ public class SortWriteBufferManagerTest {
         1000,
         true,
         5,
-        0.2f);
+        0.2f,
+        1024000L);
     byte[] key = new byte[20];
     byte[] value = new byte[1024];
     random.nextBytes(key);
@@ -174,7 +176,8 @@ public class SortWriteBufferManagerTest {
         2000,
         true,
         5,
-        0.2f);
+        0.2f,
+        1024000L);
     Random random = new Random();
     for (int i = 0; i < 1000; i++) {
       byte[] key = new byte[20];

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -218,7 +218,8 @@ public class FetcherTest {
       2000,
       true,
         5,
-        0.2f);
+        0.2f,
+        1024000L);
 
     for (String key : keysToValues.keySet()) {
       String value = keysToValues.get(key);

--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/RssSparkConfig.java
@@ -31,7 +31,8 @@ public class RssSparkConfig {
       SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_PARTITION_NUM_PER_RANGE;
   public static final int RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE =
       RssClientConfig.RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE;
-  public static final String RSS_WRITER_BUFFER_SIZE = SPARK_RSS_CONFIG_PREFIX + "rss.writer.buffer.size";
+  public static final String RSS_WRITER_BUFFER_SIZE =
+      SPARK_RSS_CONFIG_PREFIX + RssClientConfig.RSS_WRITER_BUFFER_SIZE;
   public static final String RSS_WRITER_BUFFER_SIZE_DEFAULT_VALUE = "3m";
   public static final String RSS_WRITER_SERIALIZER_BUFFER_SIZE =
       SPARK_RSS_CONFIG_PREFIX + "rss.writer.serializer.buffer.size";

--- a/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
+++ b/client/src/main/java/com/tencent/rss/client/util/RssClientConfig.java
@@ -43,7 +43,7 @@ public class RssClientConfig {
   public static final long RSS_CLIENT_SEND_CHECK_INTERVAL_MS_DEFAULT_VALUE = 500;
   public static final String RSS_CLIENT_SEND_CHECK_TIMEOUT_MS = "rss.client.send.check.timeout.ms";
   public static final long RSS_CLIENT_SEND_CHECK_TIMEOUT_MS_DEFAULT_VALUE = 60 * 1000 * 10;
-
+  public static final String RSS_WRITER_BUFFER_SIZE = "rss.writer.buffer.size";
   public static final String RSS_PARTITION_NUM_PER_RANGE = "rss.partitionNum.per.range";
   public static final int RSS_PARTITION_NUM_PER_RANGE_DEFAULT_VALUE = 1;
   public static final String RSS_REMOTE_STORAGE_PATH = "rss.remote.storage.path";


### PR DESCRIPTION
### What changes were proposed in this pull request?
We do two things:
1. increase partition level memory limit, If partition buffer memory exceed this limit, we will send this buffer.
2. decrease temporary memory, when we don't need the buffer, we will release this buffer immediately.

### Why are the changes needed?
If we don't have this patch, we will encounter oom problems

### Does this PR introduce _any_ user-facing change?
Yes, we increase two configuration
mapreduce.rss.writer.buffer.size means partition level memory limit,
mapreduce.rss.client.memory.threshold means that we can use memory percentage of total sort memory.

### How was this patch tested?
New UT
