### PR TITLE
[Improvement] Reuse the codec from a pool

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
@@ -25,10 +25,10 @@ import java.lang.reflect.Field;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.io.IOUtils;
-
-import com.tencent.rss.common.exception.RssException;
 import org.apache.hadoop.io.compress.CodecPool;
 import org.apache.hadoop.io.compress.Decompressor;
+
+import com.tencent.rss.common.exception.RssException;
 
 // In MR shuffle, MapOutput encapsulates the logic to fetch map task's output data via http.
 // So, in RSS, we should bypass this logic, and directly write data to MapOutput.

--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/task/reduce/RssBypassWriter.java
@@ -55,18 +55,6 @@ public class RssBypassWriter {
     }
   }
 
-  static Decompressor getDecompressor(InMemoryMapOutput inMemoryMapOutput) {
-    try {
-      Class clazz = Class.forName(InMemoryMapOutput.class.getName());
-      Field deCompressorField = clazz.getDeclaredField("decompressor");
-      deCompressorField.setAccessible(true);
-      Decompressor decompressor = (Decompressor) deCompressorField.get(inMemoryMapOutput);
-      return decompressor;
-    } catch (Exception e) {
-      throw new RssException("Get Decompressor fail " + e.getMessage());
-    }
-  }
-
   private static void write(InMemoryMapOutput inMemoryMapOutput, byte[] buffer) {
     byte[] memory = inMemoryMapOutput.getMemory();
     System.arraycopy(buffer, 0, memory, 0, buffer.length);
@@ -96,6 +84,18 @@ public class RssBypassWriter {
       IOUtils.cleanup(LOG, disk);
       throw new RssException("Failed to write OnDiskMapOutput due to: "
         + ioe.getMessage());
+    }
+  }
+
+  static Decompressor getDecompressor(InMemoryMapOutput inMemoryMapOutput) {
+    try {
+      Class clazz = Class.forName(InMemoryMapOutput.class.getName());
+      Field deCompressorField = clazz.getDeclaredField("decompressor");
+      deCompressorField.setAccessible(true);
+      Decompressor decompressor = (Decompressor) deCompressorField.get(inMemoryMapOutput);
+      return decompressor;
+    } catch (Exception e) {
+      throw new RssException("Get Decompressor fail " + e.getMessage());
     }
   }
 }

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -39,12 +39,16 @@ import com.tencent.rss.common.ShuffleAssignmentsInfo;
 import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
+import com.tencent.rss.common.util.RssUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparator;
+import org.apache.hadoop.io.compress.BZip2Codec;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.IFile;
@@ -56,6 +60,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.SortWriteBufferManager;
 import org.apache.hadoop.mapred.TaskStatus;
 import org.apache.hadoop.mapreduce.JobID;
+import org.apache.hadoop.mapreduce.RssMRUtils;
 import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.MRConfig;
@@ -66,6 +71,8 @@ import org.junit.jupiter.api.Test;
 import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+import static org.junit.Assert.assertEquals;
 
 public class FetcherTest {
   static JobID jobId = new JobID("a", 0);
@@ -142,6 +149,24 @@ public class FetcherTest {
     }
     validate(allKeysExpected, allKeys);
     validate(allValuesExpected, allValues);
+  }
+
+  @Test
+  public void testCodecIsDuplicated() throws Exception {
+    fs = FileSystem.getLocal(conf);
+    BZip2Codec codec = new BZip2Codec();
+    codec.setConf(new Configuration());
+    merger = new MergeManagerImpl<Text, Text>(
+        reduceId1, jobConf, fs, lda, Reporter.NULL, codec, null, null, null, null,
+        null, null, new Progress(), new MROutputFiles());
+    TaskAttemptID taskAttemptID = RssMRUtils.createMRTaskAttemptId(new JobID(), TaskType.MAP, 1, 1);
+    byte[] buffer = new byte[10];
+    MapOutput  mapOutput1 = merger.reserve(taskAttemptID, 10, 1);
+    RssBypassWriter.write(mapOutput1, buffer);
+    MapOutput mapOutput2 = merger.reserve(taskAttemptID, 10, 1);
+    RssBypassWriter.write(mapOutput2, buffer);
+    assertEquals(RssBypassWriter.getDecompressor(
+        (InMemoryMapOutput) mapOutput1), RssBypassWriter.getDecompressor((InMemoryMapOutput) mapOutput2));
   }
 
 

--- a/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
+++ b/client-mr/src/test/java/org/apache/hadoop/mapreduce/task/reduce/FetcherTest.java
@@ -39,7 +39,6 @@ import com.tencent.rss.common.ShuffleAssignmentsInfo;
 import com.tencent.rss.common.ShuffleBlockInfo;
 import com.tencent.rss.common.ShuffleServerInfo;
 import com.tencent.rss.common.exception.RssException;
-import com.tencent.rss.common.util.RssUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,8 +46,6 @@ import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.compress.BZip2Codec;
-import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.io.serializer.SerializationFactory;
 import org.apache.hadoop.mapred.Counters;
 import org.apache.hadoop.mapred.IFile;
@@ -72,7 +69,7 @@ import com.tencent.rss.client.api.ShuffleReadClient;
 import com.tencent.rss.client.response.CompressedShuffleBlock;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FetcherTest {
   static JobID jobId = new JobID("a", 0);


### PR DESCRIPTION
### What changes were proposed in this pull request?
In InMemoryMapOutput constructor method, we create a decompressor or borrow a decompressor from pool. Now we need to put it back, otherwise we will create a decompressor for every InMemoryMapOutput object, they will cause `out of direct memory` problems.

### Why are the changes needed?
If we don't have this patch, some applications will fail because of oom.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
New ut