### PR TITLE
[Improvement]  Add rpc timeout for   `requireBuffer` method

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapred/SortWriteBufferManager.java
@@ -151,7 +151,8 @@ public class SortWriteBufferManager<K, V> {
     memoryLock.lock();
     try {
       while (memoryUsedSize.get() > maxMemSize) {
-        LOG.warn("memoryUsedSize {} is more than {}", memoryUsedSize, maxMemSize);
+        LOG.warn("memoryUsedSize {} is more than {}, inSendListBytes {}",
+            memoryUsedSize, maxMemSize, inSendListBytes);
         full.await();
       }
     } finally {

--- a/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
+++ b/internal-client/src/main/java/com/tencent/rss/client/impl/grpc/ShuffleServerGrpcClient.java
@@ -164,7 +164,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
 
   public long requirePreAllocation(int requireSize, int retryMax, long retryIntervalMax) {
     RequireBufferRequest rpcRequest = RequireBufferRequest.newBuilder().setRequireSize(requireSize).build();
-    RequireBufferResponse rpcResponse = blockingStub.requireBuffer(rpcRequest);
+    RequireBufferResponse rpcResponse = blockingStub.withDeadlineAfter(
+        RPC_TIMEOUT_DEFAULT_MS, TimeUnit.MILLISECONDS).requireBuffer(rpcRequest);
     int retry = 0;
     long result = FAILED_REQUIRE_ID;
     Random random = new Random();
@@ -184,7 +185,8 @@ public class ShuffleServerGrpcClient extends GrpcClient implements ShuffleServer
       } catch (Exception e) {
         LOG.warn("Exception happened when require pre allocation", e);
       }
-      rpcResponse = blockingStub.requireBuffer(rpcRequest);
+      rpcResponse = blockingStub.withDeadlineAfter(
+          RPC_TIMEOUT_DEFAULT_MS, TimeUnit.MILLISECONDS).requireBuffer(rpcRequest);
       retry++;
     }
     if (rpcResponse.getStatus() == StatusCode.SUCCESS) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add rpc timeout for   `requireBuffer` method

### Why are the changes needed?
Some tasks hang for long time, and task is blocked by `requreBuffer` method, jstack is below as
<img width="919" alt="wecom-temp-bbdb33e45affec12e91a0ff29d55c8a8" src="https://user-images.githubusercontent.com/8159038/174028130-522da8c0-5c52-413c-b976-02461547e153.png">

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test