### PR TITLE
[Minor] Prevent returning incomplete shuffle blocks

### DIFF
--- a/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
+++ b/client-spark/common/src/main/java/org/apache/spark/shuffle/writer/WriteBufferManager.java
@@ -146,7 +146,7 @@ public class WriteBufferManager extends MemoryConsumer {
 
     // check buffer size > spill threshold
     if (usedBytes.get() - inSendListBytes.get() > spillSize) {
-      result = clear();
+      result.addAll(clear());
     }
     writeTime += System.currentTimeMillis() - start;
     return result;


### PR DESCRIPTION
### What changes were proposed in this pull request?
The problem only occurs when `wb.getMemoryUsed() > bufferSize` and `usedBytes.get() - inSendListBytes.get() > spillSize`. 

Although it doesn't seem to happen because of the logic, i think it should be optimized by using `addAll` to avoid confusion.

### Why are the changes needed?
Better code

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need.
