### PR TITLE
[Improvement] Bump grpc and protobuff version to allow building on Mac M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
 
   <properties>
     <checkstyle.version>9.3</checkstyle.version>
-    <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
+    <error_prone_annotations.version>2.9.0</error_prone_annotations.version>
     <execution.root>${user.dir}</execution.root>
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
     <grpc.version>1.42.2</grpc.version>
-    <guava.version>30.0-jre</guava.version>
+    <guava.version>30.1.1-jre</guava.version>
     <hadoop.scope>provided</hadoop.scope>
     <hadoop.version>2.8.5</hadoop.version>
     <httpclient.version>4.5.3</httpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <error_prone_annotations.version>2.3.4</error_prone_annotations.version>
     <execution.root>${user.dir}</execution.root>
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
-    <grpc.version>1.33.0</grpc.version>
+    <grpc.version>1.42.2</grpc.version>
     <guava.version>30.0-jre</guava.version>
     <hadoop.scope>provided</hadoop.scope>
     <hadoop.version>2.8.5</hadoop.version>
@@ -61,8 +61,8 @@
     <picocli.version>4.5.2</picocli.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <prometheus.simpleclient.version>0.9.0</prometheus.simpleclient.version>
-    <protobuf.version>3.12.0</protobuf.version>
-    <protoc.version>3.12.0</protoc.version>
+    <protobuf.version>3.18.2</protobuf.version>
+    <protoc.version>3.18.2</protoc.version>
     <roaring.bitmap.version>0.9.15</roaring.bitmap.version>
     <rss.shade.packageName>com.tencent.rss</rss.shade.packageName>
     <skipDeploy>false</skipDeploy>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -99,7 +99,7 @@
           <artifactId>protobuf-maven-plugin</artifactId>
           <configuration>
             <protocArtifact>
-                com.google.protobuf:protoc:3.12.0:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}
             </protocArtifact>
             <!-- Place these in a location that compiler-plugin is already looking -->
             <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Upgrade to grpc 1.42.2 and protobuf 3.18.2.
2. Upgrade related dependencies enforced by `RequireUpperBoundDeps`.

### Why are the changes needed?

The project can be build seamlessly on osx-aarch_64 JDK now.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

By CI.
