### PR TITLE
[Bugfix] Fix spark2 executor stop NPE problem

### DIFF
--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -373,7 +373,9 @@ public class RssShuffleManager implements ShuffleManager {
 
   @Override
   public void stop() {
-    heartBeatScheduledExecutorService.shutdownNow();
+    if (heartBeatScheduledExecutorService != null) {
+      heartBeatScheduledExecutorService.shutdownNow();
+    }
     threadPoolExecutor.shutdownNow();
     shuffleWriteClient.close();
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
We need to judge heartbeatExecutorService whether is null when we will stop it.

### Why are the changes needed?
#177 pr introduce this problem, when we run Spark applications on our cluster, the executor will throw NPE when method `stop` is called.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test