### PR TITLE
[Bugfix] [0.5] Fix MR don't have remote storage information when we use dynamic conf and MEMORY_LOCALE_HDFS storageType

### DIFF
--- a/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
+++ b/client-mr/src/main/java/org/apache/hadoop/mapreduce/v2/app/RssMRAppMaster.java
@@ -180,7 +180,7 @@ public class RssMRAppMaster extends MRAppMaster {
         RssMRUtils.applyDynamicClientConf(extraConf, clusterClientConf);
       }
 
-      String storageType = conf.get(RssMRConfig.RSS_STORAGE_TYPE);
+      String storageType = RssMRUtils.getString(extraConf, conf, RssMRConfig.RSS_STORAGE_TYPE);
       RemoteStorageInfo defaultRemoteStorage =
           new RemoteStorageInfo(conf.get(RssMRConfig.RSS_REMOTE_STORAGE_PATH, ""));
       RemoteStorageInfo remoteStorage = ClientUtils.fetchRemoteStorage(


### PR DESCRIPTION
backport 0.5.0

### What changes were proposed in this pull request?
We should acquire the storageType from extraConf. 

### Why are the changes needed?
If we don't have this patch, MR don't work when we use dynamic conf and MEMORY_LOCALE_HDFS storageType.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test