### PR TITLE
Check ADAPTIVE_EXECUTION_ENABLED in RssShuffleManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ rss-xxx.tgz will be generated for deployment
    ```
    spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
    spark.rss.coordinator.quorum <coordinatorIp1>:19999,<coordinatorIp2>:19999
+   # Note: For Spark2, spark.sql.adaptive.enabled should be false cause Spark2 doesn't support AQE.
    ```
 
 ### Support Spark dynamic allocation

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ rss-xxx.tgz will be generated for deployment
    ```
    spark.shuffle.manager org.apache.spark.shuffle.RssShuffleManager
    spark.rss.coordinator.quorum <coordinatorIp1>:19999,<coordinatorIp2>:19999
-   # Note: For Spark2, spark.sql.adaptive.enabled should be false cause Spark2 doesn't support AQE.
+   # Note: For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.
    ```
 
 ### Support Spark dynamic allocation

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -138,7 +138,7 @@ public class RssShuffleManager implements ShuffleManager {
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
     this.sparkConf = sparkConf;
     if (sparkConf.getBoolean("spark.sql.adaptive.enabled", false)) {
-      throw new IllegalArgumentException("For Spark2, spark.sql.adaptive.enabled should be false cause Spark2 doesn't support AQE.");
+      throw new IllegalArgumentException("For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.");
     }
     // set & check replica config
     this.dataReplica = sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA,

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -136,10 +136,11 @@ public class RssShuffleManager implements ShuffleManager {
   };
 
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
-    this.sparkConf = sparkConf;
     if (sparkConf.getBoolean("spark.sql.adaptive.enabled", false)) {
       throw new IllegalArgumentException("For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.");
     }
+    this.sparkConf = sparkConf;
+
     // set & check replica config
     this.dataReplica = sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA,
         RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -137,7 +137,9 @@ public class RssShuffleManager implements ShuffleManager {
 
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
     this.sparkConf = sparkConf;
-
+    if (sparkConf.getBoolean("spark.sql.adaptive.enabled", false)) {
+      throw new IllegalArgumentException("For Spark2, spark.sql.adaptive.enabled should be false cause Spark2 doesn't support AQE.");
+    }
     // set & check replica config
     this.dataReplica = sparkConf.getInt(RssSparkConfig.RSS_DATA_REPLICA,
         RssSparkConfig.RSS_DATA_REPLICA_DEFAULT_VALUE);

--- a/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
+++ b/client-spark/spark2/src/main/java/org/apache/spark/shuffle/RssShuffleManager.java
@@ -137,7 +137,7 @@ public class RssShuffleManager implements ShuffleManager {
 
   public RssShuffleManager(SparkConf sparkConf, boolean isDriver) {
     if (sparkConf.getBoolean("spark.sql.adaptive.enabled", false)) {
-      throw new IllegalArgumentException("For Spark2, spark.sql.adaptive.enabled should be false because Spark2 doesn't support AQE.");
+      throw new IllegalArgumentException("Spark2 doesn't support AQE, spark.sql.adaptive.enabled should be false.");
     }
     this.sparkConf = sparkConf;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
 1. Add checking of spark.sql.adaptive.enabled=false in RssShuffleManager's constructor for spark2.
 2. Add a description of this parameter in the Deploy Spark Client section of the readme.

### Why are the changes needed?
 When use firestorm+spark2+spark.sql.adaptive.enabled=true，the result is wrong，but we didn't get any hints.


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manual test
