### PR TITLE
[Improvement] Add RSS_IP environment variable support for K8S

### DIFF
--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -103,7 +103,8 @@ public class RssUtils {
   // loop back, etc.). If the network interface in the machine is more than one, we
   // will choose the first IP.
   public static String getHostIp() throws Exception {
-    // For K8S, there are too many IPS, it's hard to decide which we should use
+    // For K8S, there are too many IPs, it's hard to decide which we should use.
+    // So we use the environment variable to tell RSS to use which one.
     String ip = System.getenv("RSS_IP");
     if (ip != null) {
       if (!InetAddresses.isInetAddress(ip)) {

--- a/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
+++ b/common/src/main/java/com/tencent/rss/common/util/RssUtils.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,6 +103,14 @@ public class RssUtils {
   // loop back, etc.). If the network interface in the machine is more than one, we
   // will choose the first IP.
   public static String getHostIp() throws Exception {
+    // For K8S, there are too many IPS, it's hard to decide which we should use
+    String ip = System.getenv("RSS_IP");
+    if (ip != null) {
+      if (!InetAddresses.isInetAddress(ip)) {
+        throw new RuntimeException("Environment RSS_IP: " + ip + " is wrong format");
+      }
+      return ip;
+    }
     Enumeration<NetworkInterface> nif = NetworkInterface.getNetworkInterfaces();
     String siteLocalAddress = null;
     while (nif.hasMoreElements()) {

--- a/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
+++ b/common/src/test/java/com/tencent/rss/common/util/RssUtilsTest.java
@@ -18,6 +18,7 @@
 
 package com.tencent.rss.common.util;
 
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -62,6 +63,18 @@ public class RssUtilsTest {
       if (!address.equals("127.0.0.1")) {
         assertEquals(address, realIp);
       }
+      setEnv("RSS_IP", "8.8.8.8");
+      assertEquals("8.8.8.8", RssUtils.getHostIp());
+      setEnv("RSS_IP", "xxxx");
+      boolean isException = false;
+      try {
+        RssUtils.getHostIp();
+      } catch (Exception e) {
+        isException = true;
+      }
+      setEnv("RSS_IP", realIp);
+      RssUtils.getHostIp();
+      assertTrue(isException);
     } catch (Exception e) {
       fail(e.getMessage());
     }
@@ -182,6 +195,19 @@ public class RssUtilsTest {
 
     public String get() {
       return null;
+    }
+  }
+
+  public static void setEnv(String key, String value) {
+    try {
+      Map<String, String> env = System.getenv();
+      Class<?> cl = env.getClass();
+      Field field = cl.getDeclaredField("m");
+      field.setAccessible(true);
+      Map<String, String> writableEnv = (Map<String, String>) field.get(env);
+      writableEnv.put(key, value);
+    } catch (Exception e) {
+      throw new IllegalStateException("Failed to set environment variable", e);
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Method `getHostIp` can acquire IP by environment variable.

### Why are the changes needed?
For K8S, there are too many IPs, it's hard to decide which we should use. So we use the environment variable to tell RSS
to use which one.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
UT